### PR TITLE
switch to FFI for commP hashing

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -233,7 +233,7 @@ func main() {
 				return nil, err
 			}
 
-			commpcid, size, err := filclient.GeneratePieceCommitment(ctx, c, nd.Blockstore)
+			commpcid, size, err := filclient.GeneratePieceCommitmentFFI(ctx, c, nd.Blockstore)
 			if err != nil {
 				return nil, err
 			}

--- a/replication.go
+++ b/replication.go
@@ -2393,7 +2393,7 @@ func (cm *ContentManager) runPieceCommCompute(ctx context.Context, data cid.Cid,
 	}
 
 	log.Infow("computing piece commitment", "data", cont.Cid.CID)
-	return filclient.GeneratePieceCommitment(ctx, data, bs)
+	return filclient.GeneratePieceCommitmentFFI(ctx, data, bs)
 }
 
 func (cm *ContentManager) getPieceCommitment(ctx context.Context, data cid.Cid, bs blockstore.Blockstore) (cid.Cid, abi.UnpaddedPieceSize, error) {


### PR DESCRIPTION
I've been bench-testing this locally with a manually pinned CID, and am seeing 40-50% speed improvements over `GeneratePieceCommitment`

two questions before this lands:
* should I add a more reproducible bench test?
* curious about other potential ramifications of using FFI, most of my testing has been with relatively controlled data, not clear on the tradeoffs in accuracy, etc

/cc @whyrusleeping for :eyes: 