### PR TITLE
feat: support building for calibnet and update Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /barge
 /estuary-dealer
 /bsget
+/benchest
+/estuary-shuttle
 
 estuary-blocks/*
 estuary-leveldb/*

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ estuary-peer.key
 estuary-wallet/*
 estuary-write-log/*
 estuary.db
+estuary_calibnet.db
 
 cidlistsdir/*
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ deps: $(BUILD_DEPS)
 
 .PHONY: estuary
 estuary:
-	go build $(GOLAGS)
+	go build $(GOFLAGS)
 BINS+=estuary
 
 .PHONY: shuttle

--- a/Makefile
+++ b/Makefile
@@ -54,18 +54,43 @@ CLEAN+=build/.update-modules
 #GOFLAGS+=-ldflags="$(ldflags)"
 
 .PHONY: build
-build: deps estuary
+build: deps estuary shuttle barge benchest bsget
 
 .PHONY: deps
 deps: $(BUILD_DEPS)
 
 .PHONY: estuary
 estuary:
-	go build $(GOFLAGS)
+	go build $(GOLAGS)
+BINS+=estuary
+
+.PHONY: shuttle
+shuttle:
+	go build $(GOFLAGS) -o estuary-shuttle ./cmd/estuary-shuttle
+BINS+=estuary-shuttle
+
+.PHONY: barge
+barge:
+	go build $(GOFLAGS) -o barge ./cmd/barge
+BINS+=barge
+
+.PHONY: benchest
+benchest:
+	go build $(GOFLAGS) -o benchest ./cmd/benchest
+BINS+=benchest
+
+.PHONY: bsget
+bsget:
+	go build $(GOFLAGS) -o bsget ./cmd/bsget
+BINS+=bsget
 
 .PHONY: install
 install: estuary
 	cp estuary /usr/local/bin/estuary
+
+.PHONY: install-shuttle
+install-shuttle: shuttle
+	cp estuary-shuttle /usr/local/bin/estuary-shuttle
 
 .PHONY: install-estuary-service
 install-estuary-service:
@@ -84,13 +109,6 @@ install-estuary-service:
 	#Run 'sudo systemctl start estuary-setup.service' to complete setup
 	#Run 'sudo systemctl enable --now estuary.service' once ready to enable and start estuary service
 
-.PHONY: shuttle
-shuttle:
-	go build ./cmd/estuary-shuttle
-
-.PHONY: install-shuttle
-install-shuttle: shuttle
-	cp estuary-shuttle /usr/local/bin/estuary-shuttle
 
 .PHONY: install-estuary-shuttle-service
 install-estuary-shuttle-service:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ deps: $(BUILD_DEPS)
 
 .PHONY: estuary
 estuary:
-	go build
+	go build $(GOFLAGS)
 
 .PHONY: install
 install: estuary
@@ -116,3 +116,6 @@ clean:
 dist-clean:
 	git clean -xdff
 	git submodule deinit --all -f
+
+calibnet: GOFLAGS+=-tags=calibnet
+calibnet: build

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -6,11 +6,11 @@ import (
 	"github.com/filecoin-project/go-address"
 )
 
-// TODO get miners sorted
+// Three miners with most power as of 2021-09-17
 var calibnetMinerStrs = []string{
-	"t01000",
-	"t01001",
-	"t01002",
+	"t03112",
+	"t03149",
+	"t01247",
 }
 
 var defaultCalibnetDatabaseValue = "sqlite=estuary_calibnet.db"

--- a/build/params_calibnet.go
+++ b/build/params_calibnet.go
@@ -1,0 +1,22 @@
+// +build calibnet
+
+package build
+
+import (
+	"github.com/filecoin-project/go-address"
+)
+
+// TODO get miners sorted
+var calibnetMinerStrs = []string{
+	"t01000",
+	"t01001",
+	"t01002",
+}
+
+var defaultCalibnetDatabaseValue = "sqlite=estuary_calibnet.db"
+
+func init() {
+	SetAddressNetwork(address.Testnet)
+	SetDefaultMiners(calibnetMinerStrs)
+	SetDefaultDatabaseValue(defaultCalibnetDatabaseValue)
+}

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -1,0 +1,56 @@
+// +build !calibnet
+
+package build
+
+import (
+	"github.com/filecoin-project/go-address"
+)
+
+// miners from minerX spreadsheet
+var mainnetMinerStrs = []string{
+	"f02620",
+	"f023971",
+	"f022142",
+	"f019551",
+	"f01240",
+	"f01247",
+	"f01278",
+	"f071624",
+	"f0135078",
+	"f022352",
+	"f014768",
+	"f022163",
+	"f09848",
+	"f02576",
+	"f02606",
+	"f019041",
+	"f010617",
+	"f023467",
+	"f01276",
+	"f02401",
+	"f02387",
+	"f019104",
+	"f099608",
+	"f062353",
+	"f07998",
+	"f019362",
+	"f019100",
+	"f014409",
+	"f066596",
+	"f01234",
+	"f058369",
+	"f08399",
+	"f021716",
+	"f010479",
+	"f08403",
+	"f01277",
+	"f015927",
+}
+
+var defaultMainnetDatabaseValue = "sqlite=estuary.db"
+
+func init() {
+	SetAddressNetwork(address.Mainnet)
+	SetDefaultMiners(mainnetMinerStrs)
+	SetDefaultDatabaseValue(defaultMainnetDatabaseValue)
+}

--- a/build/params_shared.go
+++ b/build/params_shared.go
@@ -1,0 +1,28 @@
+package build
+
+import (
+	"github.com/filecoin-project/go-address"
+)
+
+func SetAddressNetwork(n address.Network) {
+	address.CurrentNetwork = n
+}
+
+var DefaultMiners []address.Address
+
+func SetDefaultMiners(minerStrs []string) {
+	for _, s := range minerStrs {
+		a, err := address.NewFromString(s)
+		if err != nil {
+			panic(err)
+		}
+
+		DefaultMiners = append(DefaultMiners, a)
+	}
+}
+
+var DefaultDatabaseValue string
+
+func SetDefaultDatabaseValue(dbStr string) {
+	DefaultDatabaseValue = dbStr
+}

--- a/main.go
+++ b/main.go
@@ -9,12 +9,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/application-research/estuary/build"
 	"github.com/application-research/estuary/node"
 	"github.com/application-research/estuary/pinner"
 	"github.com/application-research/estuary/stagingbs"
 	"github.com/application-research/estuary/util"
 	"github.com/application-research/filclient"
-	"github.com/filecoin-project/go-address"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -34,62 +34,6 @@ import (
 )
 
 var log = logging.Logger("estuary")
-
-var defaultMiners []address.Address
-
-var defaultDatabaseValue = "sqlite=estuary.db"
-
-func init() {
-	// miners from minerX spreadsheet
-	minerStrs := []string{
-		"f02620",
-		"f023971",
-		"f022142",
-		"f019551",
-		"f01240",
-		"f01247",
-		"f01278",
-		"f071624",
-		"f0135078",
-		"f022352",
-		"f014768",
-		"f022163",
-		"f09848",
-		"f02576",
-		"f02606",
-		"f019041",
-		"f010617",
-		"f023467",
-		"f01276",
-		"f02401",
-		"f02387",
-		"f019104",
-		"f099608",
-		"f062353",
-		"f07998",
-		"f019362",
-		"f019100",
-		"f014409",
-		"f066596",
-		"f01234",
-		"f058369",
-		"f08399",
-		"f021716",
-		"f010479",
-		"f08403",
-		"f01277",
-		"f015927",
-	}
-
-	for _, s := range minerStrs {
-		a, err := address.NewFromString(s)
-		if err != nil {
-			panic(err)
-		}
-
-		defaultMiners = append(defaultMiners, a)
-	}
-}
 
 type storageMiner struct {
 	gorm.Model
@@ -180,7 +124,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "database",
 			Usage:   "specify connection string for estuary database",
-			Value:   defaultDatabaseValue,
+			Value:   build.DefaultDatabaseValue,
 			EnvVars: []string{"ESTUARY_DATABASE"},
 		},
 		&cli.StringFlag{
@@ -512,7 +456,7 @@ func setupDatabase(cctx *cli.Context) (*gorm.DB, error) {
 
 	if count == 0 {
 		fmt.Println("adding default miner list to database...")
-		for _, m := range defaultMiners {
+		for _, m := range build.DefaultMiners {
 			db.Create(&storageMiner{Address: util.DbAddr{m}})
 		}
 


### PR DESCRIPTION
- allows testnet addresses to be used
- creates calibration network-specific database
- defines calibration specific miners
- builds all binaries from `make`
- `make clean` removes all bins