### PR TITLE
reset nextEvent time to zero when queue is emptied

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -524,6 +524,7 @@ func (qm *queueManager) processQueue() {
 			return
 		}
 	}
+	qm.nextEvent = time.Time{}
 }
 
 func (cm *ContentManager) currentLocationForContent(c uint) (string, error) {


### PR DESCRIPTION
This should fix a bug where we fail to process any new things if we ever manage to get the queue to zero.

I'm not actually sure how the queue gets to zero ever, but ive seen evidence of that happening, and this is fairly obvious as a bug in that case.