### PR TITLE
add a sub-DAG selector for use in lotus retrieval

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1113,23 +1113,15 @@ func (s *Server) calcSelector(aggregatedIn uint, contentID uint) (string, error)
 	// sort the known content IDs aggregated in a CAR, and use the index in the sorted list
 	// to build the CAR sub-selector
 
-	// SELECT ordinal - 1 FROM (
-	//   SELECT
-	//     id, ROW_NUMBER() OVER ( ORDER BY CAST(id AS TEXT) ) AS ordinal
-	//   FROM contents
-	//   WHERE aggregated_in = ?
-    // ) subq
-	// WHERE id = ?
-
-	subQuery := s.DB.Table("contents").
-		Select("id, ROW_NUMBER() OVER ( ORDER BY CAST(id as TEXT) ) AS ordinal").
-		Where("aggregated_in = ?", aggregatedIn)
-
 	var ordinal uint
-	result := s.DB.Table("(?) subq", subQuery).
-		Select("ordinal - 1").
-		Where("id = ?", contentID).
-		Find(&ordinal)
+	result := s.DB.Raw(`SELECT ordinal - 1 FROM (
+				SELECT
+					id, ROW_NUMBER() OVER ( ORDER BY CAST(id AS TEXT) ) AS ordinal
+				FROM contents
+				WHERE aggregated_in = ?
+			) subq
+				WHERE id = ?
+			`, aggregatedIn, contentID).Scan(&ordinal)
 
 	if result.Error != nil {
 		return "", result.Error 


### PR DESCRIPTION
this code may be naive, so I'm looking for feedback to make sure this is the best way to provide info needed by estuary-www.

the basic idea is, given the root CID of an aggregated DAG, and the content ID (PK of the `contents` table of the DB) of a specific file:
* fetch and sort all content IDs for the aggregated deal associated with the CID -- this sorted list represents the canonical index of the actual nodes in the aggregated DAG (root CID)
* match the specific file's content ID with it's index in the sorted list from above, and you now have an index to build the selector in the form `Links/$index/Hash`

after this lands, the accompanying estuary-www PR can land as well

closes #76