### PR TITLE
Fix directory CID listing as file

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -40,7 +40,8 @@ import (
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/ipfs/go-merkledag"
+	merkledag "github.com/ipfs/go-merkledag"
+	unixfs "github.com/ipfs/go-unixfs"
 	uio "github.com/ipfs/go-unixfs/io"
 	car "github.com/ipld/go-car"
 	"github.com/labstack/echo/v4"
@@ -4201,8 +4202,37 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 			return err
 		}
 
+		// Build a new local DAGService to query for the CID if our ref and see if it's a directory
+		bserv := blockservice.New(s.Node.Blockstore, offline.Exchange(s.Node.Blockstore))
+		dserv := merkledag.NewDAGService(bserv)
+		ctx := c.Request().Context()
+		nd, err := dserv.Get(ctx, r.Cid.CID)
+		if err != nil {
+			return err
+		}
+
 		// if the relative path requires pathing up, its definitely not in this dir
 		if strings.HasPrefix(relp, "..") {
+			continue
+		}
+
+		// TODO: maybe find a way to reuse s.Node or s.gwayHandler.dserv
+		// Need to transform node into a unixfs node to check if it's dir
+		fsNode, err := unixfs.ExtractFSNode(nd)
+		if err != nil {
+			return err
+		}
+		if fsNode.IsDir() { // if CID is a dir
+			if !dirs[relp] {
+				dirs[relp] = true
+				out = append(out, collectionListResponse{
+					Name:   relp,
+					Dir:    true,
+					Size:   r.Size,
+					ContID: r.ContID,
+					Cid:    &r.Cid,
+				})
+			}
 			continue
 		}
 
@@ -4217,7 +4247,7 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 			continue
 		}
 
-		parts := strings.Split(relp, "/")
+		parts := strings.Split(relp, "/") // if it is a subcollection
 		if !dirs[parts[0]] {
 			dirs[parts[0]] = true
 			out = append(out, collectionListResponse{

--- a/handlers.go
+++ b/handlers.go
@@ -4148,9 +4148,17 @@ type collectionListQueryRes struct {
 	Path   *string
 }
 
+type CidType string
+
+const (
+	Raw  CidType = "raw"
+	File         = "file"
+	Dir          = "directory"
+)
+
 type collectionListResponse struct {
 	Name   string      `json:"name"`
-	Dir    bool        `json:"dir"`
+	Type   CidType     `json:"type"`
 	Size   int64       `json:"size"`
 	ContID uint        `json:"contId"`
 	Cid    *util.DbCID `json:"cid,omitempty"`
@@ -4219,15 +4227,23 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 		// TODO: maybe find a way to reuse s.Node or s.gwayHandler.dserv
 		// Need to transform node into a unixfs node to check if it's dir
 		fsNode, err := unixfs.ExtractFSNode(nd)
-		if err != nil {
-			return err
+		if err != nil { // Can't cast to unixfs node, set type as raw
+			out = append(out, collectionListResponse{
+				Name:   filepath.Base(relp),
+				Type:   Raw,
+				Size:   r.Size,
+				ContID: r.ContID,
+				Cid:    &r.Cid,
+			})
+			continue
 		}
+
 		if fsNode.IsDir() { // if CID is a dir
 			if !dirs[relp] {
 				dirs[relp] = true
 				out = append(out, collectionListResponse{
 					Name:   relp,
-					Dir:    true,
+					Type:   Dir,
 					Size:   r.Size,
 					ContID: r.ContID,
 					Cid:    &r.Cid,
@@ -4239,7 +4255,7 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 		if !strings.Contains(relp, "/") {
 			out = append(out, collectionListResponse{
 				Name:   filepath.Base(relp),
-				Dir:    false,
+				Type:   File,
 				Size:   r.Size,
 				ContID: r.ContID,
 				Cid:    &r.Cid,
@@ -4252,7 +4268,7 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 			dirs[parts[0]] = true
 			out = append(out, collectionListResponse{
 				Name: parts[0],
-				Dir:  true,
+				Type: Dir,
 			})
 			continue
 		}


### PR DESCRIPTION
As explained [here](https://gist.github.com/marshall/e7b7201400f1339dd51e904d579b46ad), when listing the contents of a collection using `http://localhost:3004/collections/fs/list?col=my-collection-uuid&dir=/`, we found that all CIDs of directories that were added through `/content/add-ipfs` were showing as files instead of directories. This PR fixes that behavior, however it still does not support listing the contents of those directories as of now.

### Reproducing
I wrote [a small PoC for this](https://gist.github.com/gmelodie/3027b9297b53ebbe2ffd7f9d703f2d86). Here's how to use it:
1. Setup `./estuary`, `estuary-shuttle` and your `ipfs daemon` (obs: not sure if the shuttle is necessary but good measure)
2. Create a collection and save its UUID (you can use the `/collections/create` endpoint for that
```bash
curl -X POST http://localhost:3004/collections/create -d '{ "name": "A collection name here", "description": "A collection test" }' -H "Content-Type: application/json" -H "Authorization: Bearer MY-API-KEY-HERE"
```
3. Edit the PoC script to add your new collection's UUID to it.
4. Run the PoC
```bash
./pin-dir-est.sh
```

### Fixed
Before:
```bash
> curl -X GET -H "Authorization: Bearer $APIKEY" "http://localhost:3004/collections/fs/list?col=cadf85f5-af32-41ec-8373-6de3fd54c0c4&dir=/" 2>/dev/null | 
[
  {
    "name": "testdir",
    "dir": false,
    "size": 676,
    "contId": 14,
    "cid": "QmcKmsYCWgvx1ypqgpo88NqSt4Xw93RXATshzspXd4mTZi"
  }

```
Now (fixed):
```bash
> curl -X GET -H "Authorization: Bearer $APIKEY" "http://localhost:3004/collections/fs/list?col=cadf85f5-af32-41ec-8373-6de3fd54c0c4&dir=/" 2>/dev/null | jq     
[
  {
    "name": "testdir",
    "dir": true,
    "size": 676,
    "contId": 12,
    "cid": "QmcKmsYCWgvx1ypqgpo88NqSt4Xw93RXATshzspXd4mTZi"
  }
]
```