### PR TITLE
support filesystem paths in shuttle /content/add API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,7 @@ dist-clean:
 
 calibnet: GOFLAGS+=-tags=calibnet
 calibnet: build
+
+.PHONY: test
+test:
+	go test $(GOFLAGS) -v ./...

--- a/cmd/barge/client.go
+++ b/cmd/barge/client.go
@@ -133,7 +133,7 @@ func (c *EstClient) Viewer(ctx context.Context) (*util.ViewerResponse, error) {
 	return &vresp, nil
 }
 
-func (c *EstClient) AddCar(fpath, name string) (*util.AddFileResponse, error) {
+func (c *EstClient) AddCar(fpath, name string) (*util.ContentAddResponse, error) {
 	fi, err := os.Open(fpath)
 	if err != nil {
 		return nil, err
@@ -172,7 +172,7 @@ func (c *EstClient) AddCar(fpath, name string) (*util.AddFileResponse, error) {
 		return nil, fmt.Errorf("got invalid status code: %d", resp.StatusCode)
 	}
 
-	var rbody util.AddFileResponse
+	var rbody util.ContentAddResponse
 	if err := json.NewDecoder(resp.Body).Decode(&rbody); err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (c *EstClient) AddCar(fpath, name string) (*util.AddFileResponse, error) {
 	return &rbody, nil
 }
 
-func (c *EstClient) AddFile(fpath, name string) (*util.AddFileResponse, error) {
+func (c *EstClient) AddFile(fpath, name string) (*util.ContentAddResponse, error) {
 	r, w := io.Pipe()
 	fi, err := os.Open(fpath)
 	if err != nil {
@@ -244,7 +244,7 @@ func (c *EstClient) AddFile(fpath, name string) (*util.AddFileResponse, error) {
 		return nil, fmt.Errorf("got invalid status code: %d", resp.StatusCode)
 	}
 
-	var rbody util.AddFileResponse
+	var rbody util.ContentAddResponse
 	if err := json.NewDecoder(resp.Body).Decode(&rbody); err != nil {
 		return nil, err
 	}

--- a/cmd/benchest/main.go
+++ b/cmd/benchest/main.go
@@ -210,7 +210,7 @@ func RunBench(name string, fi io.Reader, host string, estToken string) (*benchRe
 		}, nil
 	}
 
-	var rbody util.AddFileResponse
+	var rbody util.ContentAddResponse
 	if err := json.NewDecoder(resp.Body).Decode(&rbody); err != nil {
 		return nil, err
 	}

--- a/util/content.go
+++ b/util/content.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"github.com/ipfs/go-cid"
+)
+
+type ContentInCollection struct {
+	Collection     string `json:"collection"`
+	CollectionPath string `json:"collectionPath"`
+}
+
+type ContentAddIpfsBody struct {
+	ContentInCollection
+
+	Root  string   `json:"root"`
+	Name  string   `json:"name"`
+	Peers []string `json:"peers"`
+}
+
+type ContentAddResponse struct {
+	Cid       string   `json:"cid"`
+	EstuaryId uint     `json:"estuaryId"`
+	Providers []string `json:"providers"`
+}
+
+type ContentCreateBody struct {
+	ContentInCollection
+
+	Root     cid.Cid `json:"root"`
+	Name     string  `json:"name"`
+	Location string  `json:"location"`
+}
+
+type ContentCreateResponse struct {
+	ID uint `json:"id"`
+}

--- a/util/http.go
+++ b/util/http.go
@@ -99,12 +99,6 @@ type ViewerResponse struct {
 	Settings UserSettings `json:"settings"`
 }
 
-type AddFileResponse struct {
-	Cid       string   `json:"cid"`
-	EstuaryId uint     `json:"estuaryId"`
-	Providers []string `json:"providers"`
-}
-
 func ErrorHandler(err error, ctx echo.Context) {
 	log.Errorf("handler error: %s", err)
 	var herr *HttpError


### PR DESCRIPTION
this brings estuary-shuttle's `/content/add` API up to parity with the primary node's endpoint of the same name, adding support for arbitrary filesystem paths with the `collectionPath` parameter. this required changes in both the shuttle and primary node, and is needed to make uploading with rclone work for both the primary and shuttle upload endpoints

summary of changes:
   - refactored content request/response body types into util/content.go
   - removed []Collection arguments in favor of a single collection w/ a single path (see ContentInCollection)
   - forward along `collectionPath` from the shuttle to the primary node's `/content/create`
   - add handling for `collectionPath` in `/content/create`
   - added support for http shuttle URLs in UploadEndpoints in dev mode

the matching rclone client-side work to support upload endpoints has also landed here for reference:
https://github.com/application-research/rclone/commit/a25e393f7f3ef77e78a94409c7cf87984b9fb780