### PR TITLE
Fix collection/filename/directory inconsistencies

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -497,7 +497,7 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 		// default: colp ends in / (does not include filename e.g. /hello/)
 		pathWithFilename := colp + filename
 
-		// if path is does not end in /, it includes the filename
+		// if path does not end in /, it includes the filename
 		if !strings.HasSuffix(colp, "/") {
 			pathWithFilename = colp
 			filename = filepath.Base(colp)
@@ -4746,7 +4746,7 @@ func sanitizePath(p string) (string, error) {
 	}
 
 	if p[0] != '/' {
-		return "", fmt.Errorf("all paths must be absolute")
+		return "", fmt.Errorf("paths must start with /")
 	}
 
 	// TODO: prevent use of special weird characters

--- a/handlers.go
+++ b/handlers.go
@@ -4586,11 +4586,12 @@ func openApiMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 }
 
 type collectionListQueryRes struct {
-	ContID uint
-	Cid    util.DbCID
-	Size   int64
-	Path   *string
-	Type   util.ContentType
+	ContID   uint
+	Cid      util.DbCID
+	Size     int64
+	Path     *string
+	Type     util.ContentType
+	Filename *string
 }
 
 type CidType string
@@ -4644,7 +4645,7 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 	if err := s.DB.Model(CollectionRef{}).
 		Joins("left join contents on contents.id = collection_refs.content").
 		Where("collection = ?", col.ID).
-		Select("contents.id as cont_id, contents.cid as cid, path, size, contents.type").
+		Select("contents.id as cont_id, contents.cid as cid, contents.name as filename, path, size, contents.type").
 		Scan(&refs).Error; err != nil {
 		return err
 	}
@@ -4706,7 +4707,7 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 				contentType = Dir
 			}
 			out = append(out, collectionListResponse{
-				Name:   filepath.Base(relp),
+				Name:   *r.Filename,
 				Type:   contentType,
 				Size:   r.Size,
 				ContID: r.ContID,

--- a/handlers.go
+++ b/handlers.go
@@ -471,6 +471,11 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 		return err
 	}
 
+	filename := params.Name
+	if filename == "" {
+		filename = params.Root
+	}
+
 	var cols []*CollectionRef
 	if params.Collection != "" {
 		var srchCol Collection
@@ -488,10 +493,12 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 			}
 			colp = &p
 		}
+		// TODO: path is a dir or is the entire path with file? (if we put / the file is named . when listing)
+		pathWithFilename := *colp + filename
 
 		cols = []*CollectionRef{&CollectionRef{
 			Collection: srchCol.ID,
-			Path:       colp,
+			Path:       &pathWithFilename,
 		}}
 	}
 
@@ -518,11 +525,6 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 		if count > 0 {
 			return c.JSON(302, map[string]string{"message": "content with given cid already preserved"})
 		}
-	}
-
-	filename := params.Name
-	if filename == "" {
-		filename = params.Root
 	}
 
 	pinstatus, err := s.CM.pinContent(ctx, u.ID, rcid, filename, cols, addrInfos, 0, nil)
@@ -4707,6 +4709,7 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 				contentType = Dir
 			}
 			out = append(out, collectionListResponse{
+				// Name:   filepath.Base(relp),
 				Name:   *r.Filename,
 				Type:   contentType,
 				Size:   r.Size,
@@ -4741,7 +4744,7 @@ func sanitizePath(p string) (string, error) {
 
 	// TODO: prevent use of special weird characters
 
-	return filepath.Clean(p), nil
+	return filepath.Clean(p) + "/", nil
 }
 
 // handleColfsAdd godoc


### PR DESCRIPTION
I found some bugs while poking around `add-ipfs` and, since they were pretty similar and related, decided to make the fixes in a single PR.

**Edit:** 1, 2 and 4 are now present on #103

~1. Estuary crashes when providing `"collectionPath": ""` in `/add-ipfs`(on `sanitizePath`, in `handlers.go`)~

~2. When `collectionPath` is `nil`, the file becomes unseeable from `/content/fs/list`. It's on the database, but since querying will always take a path (even when you don't provide any it'll default to `/`), it will never show our file.~

3. file in root `/` showing as `.` (using relative path to get filename, now using filename from field `name` of table `contents`)

~4. adding two CIDs on the same directory will make listing show the same CID for both array elements (the one from the newer CID). Fixed with `&util.DbCID{r.Cid.CID}`.~

5. Files with the same path appear overwritten when listing. `collection_refs` should be `path` + `/` + `filename`, not something else.
