### PR TITLE
replace cid by multihash in objects table

### DIFF
--- a/dbmgr/dbmgr.go
+++ b/dbmgr/dbmgr.go
@@ -15,9 +15,7 @@ import (
 	"gorm.io/gorm"
 )
 
-var (
-	ErrNotFiltered = errors.New("actions requires query to be filtered, but no filters were applied")
-)
+var ErrNotFiltered = errors.New("actions requires query to be filtered, but no filters were applied")
 
 type DBSortOrder int
 
@@ -155,7 +153,7 @@ func NewDBMgr(dbval string) (*DBMgr, error) {
 		return nil, err
 	}
 
-	//miners from minerX spreadsheet
+	// miners from minerX spreadsheet
 	minerStrs := []string{
 		"f02620",
 		"f023971",
@@ -225,23 +223,26 @@ type UsersQuery struct {
 	DB       *gorm.DB
 	filtered bool
 }
-type UserID uint
-type User struct {
-	gorm.Model
 
-	UUID     string `gorm:"unique"`
-	Username string `gorm:"unique"`
-	PassHash string
+type (
+	UserID uint
+	User   struct {
+		gorm.Model
 
-	UserEmail string
+		UUID     string `gorm:"unique"`
+		Username string `gorm:"unique"`
+		PassHash string
 
-	Address util.DbAddr
+		UserEmail string
 
-	Perm  int
-	Flags int
+		Address util.DbAddr
 
-	StorageDisabled bool
-}
+		Perm  int
+		Flags int
+
+		StorageDisabled bool
+	}
+)
 
 func NewUsersQuery(db *gorm.DB) *UsersQuery {
 	return &UsersQuery{DB: db.Model(User{})}
@@ -308,6 +309,7 @@ func (q *UsersQuery) ExpectDelete() error {
 // AUTH TOKENS
 
 type AuthTokensQuery struct{ DB *gorm.DB }
+
 type AuthToken struct {
 	gorm.Model
 	Token  string `gorm:"unique"`
@@ -329,32 +331,35 @@ type ContentsQuery struct {
 	DB       *gorm.DB
 	filtered bool
 }
-type ContentID uint
-type Content struct {
-	ID        uint `gorm:"primarykey"`
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt gorm.DeletedAt `gorm:"index"`
 
-	Cid         util.DbCID
-	Name        string
-	UserID      UserID
-	Description string
-	Size        int64
-	Active      bool
-	Offloaded   bool
-	Replication int
+type (
+	ContentID uint
+	Content   struct {
+		ID        uint `gorm:"primarykey"`
+		CreatedAt time.Time
+		UpdatedAt time.Time
+		DeletedAt gorm.DeletedAt `gorm:"index"`
 
-	AggregatedIn ContentID
-	Aggregate    bool
+		Cid         util.DbCID
+		Name        string
+		UserID      UserID
+		Description string
+		Size        int64
+		Active      bool
+		Offloaded   bool
+		Replication int
 
-	Pinning bool
-	PinMeta string
+		AggregatedIn ContentID
+		Aggregate    bool
 
-	Failed bool
+		Pinning bool
+		PinMeta string
 
-	Location string
-}
+		Failed bool
+
+		Location string
+	}
+)
 
 func NewContentsQuery(db *gorm.DB) *ContentsQuery {
 	return &ContentsQuery{DB: db.Model(Content{})}
@@ -477,22 +482,25 @@ func (q *ContentsQuery) Delete() error {
 
 // OBJECTS
 
-type ObjectsQuery struct{ DB *gorm.DB }
-type ObjectID uint
-type Object struct {
-	ID         ObjectID   `gorm:"primarykey"`
-	Cid        util.DbCID `gorm:"index"`
-	Size       int
-	Reads      int
-	LastAccess time.Time
-}
+type (
+	ObjectsQuery struct{ DB *gorm.DB }
+	ObjectID     uint
+	Object       struct {
+		ID         ObjectID    `gorm:"primarykey"`
+		Cid        util.DbCID  `gorm:"index"`
+		Hash       util.DbHash `gorm:"index"`
+		Size       int
+		Reads      int
+		LastAccess time.Time
+	}
+)
 
 func NewObjectsQuery(db *gorm.DB) *ObjectsQuery {
 	return &ObjectsQuery{DB: db.Model(Object{})}
 }
 
 func (q *ObjectsQuery) WithCid(cid gocid.Cid) *ObjectsQuery {
-	q.DB = q.DB.Where("cid = ?", cidToBytes(cid))
+	q.DB = q.DB.Where("hash = ? OR cid = ?", cid.Hash(), cidToBytes(cid))
 	return q
 }
 
@@ -526,13 +534,16 @@ type ObjRefsQuery struct {
 	DB       *gorm.DB
 	filtered bool
 }
-type ObjRefID uint
-type ObjRef struct {
-	ID        ObjRefID `gorm:"primarykey"`
-	Content   ContentID
-	Object    ObjectID
-	Offloaded uint
-}
+
+type (
+	ObjRefID uint
+	ObjRef   struct {
+		ID        ObjRefID `gorm:"primarykey"`
+		Content   ContentID
+		Object    ObjectID
+		Offloaded uint
+	}
+)
 
 func NewObjRefsQuery(db *gorm.DB) *ObjRefsQuery {
 	return &ObjRefsQuery{DB: db.Model(ObjRef{})}
@@ -575,25 +586,27 @@ func (q *ObjRefsQuery) Delete() error {
 
 // DEALS
 
-type DealsQuery struct{ DB *gorm.DB }
-type DealID uint
-type Deal struct {
-	gorm.Model
+type (
+	DealsQuery struct{ DB *gorm.DB }
+	DealID     uint
+	Deal       struct {
+		gorm.Model
 
-	Content          uint
-	PropCid          util.DbCID
-	Miner            string
-	DealID           int64
-	Failed           bool
-	Verified         bool
-	FailedAt         time.Time
-	DTChan           string
-	TransferStarted  time.Time
-	TransferFinished time.Time
+		Content          uint
+		PropCid          util.DbCID
+		Miner            string
+		DealID           int64
+		Failed           bool
+		Verified         bool
+		FailedAt         time.Time
+		DTChan           string
+		TransferStarted  time.Time
+		TransferFinished time.Time
 
-	OnChainAt time.Time
-	SealedAt  time.Time
-}
+		OnChainAt time.Time
+		SealedAt  time.Time
+	}
+)
 
 func NewDealsQuery(db *gorm.DB) *DealsQuery {
 	return &DealsQuery{DB: db.Model(Deal{})}
@@ -663,18 +676,20 @@ func (q *DealsQuery) Count() (int64, error) {
 
 // COLLECTIONS
 
-type CollectionsQuery struct{ DB *gorm.DB }
-type CollectionID uint
-type Collection struct {
-	ID        CollectionID `gorm:"primarykey"`
-	CreatedAt time.Time
+type (
+	CollectionsQuery struct{ DB *gorm.DB }
+	CollectionID     uint
+	Collection       struct {
+		ID        CollectionID `gorm:"primarykey"`
+		CreatedAt time.Time
 
-	UUID string `gorm:"index"`
+		UUID string `gorm:"index"`
 
-	Name        string `gorm:"unique"`
-	Description string
-	UserID      UserID
-}
+		Name        string `gorm:"unique"`
+		Description string
+		UserID      UserID
+	}
+)
 
 func NewCollectionsQuery(db *gorm.DB) *CollectionsQuery {
 	return &CollectionsQuery{DB: db.Model(Collection{})}
@@ -701,14 +716,16 @@ func (q *CollectionsQuery) Get() (Collection, error) {
 
 // COLLECTION REFS
 
-type CollectionRefsQuery struct{ DB *gorm.DB }
-type CollectionRefID uint
-type CollectionRef struct {
-	ID         CollectionRefID `gorm:"primarykey"`
-	CreatedAt  time.Time
-	Collection CollectionID
-	Content    ContentID
-}
+type (
+	CollectionRefsQuery struct{ DB *gorm.DB }
+	CollectionRefID     uint
+	CollectionRef       struct {
+		ID         CollectionRefID `gorm:"primarykey"`
+		CreatedAt  time.Time
+		Collection CollectionID
+		Content    ContentID
+	}
+)
 
 func NewCollectionRefsQuery(db *gorm.DB) *CollectionRefsQuery {
 	return &CollectionRefsQuery{DB: db.Model(CollectionRef{})}
@@ -721,6 +738,7 @@ func (q *CollectionRefsQuery) Create(collectionRef CollectionRef) error {
 // DFE RECORDS
 
 type DFERecordsQuery struct{ DB *gorm.DB }
+
 type DFERecord struct {
 	gorm.Model
 
@@ -751,6 +769,7 @@ func (q *DFERecordsQuery) Count() (int64, error) {
 // PROPOSAL RECORDS
 
 type ProposalRecordsQuery struct{ DB *gorm.DB }
+
 type ProposalRecord struct {
 	PropCid util.DbCID
 	Data    []byte
@@ -775,15 +794,17 @@ func (q *ProposalRecordsQuery) Get() (ProposalRecord, error) {
 
 // INVITE CODES
 
-type InviteCodesQuery struct{ DB *gorm.DB }
-type InviteCodeID uint
-type InviteCode struct {
-	gorm.Model
+type (
+	InviteCodesQuery struct{ DB *gorm.DB }
+	InviteCodeID     uint
+	InviteCode       struct {
+		gorm.Model
 
-	Code      string `gorm:"unique"`
-	CreatedBy uint
-	ClaimedBy uint
-}
+		Code      string `gorm:"unique"`
+		CreatedBy uint
+		ClaimedBy uint
+	}
+)
 
 func NewInviteCodesQuery(db *gorm.DB) *InviteCodesQuery {
 	return &InviteCodesQuery{DB: db.Model(InviteCode{})}
@@ -799,7 +820,7 @@ func (q *InviteCodesQuery) GetClaimedInvites() ([]ClaimedInvite, error) {
 	var invites []ClaimedInvite
 	if err := q.DB.
 		Select("code, username, (?) as claimed_by", q.DB.Table("users").Select("username").Where("id = invite_codes.claimed_by")).
-		//Where("claimed_by IS NULL").
+		// Where("claimed_by IS NULL").
 		Joins("left join users on users.id = invite_codes.created_by").
 		Scan(&invites).Error; err != nil {
 		return nil, err
@@ -817,18 +838,21 @@ type StorageMinersQuery struct {
 	DB       *gorm.DB
 	filtered bool
 }
-type StorageMinerID uint
-type StorageMiner struct {
-	gorm.Model
 
-	Address         util.DbAddr `gorm:"unique"`
-	Suspended       bool
-	SuspendedReason string
-	Name            string
-	Version         string
-	Location        string
-	Owner           UserID
-}
+type (
+	StorageMinerID uint
+	StorageMiner   struct {
+		gorm.Model
+
+		Address         util.DbAddr `gorm:"unique"`
+		Suspended       bool
+		SuspendedReason string
+		Name            string
+		Version         string
+		Location        string
+		Owner           UserID
+	}
+)
 
 func NewStorageMinersQuery(db *gorm.DB) *StorageMinersQuery {
 	return &StorageMinersQuery{DB: db.Model(StorageMiner{})}
@@ -877,23 +901,25 @@ func (q *StorageMinersQuery) Delete() error {
 
 // RETRIEVAL SUCCESS RECORDS
 
-type RetrievalSuccessRecordsQuery struct{ DB *gorm.DB }
-type RetrievalSuccessRecordID uint
-type RetrievalSuccessRecord struct {
-	ID        uint `gorm:"primarykey"`
-	CreatedAt time.Time
+type (
+	RetrievalSuccessRecordsQuery struct{ DB *gorm.DB }
+	RetrievalSuccessRecordID     uint
+	RetrievalSuccessRecord       struct {
+		ID        uint `gorm:"primarykey"`
+		CreatedAt time.Time
 
-	Cid   util.DbCID
-	Miner string
+		Cid   util.DbCID
+		Miner string
 
-	Peer         string
-	Size         uint64
-	DurationMs   int64
-	AverageSpeed uint64
-	TotalPayment string
-	NumPayments  int
-	AskPrice     string
-}
+		Peer         string
+		Size         uint64
+		DurationMs   int64
+		AverageSpeed uint64
+		TotalPayment string
+		NumPayments  int
+		AskPrice     string
+	}
+)
 
 func NewRetrievalSuccessRecordsQuery(db *gorm.DB) *RetrievalSuccessRecordsQuery {
 	return &RetrievalSuccessRecordsQuery{DB: db.Model(RetrievalSuccessRecord{})}
@@ -909,17 +935,19 @@ func (q *RetrievalSuccessRecordsQuery) Count() (int64, error) {
 
 // RETRIEVAL FAILURE RECORDS
 
-type RetrievalFailureRecordsQuery struct{ DB *gorm.DB }
-type RetrievalFailureRecordID uint
-type RetrievalFailureRecord struct {
-	gorm.Model
+type (
+	RetrievalFailureRecordsQuery struct{ DB *gorm.DB }
+	RetrievalFailureRecordID     uint
+	RetrievalFailureRecord       struct {
+		gorm.Model
 
-	Miner   string
-	Phase   string
-	Message string
-	Content ContentID
-	Cid     util.DbCID
-}
+		Miner   string
+		Phase   string
+		Message string
+		Content ContentID
+		Cid     util.DbCID
+	}
+)
 
 func NewRetrievalFailureRecordsQuery(db *gorm.DB) *RetrievalFailureRecordsQuery {
 	return &RetrievalFailureRecordsQuery{DB: db.Model(RetrievalFailureRecord{})}
@@ -936,6 +964,7 @@ func (q *RetrievalFailureRecordsQuery) Count() (int64, error) {
 // PIECE COMM RECORDS
 
 type PieceCommRecordsQuery struct{ DB *gorm.DB }
+
 type PieceCommRecord struct {
 	Data  util.DbCID `gorm:"unique"`
 	Piece util.DbCID
@@ -948,17 +977,19 @@ func NewPieceCommRecordsQuery(db *gorm.DB) *PieceCommRecordsQuery {
 
 // MINER STORAGE ASKS
 
-type MinerStorageAsksQuery struct{ DB *gorm.DB }
-type MinerStorageAskID uint
-type MinerStorageAsk struct {
-	gorm.Model
+type (
+	MinerStorageAsksQuery struct{ DB *gorm.DB }
+	MinerStorageAskID     uint
+	MinerStorageAsk       struct {
+		gorm.Model
 
-	Miner         string `gorm:"unique"`
-	Price         string
-	VerifiedPrice string
-	MinPieceSize  abi.PaddedPieceSize
-	MaxPieceSize  abi.PaddedPieceSize
-}
+		Miner         string `gorm:"unique"`
+		Price         string
+		VerifiedPrice string
+		MinPieceSize  abi.PaddedPieceSize
+		MaxPieceSize  abi.PaddedPieceSize
+	}
+)
 
 func NewMinerStorageAsksQuery(db *gorm.DB) *MinerStorageAsksQuery {
 	return &MinerStorageAsksQuery{DB: db.Model(MinerStorageAsk{})}
@@ -966,21 +997,23 @@ func NewMinerStorageAsksQuery(db *gorm.DB) *MinerStorageAsksQuery {
 
 // SHUTTLES
 
-type ShuttlesQuery struct{ DB *gorm.DB }
-type ShuttleID uint
-type Shuttle struct {
-	gorm.Model
+type (
+	ShuttlesQuery struct{ DB *gorm.DB }
+	ShuttleID     uint
+	Shuttle       struct {
+		gorm.Model
 
-	Handle string `gorm:"unique"`
-	Host   string
-	PeerID string
+		Handle string `gorm:"unique"`
+		Host   string
+		PeerID string
 
-	Private bool
+		Private bool
 
-	Open bool
+		Open bool
 
-	Priority int
-}
+		Priority int
+	}
+)
 
 func NewShuttlesQuery(db *gorm.DB) *ShuttlesQuery {
 	return &ShuttlesQuery{DB: db.Model(Shuttle{})}

--- a/gc.go
+++ b/gc.go
@@ -52,7 +52,7 @@ func (cm *ContentManager) maybeRemoveObject(c cid.Cid) (bool, error) {
 
 func (cm *ContentManager) trackingObject(c cid.Cid) (bool, error) {
 	var count int64
-	if err := cm.DB.Model(&Object{}).Where("cid = ?", c.Bytes()).Count(&count).Error; err != nil {
+	if err := cm.DB.Model(&Object{}).Where("hash = ?", c.Hash()).Count(&count).Error; err != nil {
 		if xerrors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil
 		}

--- a/gc.go
+++ b/gc.go
@@ -178,11 +178,11 @@ func (cm *ContentManager) deleteIfNotPinned(ctx context.Context, o *Object) erro
 	defer cm.contentLk.Unlock()
 
 	var objs []Object
-	if err := cm.DB.Limit(1).Model(Object{}).Where("id = ? OR cid = ?", o.ID, o.Cid).Find(&objs).Error; err != nil {
+	if err := cm.DB.Limit(1).Model(Object{}).Where("id = ? OR hash = ?", o.ID, o.Hash).Find(&objs).Error; err != nil {
 		return err
 	}
 	if len(objs) == 0 {
-		return cm.Node.Blockstore.DeleteBlock(o.Cid.CID)
+		return cm.Node.Blockstore.DeleteBlock(o.Hash.Cid())
 	}
 	return nil
 }

--- a/handlers.go
+++ b/handlers.go
@@ -158,10 +158,10 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 	deals.GET("/status-by-proposal/:propcid", withUser(s.handleGetDealStatusByPropCid))
 	deals.GET("/query/:miner", s.handleQueryAsk)
 	deals.POST("/make/:miner", withUser(s.handleMakeDeal))
-	//deals.POST("/transfer/start/:miner/:propcid/:datacid", s.handleTransferStart)
+	// deals.POST("/transfer/start/:miner/:propcid/:datacid", s.handleTransferStart)
 	deals.POST("/transfer/status", s.handleTransferStatus)
 	deals.GET("/transfer/in-progress", s.handleTransferInProgress)
-	//deals.POST("/transfer/restart", s.handleTransferRestart)
+	// deals.POST("/transfer/restart", s.handleTransferRestart)
 	deals.GET("/status/:miner/:propcid", s.handleDealStatus)
 	deals.POST("/estimate", s.handleEstimateDealCost)
 	deals.GET("/proposal/:propcid", s.handleGetProposal)
@@ -694,7 +694,7 @@ func (cm *ContentManager) addDatabaseTrackingToContent(ctx context.Context, cont
 
 		objlk.Lock()
 		objects = append(objects, &Object{
-			Cid:  util.DbCID{c},
+			Hash: util.DbHashFromCid(c),
 			Size: len(node.RawData()),
 		})
 		objlk.Unlock()
@@ -810,7 +810,6 @@ type expandedContent struct {
 }
 
 func (s *Server) handleListContentWithDeals(c echo.Context, u *User) error {
-
 	var limit int = 20
 	if limstr := c.QueryParam("limit"); limstr != "" {
 		l, err := strconv.Atoi(limstr)
@@ -844,7 +843,6 @@ func (s *Server) handleListContentWithDeals(c echo.Context, u *User) error {
 				if err := s.DB.Model(Content{}).Where("aggregated_in = ?", cont.ID).Count(&ec.AggregatedFiles).Error; err != nil {
 					return err
 				}
-
 			}
 			out = append(out, ec)
 		}
@@ -1256,7 +1254,7 @@ func (s *Server) handleAdminGetInvites(c echo.Context) error {
 	var invites []getInvitesResp
 	if err := s.DB.Debug().Model(&InviteCode{}).
 		Select("code, username, (?) as claimed_by", s.DB.Table("users").Select("username").Where("id = invite_codes.claimed_by")).
-		//Where("claimed_by IS NULL").
+		// Where("claimed_by IS NULL").
 		Joins("left join users on users.id = invite_codes.created_by").
 		Scan(&invites).Error; err != nil {
 		return err
@@ -1320,7 +1318,6 @@ type adminStatsResponse struct {
 }
 
 func (s *Server) handleAdminStats(c echo.Context) error {
-
 	var dealsTotal int64
 	if err := s.DB.Model(&contentDeal{}).Count(&dealsTotal).Error; err != nil {
 		return err
@@ -1678,7 +1675,6 @@ func (s *Server) handleRetrievalCheck(c echo.Context) error {
 	}
 
 	return c.JSON(200, "We did a thing")
-
 }
 
 type estimateDealBody struct {
@@ -2500,7 +2496,6 @@ func (s *Server) handleGetCollectionContents(c echo.Context, u *User) error {
 
 func (s *Server) tracingMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-
 		r := c.Request()
 
 		attrs := []attribute.KeyValue{
@@ -2781,7 +2776,6 @@ type dealPairs struct {
 }
 
 func (s *Server) handleGetAllDealsForUser(c echo.Context, u *User) error {
-
 	begin := time.Now().Add(time.Hour * 24)
 	duration := time.Hour * 24
 

--- a/main.go
+++ b/main.go
@@ -144,8 +144,8 @@ type Content struct {
 }
 
 type Object struct {
-	ID         uint       `gorm:"primarykey"`
-	Cid        util.DbCID `gorm:"index"`
+	ID         uint        `gorm:"primarykey"`
+	Hash       util.DbHash `gorm:"index"`
 	Size       int
 	Reads      int
 	LastAccess time.Time
@@ -484,7 +484,51 @@ func setupDatabase(cctx *cli.Context) (*gorm.DB, error) {
 	}
 
 	db.AutoMigrate(&Content{})
-	db.AutoMigrate(&Object{})
+
+	// Check if we need to migrate cid to hash.
+	if db.Migrator().HasColumn(&Object{}, "hash") {
+		db.AutoMigrate(&Object{})
+	} else {
+		// Migration from cid to hash is needed
+		fmt.Println("migrating object cids to multihashes")
+		type cidrow struct {
+			ID  uint
+			Cid util.DbCID
+		}
+		rows, err := db.Raw("select id, cid from objects").Rows()
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Migrator().AddColumn(&Object{}, "hash"); err != nil {
+				return err
+			}
+			count := 0
+			for rows.Next() {
+				count++
+				if count%1000 == 0 {
+					fmt.Printf("  migrated %d rows\n", count)
+				}
+				var cr cidrow
+				rows.Scan(&cr.ID, &cr.Cid)
+				hash := util.DbHashFromDbCID(&cr.Cid)
+				if err := tx.Exec("update objects set hash=? where id=?", hash, cr.ID).Error; err != nil {
+					return err
+				}
+			}
+			fmt.Printf("  migrated %d rows...done\n", count)
+			if err := tx.Migrator().DropColumn(&Object{}, "cid"); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	db.AutoMigrate(&ObjRef{})
 	db.AutoMigrate(&Collection{})
 	db.AutoMigrate(&CollectionRef{})

--- a/main.go
+++ b/main.go
@@ -636,7 +636,7 @@ func (s *Server) GarbageCollect(ctx context.Context) error {
 
 func (s *Server) trackingObject(c cid.Cid) (bool, error) {
 	var count int64
-	if err := s.DB.Model(&Object{}).Where("cid = ?", c.Bytes()).Count(&count).Error; err != nil {
+	if err := s.DB.Model(&Object{}).Where("hash = ?", c.Hash()).Count(&count).Error; err != nil {
 		if xerrors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil
 		}

--- a/migration.go
+++ b/migration.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/application-research/estuary/util"
+	"gorm.io/gorm"
+)
+
+type Migration struct {
+	Name        string `gorm:"primarykey"`
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+// ordered list of migrations. Data migrations are normally executed in the background so a migration function must
+// not interfere with the running of the rest of estuary and should be stateless, interruptable and resumable. A
+// migration may be marked as required in which case estuary will not start running until the migration has completed.
+// A large data migration may be implemented in stages across multiple versions of estuary. The first stage would
+// migrate the data in the background, retaining compatibility with existing queries. Once this is complete a later
+// version of estuary may simplify code by removing the compatibility and updating the migration to be required. This
+// will have no effect on systems that have already migrated but will allow older systems to be updated safely.
+var migrations = []struct {
+	name string
+	fn   func(context.Context, *gorm.DB) error
+
+	// when true, estuary will not start until the migration has completed
+	required bool
+}{
+
+	{
+		// Migration from cid to multihash for the objects table
+		name: "object-cid-to-hash",
+		fn: func(ctx context.Context, db *gorm.DB) error {
+			var objs []*Object
+			tx := db.Where("hash IS NULL").FindInBatches(&objs, 500, func(tx *gorm.DB, batch int) error {
+				// Make sure migration is interruptable
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+				}
+
+				for _, o := range objs {
+					o.Hash = util.DbHashFromDbCID(&o.Cid)
+				}
+
+				tx.Save(&objs)
+				log.Debugf("migrated %d cids to multihashes", tx.RowsAffected)
+				return nil
+			})
+			return tx.Error
+		},
+	},
+}
+
+func maybePerformMigrations(ctx context.Context, db *gorm.DB) error {
+	for _, minfo := range migrations {
+		var mig Migration
+		err := db.Where("name=?", minfo.name).First(&mig).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			mig.Name = minfo.name
+			mig.StartedAt = time.Now().UTC()
+		} else if err != nil {
+			return err
+		} else if !mig.CompletedAt.IsZero() {
+			// If the migration has completed then we can skip it
+			continue
+		}
+
+		if err := db.Save(mig).Error; err != nil {
+			return err
+		}
+
+		// Kick off the migration
+		if minfo.required {
+			// Migration must run to completion synchronously
+			if err := runMigration(ctx, db, mig, minfo.fn); err != nil {
+				return err
+			}
+		} else {
+			// Migration runs asynch in the background
+			go runMigration(ctx, db, mig, minfo.fn)
+		}
+
+	}
+
+	return nil
+}
+
+func runMigration(ctx context.Context, db *gorm.DB, mig Migration, fn func(context.Context, *gorm.DB) error) error {
+	log.Infof("%s migration started", mig.Name)
+	err := fn(ctx, db)
+	if err != nil {
+		log.Errorf("%s migration failed: %v", mig.Name, err)
+		return err
+	}
+	log.Infof("%s migration complete", mig.Name)
+
+	mig.CompletedAt = time.Now().UTC()
+	if err := db.Save(mig).Error; err != nil {
+		log.Errorf("%s migration completed but failed to save status: %v", mig.Name, err)
+		return err
+	}
+
+	return nil
+}

--- a/offloading.go
+++ b/offloading.go
@@ -84,6 +84,7 @@ func (cm *ContentManager) ClearUnused(ctx context.Context, spaceRequest int64, d
 
 	return result, nil
 }
+
 func (cm *ContentManager) getLastAccesses(ctx context.Context, candidates []removalCandidateInfo) ([]offloadCandidate, error) {
 	ctx, span := cm.tracer.Start(ctx, "getLastAccesses")
 	defer span.End()
@@ -113,7 +114,7 @@ func (cm *ContentManager) getLastAccesses(ctx context.Context, candidates []remo
 // additionally, for aggregates, we should check each aggregated item under the root
 func (cm *ContentManager) getLastAccessForContent(cont Content) (time.Time, error) {
 	var obj Object
-	if err := cm.DB.First(&obj, "cid = ?", cont.Cid).Error; err != nil {
+	if err := cm.DB.First(&obj, "hash = ? OR cid = ?", cont.Cid.CID.Hash(), cont.Cid).Error; err != nil {
 		return time.Time{}, err
 	}
 

--- a/pinning.go
+++ b/pinning.go
@@ -797,6 +797,7 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 	objects := make([]*Object, 0, len(pincomp.Objects))
 	for _, o := range pincomp.Objects {
 		objects = append(objects, &Object{
+			Cid:  util.DbCID{CID: o.Cid},
 			Hash: util.DbHashFromCid(o.Cid),
 			Size: o.Size,
 		})

--- a/pinning.go
+++ b/pinning.go
@@ -797,7 +797,7 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 	objects := make([]*Object, 0, len(pincomp.Objects))
 	for _, o := range pincomp.Objects {
 		objects = append(objects, &Object{
-			Cid:  util.DbCID{o.Cid},
+			Hash: util.DbHashFromCid(o.Cid),
 			Size: o.Size,
 		})
 	}

--- a/replication.go
+++ b/replication.go
@@ -618,6 +618,7 @@ func (cm *ContentManager) aggregateContent(ctx context.Context, b *contentStagin
 
 	if loc == "local" {
 		obj := &Object{
+			Cid:  util.DbCID{CID: ncid},
 			Hash: util.DbHashFromCid(ncid),
 			Size: int(size),
 		}
@@ -2375,7 +2376,7 @@ func (cm *ContentManager) RefreshContentForCid(ctx context.Context, c cid.Cid) (
 	defer span.End()
 
 	var obj Object
-	if err := cm.DB.First(&obj, "cid = ?", c.Bytes()).Error; err != nil {
+	if err := cm.DB.First(&obj, "hash = ? OR cid = ?", c.Hash(), c.Bytes()).Error; err != nil {
 		return nil, xerrors.Errorf("failed to get object from db: ", err)
 	}
 

--- a/replication.go
+++ b/replication.go
@@ -618,7 +618,7 @@ func (cm *ContentManager) aggregateContent(ctx context.Context, b *contentStagin
 
 	if loc == "local" {
 		obj := &Object{
-			Cid:  util.DbCID{ncid},
+			Hash: util.DbHashFromCid(ncid),
 			Size: int(size),
 		}
 		if err := cm.DB.Create(obj).Error; err != nil {

--- a/trackbs.go
+++ b/trackbs.go
@@ -98,7 +98,7 @@ func (tbs *TrackingBlockstore) coalescer() {
 		case req := <-tbs.countsReq:
 			resp := make([]int, len(req.req))
 			for i, o := range req.req {
-				resp[i] = tbs.buffer[o.Cid.CID].Get
+				resp[i] = tbs.buffer[o.Hash.Cid()].Get
 			}
 			req.resp <- resp
 		case req := <-tbs.accessReq:

--- a/trackbs.go
+++ b/trackbs.go
@@ -115,7 +115,7 @@ func (tbs *TrackingBlockstore) coalescer() {
 func (tbs *TrackingBlockstore) persistAccessCounts(buf map[cid.Cid]accesses) {
 	for c, acc := range buf {
 		if acc.Get > 0 {
-			err := tbs.db.Model(&Object{}).Where("cid = ?", c.Bytes()).Updates(map[string]interface{}{
+			err := tbs.db.Model(&Object{}).Where("hash = ?", c.Hash()).Updates(map[string]interface{}{
 				"reads":       gorm.Expr("reads + ?", acc.Get),
 				"last_access": acc.Last,
 			}).Error

--- a/util/database.go
+++ b/util/database.go
@@ -138,6 +138,5 @@ func (d *DbHash) UnmarshalJSON(b []byte) error {
 }
 
 func (d *DbHash) Cid() cid.Cid {
-	// TODO: is cid.Raw appropriate?
 	return cid.NewCidV1(cid.Raw, d.Hash)
 }


### PR DESCRIPTION
Adds a migration that manually adds the hash column, converts all cids to hashes and then removes the cid column. 

Fix up various places where cid is referenced but this is pretty superficial at the moment. There could be places where we could be using multihash instead of cid and avoid any conversion.

