### PR TITLE
Include jq, hwloc, and OpenCL as Requirements in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 Requirements:
 - go (1.15 or higher)
+- [jq](https://stedolan.github.io/jq/)
+- [hwloc](https://www.open-mpi.org/projects/hwloc/)
+- opencl
 
 1. Run `make clean all` inside the estuary directory
 


### PR DESCRIPTION
I noticed when setting up my local Estuary development environment that the setup scripts require `jq`, `hwloc` and `opencl` but they aren't described in the README. So this is just a very minimal PR to add them in to help improve the new user setup experience.