### PR TITLE
feat: wire tracing across rpc boundaries

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -14,7 +14,9 @@ import (
 	"sync"
 	"time"
 
+	estumetrics "github.com/application-research/estuary/metrics"
 	lru "github.com/hashicorp/golang-lru"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/urfave/cli/v2"
@@ -50,8 +52,6 @@ import (
 	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/whyrusleeping/memo"
 )
-
-var Tracer = otel.Tracer("shuttle")
 
 var log = logging.Logger("shuttle")
 
@@ -134,6 +134,27 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name: "private",
+		},
+		&cli.BoolFlag{
+			Name:  "jaeger-tracing",
+			Value: false,
+		},
+		&cli.StringFlag{
+			Name:  "jaeger-provider-host",
+			Value: "localhost",
+		},
+		&cli.IntFlag{
+			Name:  "jaeger-provider-port",
+			Value: 14268,
+		},
+		&cli.StringFlag{
+			Name:  "jaeger-provider-name",
+			Value: "estuary-shuttle",
+		},
+		&cli.Float64Flag{
+			Name:  "jaeger-sampler-ratio",
+			Usage: "If less than 1 probabilistic metrics will be used.",
+			Value: 1,
 		},
 	}
 
@@ -232,6 +253,14 @@ func main() {
 			return err
 		}
 
+		if cctx.Bool("jaeger-tracing") {
+			tp, err := estumetrics.NewJaegerTraceProvider(cctx)
+			if err != nil {
+				return err
+			}
+			otel.SetTracerProvider(tp)
+		}
+
 		d := &Shuttle{
 			Node:       nd,
 			Api:        api,
@@ -239,6 +268,8 @@ func main() {
 			Filc:       filc,
 			StagingMgr: sbm,
 			Private:    cctx.Bool("private"),
+
+			Tracer: otel.Tracer(fmt.Sprintf("shuttle_%s", cctx.String("host"))),
 
 			commpMemo: commpMemo,
 
@@ -252,6 +283,7 @@ func main() {
 			shuttleHandle: cctx.String("handle"),
 			shuttleToken:  cctx.String("auth-token"),
 		}
+
 		d.PinMgr = pinner.NewPinManager(d.doPinning, d.onPinStatusUpdate, &pinner.PinManagerOpts{
 			MaxActivePerUser: 30,
 		})
@@ -376,6 +408,8 @@ type Shuttle struct {
 	Filc       *filclient.FilClient
 	StagingMgr *stagingbs.StagingBSMgr
 
+	Tracer trace.Tracer
+
 	tcLk             sync.Mutex
 	trackingChannels map[string]*chanTrack
 
@@ -403,16 +437,16 @@ type chanTrack struct {
 	last *filclient.ChannelState
 }
 
-func (d *Shuttle) RunRpcConnection() error {
+func (s *Shuttle) RunRpcConnection() error {
 	for {
-		conn, err := d.dialConn()
+		conn, err := s.dialConn()
 		if err != nil {
 			log.Errorf("failed to dial estuary rpc endpoint: %s", err)
 			time.Sleep(time.Second * 10)
 			continue
 		}
 
-		if err := d.runRpc(conn); err != nil {
+		if err := s.runRpc(conn); err != nil {
 			log.Errorf("rpc routine exited with an error: %s", err)
 			time.Sleep(time.Second * 10)
 			continue
@@ -423,7 +457,7 @@ func (d *Shuttle) RunRpcConnection() error {
 	}
 }
 
-func (d *Shuttle) runRpc(conn *websocket.Conn) error {
+func (s *Shuttle) runRpc(conn *websocket.Conn) error {
 	conn.MaxPayloadBytes = 128 << 20
 	log.Infof("connecting to primary estuary node")
 	defer conn.Close()
@@ -431,7 +465,7 @@ func (d *Shuttle) runRpc(conn *websocket.Conn) error {
 	readDone := make(chan struct{})
 
 	// Send hello message
-	hello, err := d.getHelloMessage()
+	hello, err := s.getHelloMessage()
 	if err != nil {
 		return err
 	}
@@ -451,7 +485,7 @@ func (d *Shuttle) runRpc(conn *websocket.Conn) error {
 			}
 
 			go func(cmd *drpc.Command) {
-				if err := d.handleRpcCmd(cmd); err != nil {
+				if err := s.handleRpcCmd(cmd); err != nil {
 					log.Errorf("failed to handle rpc command: %s", err)
 				}
 			}(&cmd)
@@ -462,7 +496,7 @@ func (d *Shuttle) runRpc(conn *websocket.Conn) error {
 		select {
 		case <-readDone:
 			return fmt.Errorf("read routine exited, assuming socket is closed")
-		case msg := <-d.outgoing:
+		case msg := <-s.outgoing:
 			conn.SetWriteDeadline(time.Now().Add(time.Second * 30))
 			if err := websocket.JSON.Send(conn, msg); err != nil {
 				log.Errorf("failed to send message: %s", err)
@@ -472,32 +506,32 @@ func (d *Shuttle) runRpc(conn *websocket.Conn) error {
 	}
 }
 
-func (d *Shuttle) getHelloMessage() (*drpc.Hello, error) {
-	addr, err := d.Node.Wallet.GetDefault()
+func (s *Shuttle) getHelloMessage() (*drpc.Hello, error) {
+	addr, err := s.Node.Wallet.GetDefault()
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infow("sending hello", "hostname", d.hostname, "address", addr, "pid", d.Node.Host.ID())
+	log.Infow("sending hello", "hostname", s.hostname, "address", addr, "pid", s.Node.Host.ID())
 	return &drpc.Hello{
-		Host:    d.hostname,
-		PeerID:  d.Node.Host.ID().Pretty(),
+		Host:    s.hostname,
+		PeerID:  s.Node.Host.ID().Pretty(),
 		Address: addr,
-		Private: d.Private,
+		Private: s.Private,
 		AddrInfo: peer.AddrInfo{
-			ID:    d.Node.Host.ID(),
-			Addrs: d.Node.Host.Addrs(),
+			ID:    s.Node.Host.ID(),
+			Addrs: s.Node.Host.Addrs(),
 		},
 	}, nil
 }
 
-func (d *Shuttle) dialConn() (*websocket.Conn, error) {
-	cfg, err := websocket.NewConfig("wss://"+d.estuaryHost+"/shuttle/conn", "http://localhost")
+func (s *Shuttle) dialConn() (*websocket.Conn, error) {
+	cfg, err := websocket.NewConfig("wss://"+s.estuaryHost+"/shuttle/conn", "http://localhost")
 	if err != nil {
 		return nil, err
 	}
 
-	cfg.Header.Set("Authorization", "Bearer "+d.shuttleToken)
+	cfg.Header.Set("Authorization", "Bearer "+s.shuttleToken)
 
 	conn, err := websocket.DialConfig(cfg)
 	if err != nil {
@@ -517,9 +551,9 @@ type User struct {
 	AuthExpiry      time.Time
 }
 
-func (d *Shuttle) checkTokenAuth(token string) (*User, error) {
+func (s *Shuttle) checkTokenAuth(token string) (*User, error) {
 
-	val, ok := d.authCache.Get(token)
+	val, ok := s.authCache.Get(token)
 	if ok {
 		usr, ok := val.(*User)
 		if !ok {
@@ -527,13 +561,13 @@ func (d *Shuttle) checkTokenAuth(token string) (*User, error) {
 		}
 
 		if usr.AuthExpiry.After(time.Now()) {
-			d.authCache.Remove(token)
+			s.authCache.Remove(token)
 		} else {
 			return usr, nil
 		}
 	}
 
-	req, err := http.NewRequest("GET", "https://"+d.estuaryHost+"/viewer", nil)
+	req, err := http.NewRequest("GET", "https://"+s.estuaryHost+"/viewer", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -570,12 +604,12 @@ func (d *Shuttle) checkTokenAuth(token string) (*User, error) {
 		StorageDisabled: out.Settings.ContentAddingDisabled,
 	}
 
-	d.authCache.Add(token, usr)
+	s.authCache.Add(token, usr)
 
 	return usr, nil
 }
 
-func (d *Shuttle) AuthRequired(level int) echo.MiddlewareFunc {
+func (s *Shuttle) AuthRequired(level int) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			auth, err := util.ExtractAuth(c)
@@ -583,7 +617,7 @@ func (d *Shuttle) AuthRequired(level int) echo.MiddlewareFunc {
 				return err
 			}
 
-			u, err := d.checkTokenAuth(auth)
+			u, err := s.checkTokenAuth(auth)
 			if err != nil {
 				return err
 			}
@@ -830,21 +864,21 @@ func (s *Shuttle) createContent(ctx context.Context, u *User, root cid.Cid, fnam
 }
 
 // TODO: mostly copy paste from estuary, dedup code
-func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb pinner.PinProgressCB) error {
-	ctx, span := Tracer.Start(ctx, "doPinning")
+func (s *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb pinner.PinProgressCB) error {
+	ctx, span := s.Tracer.Start(ctx, "doPinning")
 	defer span.End()
 
 	for _, pi := range op.Peers {
-		if err := d.Node.Host.Connect(ctx, pi); err != nil {
+		if err := s.Node.Host.Connect(ctx, pi); err != nil {
 			log.Warnf("failed to connect to origin node for pinning operation: %s", err)
 		}
 	}
 
-	bserv := blockservice.New(d.Node.Blockstore, d.Node.Bitswap)
+	bserv := blockservice.New(s.Node.Blockstore, s.Node.Bitswap)
 	dserv := merkledag.NewDAGService(bserv)
 	dsess := merkledag.NewSession(ctx, dserv)
 
-	if err := d.addDatabaseTrackingToContent(ctx, op.ContId, dsess, d.Node.Blockstore, op.Obj, cb); err != nil {
+	if err := s.addDatabaseTrackingToContent(ctx, op.ContId, dsess, s.Node.Blockstore, op.Obj, cb); err != nil {
 		// pinning failed, we wont try again. mark pin as dead
 		/* maybe its fine if we retry later?
 		if err := d.DB.Model(Pin{}).Where("content = ?", op.ContId).UpdateColumns(map[string]interface{}{
@@ -866,12 +900,12 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 	*/
 
 	// this provide call goes out immediately
-	if err := d.Node.FullRT.Provide(ctx, op.Obj, true); err != nil {
+	if err := s.Node.FullRT.Provide(ctx, op.Obj, true); err != nil {
 		log.Infof("provider broadcast failed: %s", err)
 	}
 
 	// this one adds to a queue
-	if err := d.Node.Provider.Provide(op.Obj); err != nil {
+	if err := s.Node.Provider.Provide(op.Obj); err != nil {
 		log.Infof("providing failed: %s", err)
 	}
 
@@ -881,12 +915,12 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 const noDataTimeout = time.Minute * 10
 
 // TODO: mostly copy paste from estuary, dedup code
-func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint, dserv ipld.NodeGetter, bs blockstore.Blockstore, root cid.Cid, cb func(int64)) error {
-	ctx, span := Tracer.Start(ctx, "computeObjRefsUpdate")
+func (s *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint, dserv ipld.NodeGetter, bs blockstore.Blockstore, root cid.Cid, cb func(int64)) error {
+	ctx, span := s.Tracer.Start(ctx, "computeObjRefsUpdate")
 	defer span.End()
 
 	var dbpin Pin
-	if err := d.DB.First(&dbpin, "content = ?", contid).Error; err != nil {
+	if err := s.DB.First(&dbpin, "content = ?", contid).Error; err != nil {
 		return err
 	}
 
@@ -952,11 +986,11 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 		attribute.Int("numObjects", len(objects)),
 	)
 
-	if err := d.DB.CreateInBatches(objects, 300).Error; err != nil {
+	if err := s.DB.CreateInBatches(objects, 300).Error; err != nil {
 		return xerrors.Errorf("failed to create objects in db: %w", err)
 	}
 
-	if err := d.DB.Model(Pin{}).Where("content = ?", contid).UpdateColumns(map[string]interface{}{
+	if err := s.DB.Model(Pin{}).Where("content = ?", contid).UpdateColumns(map[string]interface{}{
 		"active":  true,
 		"size":    totalSize,
 		"pinning": false,
@@ -970,19 +1004,19 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 		refs[i].Object = objects[i].ID
 	}
 
-	if err := d.DB.CreateInBatches(refs, 500).Error; err != nil {
+	if err := s.DB.CreateInBatches(refs, 500).Error; err != nil {
 		return xerrors.Errorf("failed to create refs: %w", err)
 	}
 
-	d.sendPinCompleteMessage(ctx, dbpin.Content, totalSize, objects)
+	s.sendPinCompleteMessage(ctx, dbpin.Content, totalSize, objects)
 
 	return nil
 }
 
-func (d *Shuttle) onPinStatusUpdate(cont uint, status string) {
+func (s *Shuttle) onPinStatusUpdate(cont uint, status string) {
 	log.Infof("updating pin status: %d %s", cont, status)
 	if status == "failed" {
-		if err := d.DB.Model(Pin{}).Where("content = ?", cont).UpdateColumns(map[string]interface{}{
+		if err := s.DB.Model(Pin{}).Where("content = ?", cont).UpdateColumns(map[string]interface{}{
 			"pinning": false,
 			"active":  false,
 			"failed":  true,
@@ -992,7 +1026,7 @@ func (d *Shuttle) onPinStatusUpdate(cont uint, status string) {
 	}
 
 	go func() {
-		if err := d.sendRpcMessage(context.TODO(), &drpc.Message{
+		if err := s.sendRpcMessage(context.TODO(), &drpc.Message{
 			Op: "UpdatePinStatus",
 			Params: drpc.MsgParams{
 				UpdatePinStatus: &drpc.UpdatePinStatus{
@@ -1050,14 +1084,14 @@ func (s *Shuttle) addPinToQueue(p Pin, peers []peer.AddrInfo, replace uint) {
 }
 
 func (s *Shuttle) importFile(ctx context.Context, dserv ipld.DAGService, fi io.Reader) (ipld.Node, error) {
-	_, span := Tracer.Start(ctx, "importFile")
+	_, span := s.Tracer.Start(ctx, "importFile")
 	defer span.End()
 
 	return util.ImportFile(dserv, fi)
 }
 
 func (s *Shuttle) dumpBlockstoreTo(ctx context.Context, from, to blockstore.Blockstore) error {
-	ctx, span := Tracer.Start(ctx, "blockstoreCopy")
+	ctx, span := s.Tracer.Start(ctx, "blockstoreCopy")
 	defer span.End()
 
 	// TODO: smarter batching... im sure ive written this logic before, just gotta go find it

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -140,16 +140,8 @@ func main() {
 			Value: false,
 		},
 		&cli.StringFlag{
-			Name:  "jaeger-provider-host",
-			Value: "localhost",
-		},
-		&cli.IntFlag{
-			Name:  "jaeger-provider-port",
-			Value: 14268,
-		},
-		&cli.StringFlag{
-			Name:  "jaeger-provider-name",
-			Value: "estuary-shuttle",
+			Name:  "jaeger-provider-url",
+			Value: "http://localhost:14268/api/traces",
 		},
 		&cli.Float64Flag{
 			Name:  "jaeger-sampler-ratio",
@@ -254,7 +246,8 @@ func main() {
 		}
 
 		if cctx.Bool("jaeger-tracing") {
-			tp, err := estumetrics.NewJaegerTraceProvider(cctx)
+			tp, err := estumetrics.NewJaegerTraceProvider("estuary-shuttle",
+				cctx.String("jaeger-provider-url"), cctx.Float64("jaeger-sampler-ratio"))
 			if err != nil {
 				return err
 			}

--- a/cmd/estuary-shuttle/retrieval.go
+++ b/cmd/estuary-shuttle/retrieval.go
@@ -25,7 +25,7 @@ type retrievalProgress struct {
 }
 
 func (s *Shuttle) retrieveContent(ctx context.Context, contentToFetch uint, root cid.Cid, deals []drpc.StorageDeal) error {
-	ctx, span := Tracer.Start(ctx, "retrieveContent", trace.WithAttributes(
+	ctx, span := s.Tracer.Start(ctx, "retrieveContent", trace.WithAttributes(
 		attribute.Int("content", int(contentToFetch)),
 	))
 	defer span.End()
@@ -66,7 +66,7 @@ func (s *Shuttle) retrieveContent(ctx context.Context, contentToFetch uint, root
 }
 
 func (s *Shuttle) runRetrieval(ctx context.Context, contentToFetch uint, deals []drpc.StorageDeal, root cid.Cid, sel ipld.Node) error {
-	ctx, span := Tracer.Start(ctx, "runRetrieval")
+	ctx, span := s.Tracer.Start(ctx, "runRetrieval")
 	defer span.End()
 
 	var pin Pin

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -21,8 +21,14 @@ type Hello struct {
 }
 
 type Command struct {
-	Op     string
-	Params CmdParams
+	Op           string
+	Params       CmdParams
+	TraceCarrier *TraceCarrier `json:",omitempty"`
+}
+
+// HasTraceCarrier returns true iff Command `c` contains a trace.
+func (c *Command) HasTraceCarrier() bool {
+	return !(c.TraceCarrier == nil)
 }
 
 type CmdParams struct {
@@ -112,8 +118,14 @@ type ContentFetch struct {
 }
 
 type Message struct {
-	Op     string
-	Params MsgParams
+	Op           string
+	Params       MsgParams
+	TraceCarrier *TraceCarrier `json:",omitempty"`
+}
+
+// HasTraceCarrier returns true iff Message `m` contains a trace.
+func (m *Message) HasTraceCarrier() bool {
+	return !(m.TraceCarrier == nil)
 }
 
 type MsgParams struct {

--- a/drpc/traceing.go
+++ b/drpc/traceing.go
@@ -1,0 +1,74 @@
+package drpc
+
+import (
+	"encoding/json"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+/*
+TraceCarrier is required to Marshal and Unmarshall trace.SpanContext across RPC boundaries since the
+OpenTelemetry spec dictates trace.SpanContext must be read only, and therefore does not implement a
+JSON unmarshaller.
+Context: https://github.com/open-telemetry/opentelemetry-go/issues/1927#issuecomment-842663910
+*/
+
+// NewTraceCarrier accepts a trace.SpanContext and returns a TraceCarrier.
+func NewTraceCarrier(sc trace.SpanContext) *TraceCarrier {
+	if sc.IsValid() {
+		return &TraceCarrier{
+			TraceID: sc.TraceID(),
+			SpanID:  sc.SpanID(),
+			Remote:  sc.IsRemote(),
+		}
+	}
+	return nil
+}
+
+// TraceCarrier is a wrapper that allows trace.SpanContext's to be round-tripped through JSON.
+type TraceCarrier struct {
+	TraceID trace.TraceID `json:"traceID"`
+	SpanID  trace.SpanID  `json:"spanID"`
+	Remote  bool          `json:"remote"`
+}
+
+//MarshalJSON converts TraceCarrier to a trace.SpanContext and marshals it to JSON.
+func (c *TraceCarrier) MarshalJSON() ([]byte, error) {
+	return c.AsSpanContext().MarshalJSON()
+}
+
+// UnmarshalJSON unmarshalls a serialized trace.SpanContext to a TraceCarrier.
+func (c *TraceCarrier) UnmarshalJSON(b []byte) error {
+	var data traceCarrierInfo
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+	var err error
+	c.TraceID, err = trace.TraceIDFromHex(data.TraceID)
+	if err != nil {
+		return err
+	}
+	c.SpanID, err = trace.SpanIDFromHex(data.SpanID)
+	if err != nil {
+		return err
+	}
+	c.Remote = data.Remote
+
+	return nil
+}
+
+// AsSpanContext converts TraceCarrier to a trace.SpanContext.
+func (c *TraceCarrier) AsSpanContext() trace.SpanContext {
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: c.TraceID,
+		SpanID:  c.SpanID,
+		Remote:  c.Remote,
+	})
+}
+
+// carrierInfo is a helper used to deserialize a SpanContext from JSON.
+type traceCarrierInfo struct {
+	TraceID string
+	SpanID  string
+	Remote  bool
+}

--- a/go.mod
+++ b/go.mod
@@ -28,12 +28,10 @@ require (
 	github.com/ipfs/go-ds-flatfs v0.4.5
 	github.com/ipfs/go-ds-leveldb v0.4.2
 	github.com/ipfs/go-filestore v1.0.0
-	github.com/ipfs/go-graphsync v0.9.1 // indirect
 	github.com/ipfs/go-ipfs-blockstore v1.0.5-0.20210802214209-c56038684c45
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
-	github.com/ipfs/go-ipfs-pinner v0.1.2
 	github.com/ipfs/go-ipfs-provider v0.6.1
 	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/ipfs/go-ipld-format v0.2.0
@@ -66,6 +64,8 @@ require (
 	github.com/whyrusleeping/go-bs-measure v0.0.0-20210707212153-630d0432b1a7
 	github.com/whyrusleeping/memo v0.0.0-20210910192822-d78e688468b5
 	go.opentelemetry.io/otel v0.20.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.20.0
+	go.opentelemetry.io/otel/sdk v0.20.0
 	go.opentelemetry.io/otel/trace v0.20.0
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c

--- a/go.sum
+++ b/go.sum
@@ -866,7 +866,6 @@ github.com/ipfs/go-bitswap v0.1.0/go.mod h1:FFJEf18E9izuCqUtHxbWEvq+reg7o4CW5wSA
 github.com/ipfs/go-bitswap v0.1.2/go.mod h1:qxSWS4NXGs7jQ6zQvoPY3+NmOfHHG47mhkiLzBpJQIs=
 github.com/ipfs/go-bitswap v0.1.8/go.mod h1:TOWoxllhccevbWFUR2N7B1MTSVVge1s6XSMiCSA4MzM=
 github.com/ipfs/go-bitswap v0.3.2/go.mod h1:AyWWfN3moBzQX0banEtfKOfbXb3ZeoOeXnZGNPV9S6w=
-github.com/ipfs/go-bitswap v0.3.4 h1:AhJhRrG8xkxh6x87b4wWs+4U4y3DVB3doI8yFNqgQME=
 github.com/ipfs/go-bitswap v0.3.4/go.mod h1:4T7fvNv/LmOys+21tnLzGKncMeeXUYUd1nUiJ2teMvI=
 github.com/ipfs/go-bitswap v0.4.0 h1:bLiqrpef1na4wdqGLqHKv954s1zz6KFghfmQWCPjBik=
 github.com/ipfs/go-bitswap v0.4.0/go.mod h1:J2sAsp9UKxLgHDektSy3y3Q9OfQjM9sjhKBR1dlwrMg=
@@ -984,8 +983,6 @@ github.com/ipfs/go-ipfs-files v0.0.8/go.mod h1:wiN/jSG8FKyk7N0WyctKSvq3ljIa2NNTi
 github.com/ipfs/go-ipfs-flags v0.0.1/go.mod h1:RnXBb9WV53GSfTrSDVK61NLTFKvWc60n+K9EgCDh+rA=
 github.com/ipfs/go-ipfs-http-client v0.0.5 h1:niW5M0qqa0O/VRCAzr3f5Y7i3MjTpf0lhpkisjRtHR8=
 github.com/ipfs/go-ipfs-http-client v0.0.5/go.mod h1:8EKP9RGUrUex4Ff86WhnKU7seEBOtjdgXlY9XHYvYMw=
-github.com/ipfs/go-ipfs-pinner v0.1.2 h1:Ve9OBhL6eg5+tVqEnIhPZOCXDtMjB+OhOohVZxPUxms=
-github.com/ipfs/go-ipfs-pinner v0.1.2/go.mod h1:/u9kMe+TyQybN21O5OBicdyx3x93lVI77PCtiTnArUk=
 github.com/ipfs/go-ipfs-posinfo v0.0.1 h1:Esoxj+1JgSjX0+ylc0hUmJCOv6V2vFoZiETLR6OtpRs=
 github.com/ipfs/go-ipfs-posinfo v0.0.1/go.mod h1:SwyeVP+jCwiDu0C313l/8jg6ZxM0qqtlt2a0vILTc1A=
 github.com/ipfs/go-ipfs-pq v0.0.1/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
@@ -1036,7 +1033,6 @@ github.com/ipfs/go-merkledag v0.0.3/go.mod h1:Oc5kIXLHokkE1hWGMBHw+oxehkAaTOqtEb
 github.com/ipfs/go-merkledag v0.0.6/go.mod h1:QYPdnlvkOg7GnQRofu9XZimC5ZW5Wi3bKys/4GQQfto=
 github.com/ipfs/go-merkledag v0.2.3/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-merkledag v0.2.4/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
-github.com/ipfs/go-merkledag v0.3.0/go.mod h1:4pymaZLhSLNVuiCITYrpViD6vmfZ/Ws4n/L9tfNv3S4=
 github.com/ipfs/go-merkledag v0.3.1/go.mod h1:fvkZNNZixVW6cKSZ/JfLlON5OlgTXNdRLz0p6QG/I2M=
 github.com/ipfs/go-merkledag v0.3.2 h1:MRqj40QkrWkvPswXs4EfSslhZ4RVPRbxwX11js0t1xY=
 github.com/ipfs/go-merkledag v0.3.2/go.mod h1:fvkZNNZixVW6cKSZ/JfLlON5OlgTXNdRLz0p6QG/I2M=
@@ -1050,7 +1046,6 @@ github.com/ipfs/go-path v0.0.7/go.mod h1:6KTKmeRnBXgqrTvzFrPV3CamxcgvXX/4z79tfAd
 github.com/ipfs/go-peertaskqueue v0.0.4/go.mod h1:03H8fhyeMfKNFWqzYEVyMbcPUeYrqP1MX6Kd+aN+rMQ=
 github.com/ipfs/go-peertaskqueue v0.1.0/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
 github.com/ipfs/go-peertaskqueue v0.1.1/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
-github.com/ipfs/go-peertaskqueue v0.2.0 h1:2cSr7exUGKYyDeUyQ7P/nHPs9P7Ht/B+ROrpN1EJOjc=
 github.com/ipfs/go-peertaskqueue v0.2.0/go.mod h1:5/eNrBEbtSKWCG+kQK8K8fGNixoYUnr+P7jivavs9lY=
 github.com/ipfs/go-peertaskqueue v0.4.0 h1:x1hFgA4JOUJ3ntPfqLRu6v4k6kKL0p07r3RSg9JNyHI=
 github.com/ipfs/go-peertaskqueue v0.4.0/go.mod h1:KL9F49hXJMoXCad8e5anivjN+kWdr+CyGcyh4K6doLc=
@@ -2137,6 +2132,7 @@ github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5J
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -2242,8 +2238,6 @@ github.com/whyrusleeping/ledger-filecoin-go v0.9.1-0.20201010031517-c3dcc1bddce4
 github.com/whyrusleeping/mafmt v1.2.8/go.mod h1:faQJFPbLSxzD9xpA02ttW/tS9vZykNvXwGvqIpk20FA=
 github.com/whyrusleeping/mdns v0.0.0-20180901202407-ef14215e6b30/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
-github.com/whyrusleeping/memo v0.0.0-20210319212142-d69afb686d15 h1:JngnLooDwEDdtrBmfMwBFi8HbmEgktI32bS0ipHKNp4=
-github.com/whyrusleeping/memo v0.0.0-20210319212142-d69afb686d15/go.mod h1:xgUNxvGGAouwP4wwwLwlzWuKMSUElf89vICsRhit+TE=
 github.com/whyrusleeping/memo v0.0.0-20210910192822-d78e688468b5 h1:TY6591fnakZtDzd0RFzEcJiFs72ovDcHJERH+Wr7nTE=
 github.com/whyrusleeping/memo v0.0.0-20210910192822-d78e688468b5/go.mod h1:xgUNxvGGAouwP4wwwLwlzWuKMSUElf89vICsRhit+TE=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
@@ -2320,6 +2314,8 @@ go.opentelemetry.io/otel v0.20.0 h1:eaP0Fqu7SXHwvjiqDq83zImeehOHX8doTvU9AwXON8g=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
+go.opentelemetry.io/otel/exporters/trace/jaeger v0.20.0 h1:FoclOadJNul1vUiKnZU0sKFWOZtZQq3jUzSbrX2jwNM=
+go.opentelemetry.io/otel/exporters/trace/jaeger v0.20.0/go.mod h1:10qwvAmKpvwRO5lL3KQ8EWznPp89uGfhcbK152LFWsQ=
 go.opentelemetry.io/otel/metric v0.20.0 h1:4kzhXFP+btKm4jwxpjIqjs41A7MakRFUS86bqLHTIw8=
 go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9debfNp6R3s7Pr1eU=
 go.opentelemetry.io/otel/oteltest v0.20.0 h1:HiITxCawalo5vQzdHfKeZurV8x7ljcqAgiWzF6Vaeaw=

--- a/main.go
+++ b/main.go
@@ -204,16 +204,8 @@ func main() {
 			Value: false,
 		},
 		&cli.StringFlag{
-			Name:  "jaeger-provider-host",
-			Value: "localhost",
-		},
-		&cli.IntFlag{
-			Name:  "jaeger-provider-port",
-			Value: 14268,
-		},
-		&cli.StringFlag{
-			Name:  "jaeger-provider-name",
-			Value: "estuary",
+			Name:  "jaeger-provider-url",
+			Value: "http://localhost:14268/api/traces",
 		},
 		&cli.Float64Flag{
 			Name:  "jaeger-sampler-ratio",
@@ -354,7 +346,8 @@ func main() {
 
 		// setup tracing to jaeger if enabled
 		if cctx.Bool("jaeger-tracing") {
-			tp, err := metrics.NewJaegerTraceProvider(cctx)
+			tp, err := metrics.NewJaegerTraceProvider("estuary",
+				cctx.String("jaeger-provider-url"), cctx.Float64("jaeger-sampler-ratio"))
 			if err != nil {
 				return err
 			}

--- a/metrics/jaeger.go
+++ b/metrics/jaeger.go
@@ -1,10 +1,7 @@
 package metrics
 
 import (
-	"fmt"
-
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel/exporters/trace/jaeger"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -15,12 +12,8 @@ var log = logging.Logger("metrics")
 
 // NewJaegerTraceProvider returns a new and configured TracerProvider backed by Jaeger.
 // based on https://github.com/open-telemetry/opentelemetry-go/blob/v0.20.0/example/jaeger/main.go
-func NewJaegerTraceProvider(cctx *cli.Context) (*sdktrace.TracerProvider, error) {
-	serviceName := cctx.String("jaeger-provider-name")
-	sampleRatio := cctx.Float64("jaeger-sampler-ratio")
-	agentEndpoint := fmt.Sprintf("http://%s:%d/api/traces", cctx.String("jaeger-provider-host"), cctx.Int("jaeger-provider-port"))
-
-	log.Infow("creating jaeger trace provider", "name", serviceName, "ratio", sampleRatio, "endpoint", agentEndpoint)
+func NewJaegerTraceProvider(serviceName, agentEndpoint string, sampleRatio float64) (*sdktrace.TracerProvider, error) {
+	log.Infow("creating jaeger trace provider", "serviceName", serviceName, "ratio", sampleRatio, "endpoint", agentEndpoint)
 	var sampler sdktrace.Sampler
 	if sampleRatio < 1 && sampleRatio > 0 {
 		sampler = sdktrace.ParentBased(sdktrace.TraceIDRatioBased(sampleRatio))

--- a/pinning.go
+++ b/pinning.go
@@ -241,8 +241,7 @@ func (cm *ContentManager) pinContentOnShuttle(ctx context.Context, cont Content,
 	defer span.End()
 
 	if err := cm.sendShuttleCommand(ctx, handle, &drpc.Command{
-		TraceCarrier: drpc.NewTraceCarrier(span.SpanContext()),
-		Op:           drpc.CMD_AddPin,
+		Op: drpc.CMD_AddPin,
 		Params: drpc.CmdParams{
 			AddPin: &drpc.AddPin{
 				DBID:   cont.ID,


### PR DESCRIPTION
This PR wires up tracing across the RPC boundaries of the estuary node and its shuttles. Attached is a trace of a file being added to Estuary via the `/content/add-ipfs` endpoint, the request being made to the shuttle, and the response of the shuttle to estuary indicating the file has been pinned successfully.
![tracingestuaryscreenshot](https://user-images.githubusercontent.com/6546409/133860781-d2ef9490-cb45-4067-bebd-58e853d8bede.png)

I am unsure if the shuttle nodes are configured to talk with lightstep, if they are this will work out fo the box, otherwise shuttles will need further work to setup that connection. Not sure how to do that..