### PR TITLE
add metadata to various APIs to support rclone

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ type storageMiner struct {
 type Content struct {
 	ID        uint           `gorm:"primarykey" json:"id"`
 	CreatedAt time.Time      `json:"-"`
-	UpdatedAt time.Time      `json:"-"`
+	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 
 	Cid         util.DbCID `json:"cid"`


### PR DESCRIPTION
my rclone estuary backend is in a new fork here:
https://github.com/application-research/rclone/tree/estuary

this change has two minor additions that make representing estuary's content/collections API as a filesystem a bit more bearable:

* Include `updatedAt` in the json serialization of `Content` which I'm using as the `modTime` for filesystem purposes
* Include the CID in results from `/collections/fs/list` for objects
