### PR TITLE
add support for running with a dev-signed cert

### DIFF
--- a/GettingStartedDevelopment.md
+++ b/GettingStartedDevelopment.md
@@ -19,6 +19,15 @@ Next, set the `FULLNODE_API_INFO` environment variable to a synced lotus node. T
 $ export FULLNODE_API_INFO=wss://api.chain.love
 ```
 
+Next, create and install a self-signed certificate by following the instructions in the repository here:
+https://github.com/dakshshah96/local-cert-generator/
+
+Once you have the Root CA installed, you'll need to tell Estuary the path to the self-signed certificate, and corresponding private key like so:
+```bash
+$ export ESTUARY_DEV_TLS_CERT=/path/to/server.crt
+$ export ESTUARY_DEV_TLS_KEY=/path/to/server.key
+```
+
 Start your Estuary Node (Note: if you see error messages like `too many open files`, increase the number of open files allow `ulimit -n 10000`)
 
 ```bash

--- a/handlers.go
+++ b/handlers.go
@@ -259,7 +259,12 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 
 	e.GET("/shuttle/conn", s.handleShuttleConnection)
 
-	return e.Start(srv)
+	if s.certFiles != nil {
+		log.Warnf("serving TLS with a self-signed certificate. do not use in production!")
+		return e.StartTLS(srv, s.certFiles.cert, s.certFiles.key)
+	} else {
+		return e.Start(srv)
+	}
 }
 
 func serveCpuProfile(c echo.Context) error {

--- a/main.go
+++ b/main.go
@@ -194,6 +194,18 @@ func main() {
 			Name:  "default-replication",
 			Value: 6,
 		},
+		&cli.StringFlag{
+			Name:    "dev-tls-key",
+			Usage:   "enable https/wss in development with private key at `FILE`. " +
+			         "--dev-tls-cert also required",
+			EnvVars: []string{"ESTUARY_DEV_TLS_KEY"},
+		},
+		&cli.StringFlag{
+			Name:    "dev-tls-cert",
+			Usage:   "enable https/wss in development with certificate at `FILE`. " +
+			         "--dev-tls-key also required",
+			EnvVars: []string{"ESTUARY_DEV_TLS_CERT"},
+		},
 	}
 	app.Commands = []*cli.Command{
 		{
@@ -267,6 +279,15 @@ func main() {
 			}
 		}
 
+		hasCert := cctx.IsSet("dev-tls-cert") || cctx.IsSet("dev-tls-key")
+		if hasCert {
+			if !cctx.IsSet("dev-tls-key") {
+				return cli.Exit("missing required --dev-tls-key", 1)
+			} else if !cctx.IsSet("dev-tls-cert") {
+				return cli.Exit("missing required --dev-tls-cert", 1)
+			}
+		}
+
 		db, err := setupDatabase(cctx)
 		if err != nil {
 			return err
@@ -332,6 +353,13 @@ func main() {
 			StagingMgr: sbmgr,
 			tracer:     otel.Tracer("api"),
 			quickCache: make(map[string]endpointCache),
+		}
+
+		if hasCert {
+			s.certFiles = &TLSCertFiles{
+				cert: cctx.String("dev-tls-cert"),
+				key:  cctx.String("dev-tls-key"),
+			}
 		}
 
 		// TODO: this is an ugly self referential hack... should fix
@@ -476,6 +504,12 @@ type Server struct {
 
 	cacheLk    sync.Mutex
 	quickCache map[string]endpointCache
+	certFiles  *TLSCertFiles
+}
+
+type TLSCertFiles struct {
+	key  string
+	cert string
 }
 
 type endpointCache struct {


### PR DESCRIPTION
by default, estuary runs it's webserver on an insecure socket, presumably requiring a TLS termination in front of it before a shuttle can actually connect.

this is probably fine in production, but as it stands, running estuary + shuttle locally in a dev environment won't work unless you setup a terminating proxy, which is quite painful. the error messages when trying to follow the docs as is look something like this from `estuary-shuttle`:
```
2021-09-30T14:47:11.052-0500    ERROR   shuttle estuary-shuttle/main.go:426     failed to dial estuary rpc endpoint: websocket.Dial wss://localhost:3004/shuttle/conn: tls: first record does not look like a TLS handshake
```

this PR makes it straight forward to provide a self-signed cert to estuary directly, allowing the shuttle to connect as outlined in the setup docs without an issue