### PR TITLE
add indexes for frequently joined columns

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -16,6 +16,6 @@ type Collection struct {
 type CollectionRef struct {
 	ID         uint `gorm:"primaryKey"`
 	CreatedAt  time.Time
-	Collection uint
-	Content    uint
+	Collection uint `gorm:"index:,option:CONCURRENTLY"`
+	Content    uint `gorm:"index:,option:CONCURRENTLY"`
 }

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var log = logging.Logger("estuary")
 var defaultMiners []address.Address
 
 func init() {
-	//miners from minerX spreadsheet
+	// miners from minerX spreadsheet
 	minerStrs := []string{
 		"f02620",
 		"f023971",
@@ -117,7 +117,7 @@ type Content struct {
 
 	// TODO: shift most of the 'state' booleans in here into a single state
 	// field, should make reasoning about things much simpler
-	AggregatedIn uint `json:"aggregatedIn"`
+	AggregatedIn uint `json:"aggregatedIn" gorm:"index:,option:CONCURRENTLY"`
 	Aggregate    bool `json:"aggregate"`
 
 	Pinning bool   `json:"pinning"`
@@ -129,8 +129,8 @@ type Content struct {
 	// TODO: shift location tracking to just use the ID of the shuttle
 	// Also move towards recording content movement intentions in the database,
 	// making that process more resilient to failures
-	//LocID     uint   `json:"locID"`
-	//LocIntent uint   `json:"locIntent"`
+	// LocID     uint   `json:"locID"`
+	// LocIntent uint   `json:"locIntent"`
 
 	// If set, this content is part of a split dag.
 	// In such a case, the 'root' content should be advertised on the dht, but
@@ -151,8 +151,8 @@ type Object struct {
 
 type ObjRef struct {
 	ID        uint `gorm:"primarykey"`
-	Content   uint
-	Object    uint
+	Content   uint `gorm:"index:,option:CONCURRENTLY"`
+	Object    uint `gorm:"index:,option:CONCURRENTLY"`
 	Offloaded uint
 }
 
@@ -337,7 +337,6 @@ func main() {
 						return
 					}
 				}
-
 			}()
 			return out, nil
 		}
@@ -364,7 +363,7 @@ func main() {
 		}
 
 		api, closer, err := lcli.GetGatewayAPI(cctx)
-		//api, closer, err := lcli.GetFullNodeAPI(cctx)
+		// api, closer, err := lcli.GetFullNodeAPI(cctx)
 		if err != nil {
 			return err
 		}

--- a/replication.go
+++ b/replication.go
@@ -283,7 +283,6 @@ func (cb *contentStagingZone) hasContent(c Content) bool {
 }
 
 func NewContentManager(db *gorm.DB, api api.Gateway, fc *filclient.FilClient, tbs *TrackingBlockstore, nbs *node.NotifyBlockstore, prov *batched.BatchProvidingSystem, pinmgr *pinner.PinManager, nd *node.Node, hostname string) (*ContentManager, error) {
-
 	cache, err := lru.NewARC(50000)
 	if err != nil {
 		return nil, err
@@ -1000,7 +999,7 @@ func toDBAsk(netask *network.AskResponse) *minerStorageAsk {
 
 type contentDeal struct {
 	gorm.Model
-	Content          uint       `json:"content"`
+	Content          uint       `json:"content" gorm:"index:,option:CONCURRENTLY"`
 	PropCid          util.DbCID `json:"propCid"`
 	Miner            string     `json:"miner"`
 	DealID           int64      `json:"dealId"`
@@ -1203,7 +1202,7 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content Content, do
 	// its too big, need to split it up into chunks
 	if content.Size > cm.contentSizeLimit {
 		return fmt.Errorf("content too big (splitting will be implemented soon)")
-		//return cm.splitContent(ctx, content, cm.contentSizeLimit)
+		// return cm.splitContent(ctx, content, cm.contentSizeLimit)
 	}
 
 	// check if content has enough deals made for it


### PR DESCRIPTION
Surveyed the codebase for columns that commonly appear in joins or where clauses. I limited changes to large tables where we should see the most impact. Adding these indexes changes query plans from using Seq Scan on join tables to Index Scan (tested with a subset of data).

Specifying the `CONCURRENTLY` option should tell postgresql to build the index without taking locks that block reads or inserts.

