### PR TITLE
Fix ipfs-add endpoint bugs

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -429,7 +429,7 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 		defaultPath := "/" + params.Name
 		colp := &defaultPath
 		if params.CollectionPath != "" {
-			p, err := sanitizePath(*params.CollectionPath)
+			p, err := sanitizePath(params.CollectionPath)
 			if err != nil {
 				return err
 			}
@@ -4214,7 +4214,7 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 				Dir:    false,
 				Size:   r.Size,
 				ContID: r.ContID,
-				Cid:    &r.Cid,
+				Cid:    &util.DbCID{r.Cid.CID},
 			})
 			continue
 		}

--- a/handlers.go
+++ b/handlers.go
@@ -427,7 +427,7 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 
 		var colp *string
 		if params.CollectionPath != "" {
-			p, err := sanitizePath(params.CollectionPath)
+			p, err := sanitizePath(*params.CollectionPath)
 			if err != nil {
 				return err
 			}
@@ -4232,6 +4232,10 @@ func (s *Server) handleColfsListDir(c echo.Context, u *User) error {
 }
 
 func sanitizePath(p string) (string, error) {
+	if len(p) == 0 {
+		return "", fmt.Errorf("can't sanitize empty path")
+	}
+
 	if p[0] != '/' {
 		return "", fmt.Errorf("all paths must be absolute")
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -425,7 +425,9 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 			return err
 		}
 
-		var colp *string
+		// if collectionPath is "" or nil, put the file on the root dir (/filename)
+		defaultPath := "/" + params.Name
+		colp := &defaultPath
 		if params.CollectionPath != "" {
 			p, err := sanitizePath(*params.CollectionPath)
 			if err != nil {


### PR DESCRIPTION
This PR contains changes from #101  that are "harmless" (aka don't change API behavior, and are backwards compatible). As discussed with @marshall 

1. Estuary crashes when providing `"collectionPath": ""` in `/add-ipfs` (on `sanitizePath`, in `handlers.go`)

2. When `collectionPath` is `nil`, the file becomes unseeable from `/content/fs/list`. It's on the database, but since querying will always take a path (even when you don't provide any it'll default to `/`), it will never show our file. Now it defaults to `/my-filename`.

3. Adding two CIDs on the same directory will make listing show the same CID for both array elements (the one from the newer CID). Fixed with `&util.DbCID{r.Cid.CID}`.

Obs: don't quote me on the "harmless" thing about my code... ever