### PR TITLE
Add CID directory database tracking (disallow listings)

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1184,11 +1184,16 @@ func (s *Shuttle) addrsForShuttle() []string {
 }
 
 func (s *Shuttle) createContent(ctx context.Context, u *User, root cid.Cid, fname string, cic util.ContentInCollection) (uint, error) {
+	bserv := blockservice.New(s.Node.Blockstore, s.Node.Bitswap)
+	dserv := merkledag.NewDAGService(bserv)
+	contentType := util.FindCIDType(root, dserv)
+
 	data, err := json.Marshal(util.ContentCreateBody{
 		ContentInCollection: cic,
 		Root:                root,
 		Name:                fname,
 		Location:            s.shuttleHandle,
+		Type:                contentType,
 	})
 	if err != nil {
 		return 0, err

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1186,7 +1186,7 @@ func (s *Shuttle) addrsForShuttle() []string {
 func (s *Shuttle) createContent(ctx context.Context, u *User, root cid.Cid, fname string, cic util.ContentInCollection) (uint, error) {
 	bserv := blockservice.New(s.Node.Blockstore, s.Node.Bitswap)
 	dserv := merkledag.NewDAGService(bserv)
-	contentType := util.FindCIDType(root, dserv)
+	contentType := util.FindCIDType(ctx, root, dserv)
 
 	data, err := json.Marshal(util.ContentCreateBody{
 		ContentInCollection: cic,

--- a/dbmgr/dbmgr.go
+++ b/dbmgr/dbmgr.go
@@ -341,6 +341,7 @@ type Content struct {
 	UserID      UserID
 	Description string
 	Size        int64
+	Type        util.ContentType
 	Active      bool
 	Offloaded   bool
 	Replication int

--- a/main.go
+++ b/main.go
@@ -65,14 +65,15 @@ type Content struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 
-	Cid         util.DbCID `json:"cid"`
-	Name        string     `json:"name"`
-	UserID      uint       `json:"userId" gorm:"index"`
-	Description string     `json:"description"`
-	Size        int64      `json:"size"`
-	Active      bool       `json:"active"`
-	Offloaded   bool       `json:"offloaded"`
-	Replication int        `json:"replication"`
+	Cid         util.DbCID       `json:"cid"`
+	Name        string           `json:"name"`
+	UserID      uint             `json:"userId" gorm:"index"`
+	Description string           `json:"description"`
+	Size        int64            `json:"size"`
+	Type        util.ContentType `json:"type"`
+	Active      bool             `json:"active"`
+	Offloaded   bool             `json:"offloaded"`
+	Replication int              `json:"replication"`
 
 	// TODO: shift most of the 'state' booleans in here into a single state
 	// field, should make reasoning about things much simpler

--- a/pinning.go
+++ b/pinning.go
@@ -858,7 +858,7 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 		})
 	}
 
-	if err := cm.addObjectsToDatabase(ctx, pincomp.DBID, objects, handle); err != nil {
+	if err := cm.addObjectsToDatabase(ctx, pincomp.DBID, nil, cid.Cid{}, objects, handle); err != nil {
 		return xerrors.Errorf("failed to add objects to database: %w", err)
 	}
 

--- a/util/content.go
+++ b/util/content.go
@@ -1,7 +1,18 @@
 package util
 
 import (
+	"context"
+
 	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+type ContentType int64
+
+const (
+	Unknown ContentType = iota
+	File
+	Directory
 )
 
 type ContentInCollection struct {
@@ -26,11 +37,36 @@ type ContentAddResponse struct {
 type ContentCreateBody struct {
 	ContentInCollection
 
-	Root     cid.Cid `json:"root"`
-	Name     string  `json:"name"`
-	Location string  `json:"location"`
+	Root     cid.Cid     `json:"root"`
+	Name     string      `json:"name"`
+	Location string      `json:"location"`
+	Type     ContentType `json:"type"`
 }
 
 type ContentCreateResponse struct {
 	ID uint `json:"id"`
+}
+
+// FindCIDType checks if a pinned CID (root) is a file, a dir or unknown
+// Returns dbmgr.File or dbmgr.Directory on success
+// Returns dbmgr.Unknown otherwise
+func FindCIDType(root cid.Cid, dserv ipld.NodeGetter) ContentType {
+	contentType := Unknown
+	nilCID := cid.Cid{}
+	ctx := context.Background()
+
+	if root != nilCID && dserv != nil {
+		nd, err := dserv.Get(ctx, root)
+		if err == nil {
+			fsNode, err := TryExtractFSNode(nd)
+			if err == nil {
+				contentType = File
+				if fsNode.IsDir() {
+					contentType = Directory
+				}
+			}
+		}
+	}
+
+	return contentType
 }

--- a/util/unixfs.go
+++ b/util/unixfs.go
@@ -1,12 +1,15 @@
 package util
 
 import (
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/ipfs/go-cidutil"
 	chunker "github.com/ipfs/go-ipfs-chunker"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
+	unixfs "github.com/ipfs/go-unixfs"
 	"github.com/ipfs/go-unixfs/importer/balanced"
 	ihelper "github.com/ipfs/go-unixfs/importer/helpers"
 	mh "github.com/multiformats/go-multihash"
@@ -40,4 +43,22 @@ func ImportFile(dserv ipld.DAGService, fi io.Reader) (ipld.Node, error) {
 	}
 
 	return balanced.Layout(db)
+}
+
+func TryExtractFSNode(nd ipld.Node) (*unixfs.FSNode, error) {
+	switch nd := nd.(type) {
+	case *merkledag.ProtoNode:
+		n, err := unixfs.FSNodeFromBytes(nd.Data())
+		if err != nil {
+			return nil, err
+		}
+		if n.Type() == unixfs.TSymlink {
+			return nil, fmt.Errorf("symlinks not supported")
+		}
+		return n, nil // success!
+	case *merkledag.RawNode:
+	default:
+		return nil, errors.New("unknown node type")
+	}
+	return nil, errors.New("unknown node type")
 }


### PR DESCRIPTION
This PR addresses the issues raised [here](https://application-research.canny.io/estuary-bugs/p/support-pinned-ipfs-dirs-in-collectionsfslist). 
1. We now hold on the database (under the `contents` table) whether a pinned CID is a dir or a file, and show that when listing the contents of a collection (on `handleColfsListDir`). 
2. We also disallow listing directories added by CID (what we're calling "CID dirs") since the files under the root CID might not be on the same machine as the Estuary main node (aka on the shuttles) and listing them might be too expensive. 

**Obs:** we also thought about expanding the directory as it is pinned, but keeping metadata about all the files under a CID recursively on the database might not be feasible in terms of computational power.