### PR TITLE
use api.estuary.tech as preferred upload endpoint when local adding disabled

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2314,7 +2314,7 @@ func (s *Server) getPreferredUploadEndpoints(u *User) ([]string, error) {
 			out = append(out, "https://"+sh.hostname+"/content/add")
 		}
 	}
-	if !s.CM.localContentAddingDisabled {
+	if s.CM.localContentAddingDisabled {
 		out = append(out, "https://api.estuary.tech/content/add")
 	}
 	return out, nil


### PR DESCRIPTION
This inverts the condition in `getPreferredUploadEndpoints` to add estuary.tech  when local adding is disabled. Without this change a local web client uses api.estuary.tech for uploads instead of the configured api.