### PR TITLE
implement an upload proxy

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -173,6 +173,10 @@ func main() {
 			Usage: "If less than 1 probabilistic metrics will be used.",
 			Value: 1,
 		},
+		&cli.BoolFlag{
+			Name:  "libp2p-websockets",
+			Value: false,
+		},
 	}
 
 	app.Action = func(cctx *cli.Context) error {
@@ -190,11 +194,17 @@ func main() {
 			wlog = filepath.Join(ddir, wlog)
 		}
 
+		listens := []string{
+			"/ip4/0.0.0.0/tcp/6745",
+			"/ip4/0.0.0.0/udp/6746/quic",
+		}
+
+		if cctx.Bool("libp2p-websockets") {
+			listens = append(listens, "/ip4/0.0.0.0/tcp/6747/ws")
+		}
+
 		cfg := &node.Config{
-			ListenAddrs: []string{
-				"/ip4/0.0.0.0/tcp/6745",
-				"/ip4/0.0.0.0/udp/6746/quic",
-			},
+			ListenAddrs:       listens,
 			Blockstore:        bsdir,
 			WriteLog:          wlog,
 			HardFlushWriteLog: cctx.Bool("write-log-flush"),

--- a/cmd/shuttle-proxy/main.go
+++ b/cmd/shuttle-proxy/main.go
@@ -131,7 +131,10 @@ func (p *Proxy) handleContentAdd(c echo.Context) error {
 
 	c.Response().WriteHeader(resp.StatusCode)
 
-	io.Copy(c.Response().Writer, resp.Body)
+	_, err = io.Copy(c.Response().Writer, resp.Body)
+	if err != nil {
+		log.Errorf("proxying content-add body errored: %s", err)
+	}
 
 	return nil
 }
@@ -171,7 +174,10 @@ func (p *Proxy) handleAddCar(c echo.Context) error {
 
 	c.Response().WriteHeader(resp.StatusCode)
 
-	io.Copy(c.Response().Writer, resp.Body)
+	_, err = io.Copy(c.Response().Writer, resp.Body)
+	if err != nil {
+		log.Errorf("proxying content-add-car body errored: %s", err)
+	}
 
 	return nil
 }

--- a/cmd/shuttle-proxy/main.go
+++ b/cmd/shuttle-proxy/main.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/urfave/cli/v2"
+
+	"github.com/application-research/estuary/util"
+)
+
+var log = logging.Logger("shuttle-proxy")
+
+type Proxy struct {
+	ControllerUrl string
+}
+
+func main() {
+
+	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:  "listen",
+			Value: ":3205",
+		},
+		&cli.StringFlag{
+			Name:  "controller",
+			Value: "https://api.estuary.tech",
+		},
+		&cli.BoolFlag{
+			Name:  "logging",
+			Value: true,
+		},
+	}
+	app.Action = func(cctx *cli.Context) error {
+		logging := cctx.Bool("logging")
+		p := &Proxy{
+			ControllerUrl: cctx.String("controller"),
+		}
+
+		// upload.estuary.tech
+		// routes to whatever shuttle is best
+		// this is entirely because you cant return a 302 to a file upload request
+		e := echo.New()
+
+		if logging {
+			e.Use(middleware.Logger())
+		}
+
+		e.Use(middleware.CORS())
+
+		e.HTTPErrorHandler = util.ErrorHandler
+
+		e.POST("/content/add", p.handleContentAdd)
+		e.POST("/content/add-car", p.handleAddCar)
+
+		return e.Start(cctx.String("listen"))
+	}
+
+	app.RunAndExitOnError()
+}
+
+func (p *Proxy) getViewer(auth string) (*util.ViewerResponse, int, error) {
+	req, err := http.NewRequest("GET", p.ControllerUrl+"/viewer", nil)
+	if err != nil {
+		return nil, 500, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+auth)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 500, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, resp.StatusCode, fmt.Errorf("auth check failed")
+	}
+
+	var rb util.ViewerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rb); err != nil {
+		return nil, 500, err
+	}
+
+	return &rb, 0, nil
+}
+
+func (p *Proxy) getEndpoints(c echo.Context) ([]string, error) {
+	auth, err := util.ExtractAuth(c)
+	if err != nil {
+		return nil, err
+	}
+
+	view, code, err := p.getViewer(auth)
+	if err != nil {
+		// TODO: match error format of shuttles
+		return nil, c.String(code, err.Error())
+	}
+
+	if len(view.Settings.UploadEndpoints) == 0 {
+		return nil, fmt.Errorf("all upload endpoints are unavailable")
+	}
+
+	return view.Settings.UploadEndpoints, nil
+}
+func (p *Proxy) handleContentAdd(c echo.Context) error {
+	eps, err := p.getEndpoints(c)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", eps[0], c.Request().Body)
+	if err != nil {
+		return err
+	}
+
+	req.Header = c.Request().Header.Clone()
+	req.Header.Set("Shuttle-Proxy", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	c.Response().WriteHeader(resp.StatusCode)
+
+	io.Copy(c.Response().Writer, resp.Body)
+
+	return nil
+}
+
+func (p *Proxy) handleAddCar(c echo.Context) error {
+	auth, err := util.ExtractAuth(c)
+	if err != nil {
+		return err
+	}
+
+	view, code, err := p.getViewer(auth)
+	if err != nil {
+		// TODO: match error format of shuttles
+		return c.String(code, err.Error())
+	}
+
+	if len(view.Settings.UploadEndpoints) == 0 {
+		log.Errorf("no upload endpoints")
+		return c.JSON(500, map[string]string{
+			"error": "all upload endpoints are unavailable",
+		})
+	}
+
+	ep := view.Settings.UploadEndpoints[0]
+	req, err := http.NewRequest("POST", ep, c.Request().Body)
+	if err != nil {
+		return err
+	}
+
+	req.Header = c.Request().Header.Clone()
+	req.Header.Set("Shuttle-Proxy", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	c.Response().WriteHeader(resp.StatusCode)
+
+	io.Copy(c.Response().Writer, resp.Body)
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/ipld/go-car v0.3.2-0.20211001225732-32d0d9933823
 	github.com/ipld/go-ipld-prime v0.12.3
 	github.com/jinzhu/gorm v1.9.16
+	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/libp2p/go-libp2p v0.15.1
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,7 @@ github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KP
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -1306,6 +1307,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
+github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/echo/v4 v4.6.1 h1:OMVsrnNFzYlGSdaiYGHbgWQnr+JM7NG+B9suCPie14M=
 github.com/labstack/echo/v4 v4.6.1/go.mod h1:RnjgMWNDB9g/HucVWhQYNQP9PvbYf6adqftqryo7s9k=

--- a/handlers.go
+++ b/handlers.go
@@ -77,7 +77,6 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 
 	e.Use(s.tracingMiddleware)
 	e.HTTPErrorHandler = func(err error, ctx echo.Context) {
-		log.Errorf("handler error: %s", err)
 		var herr *util.HttpError
 		if xerrors.As(err, &herr) {
 			res := map[string]string{
@@ -97,6 +96,8 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 			})
 			return
 		}
+
+		log.Errorf("handler error: %s", err)
 
 		// TODO: returning all errors out to the user smells potentially bad
 		_ = ctx.JSON(500, map[string]interface{}{


### PR DESCRIPTION
This way we can have people just upload things to `upload.estuary.tech` and it will pick the right shuttle to hit. For people uploading *lots* of data, the will still want to go direct to a shuttle, but this works for more 'normal' users.