### PR TITLE
Refactor shuttle-related structs into util/shuttle.go

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1227,22 +1227,13 @@ func (s *Shuttle) createContent(ctx context.Context, u *User, root cid.Cid, fnam
 	return rbody.ID, nil
 }
 
-type shuttleCreateContentBody struct {
-	Root         cid.Cid  `json:"root"`
-	Name         string   `json:"name"`
-	Collections  []string `json:"collections"`
-	Location     string   `json:"location"`
-	DagSplitRoot uint     `json:"dagSplitRoot"`
-	User         uint     `json:"user"`
-}
-
 func (s *Shuttle) shuttleCreateContent(ctx context.Context, uid uint, root cid.Cid, fname, collection string, dagsplitroot uint) (uint, error) {
 	var cols []string
 	if collection != "" {
 		cols = []string{collection}
 	}
 
-	data, err := json.Marshal(&shuttleCreateContentBody{
+	data, err := json.Marshal(&util.ShuttleCreateContentBody{
 		Root:         root,
 		Name:         fname,
 		Collections:  cols,

--- a/handlers.go
+++ b/handlers.go
@@ -3465,11 +3465,6 @@ func (s *Server) handleContentHealthCheckByCid(c echo.Context) error {
 	})
 }
 
-type initShuttleResponse struct {
-	Handle string `json:"handle"`
-	Token  string `json:"token"`
-}
-
 func (s *Server) handleShuttleInit(c echo.Context) error {
 	shuttle := &Shuttle{
 		Handle: "SHUTTLE" + uuid.New().String() + "HANDLE",
@@ -3480,22 +3475,10 @@ func (s *Server) handleShuttleInit(c echo.Context) error {
 		return err
 	}
 
-	return c.JSON(200, &initShuttleResponse{
+	return c.JSON(200, &util.InitShuttleResponse{
 		Handle: shuttle.Handle,
 		Token:  shuttle.Token,
 	})
-}
-
-type shuttleListResponse struct {
-	Handle         string          `json:"handle"`
-	Token          string          `json:"token"`
-	Online         bool            `json:"online"`
-	LastConnection time.Time       `json:"lastConnection"`
-	AddrInfo       *peer.AddrInfo  `json:"addrInfo"`
-	Address        address.Address `json:"address"`
-	Hostname       string          `json:"hostname"`
-
-	StorageStats *shuttleStorageStats `json:"storageStats"`
 }
 
 func (s *Server) handleShuttleList(c echo.Context) error {
@@ -3504,9 +3487,9 @@ func (s *Server) handleShuttleList(c echo.Context) error {
 		return err
 	}
 
-	var out []shuttleListResponse
+	var out []util.ShuttleListResponse
 	for _, d := range shuttles {
-		out = append(out, shuttleListResponse{
+		out = append(out, util.ShuttleListResponse{
 			Handle:         d.Handle,
 			Token:          d.Token,
 			LastConnection: d.LastConnection,
@@ -4015,17 +3998,8 @@ func (s *Server) handleGetRetrievalCandidates(c echo.Context) error {
 	return c.JSON(http.StatusOK, candidates)
 }
 
-type shuttleCreateContentBody struct {
-	Root         cid.Cid  `json:"root"`
-	Name         string   `json:"name"`
-	Collections  []string `json:"collections"`
-	Location     string   `json:"location"`
-	DagSplitRoot uint     `json:"dagSplitRoot"`
-	User         uint     `json:"user"`
-}
-
 func (s *Server) handleShuttleCreateContent(c echo.Context) error {
-	var req shuttleCreateContentBody
+	var req util.ShuttleCreateContentBody
 	if err := c.Bind(&req); err != nil {
 		return err
 	}

--- a/shuttle.go
+++ b/shuttle.go
@@ -36,7 +36,7 @@ type Shuttle struct {
 	Priority int
 }
 
-type shuttleConnection struct {
+type ShuttleConnection struct {
 	handle  string
 	cmds    chan *drpc.Command
 	closing chan struct{}
@@ -54,7 +54,7 @@ type shuttleConnection struct {
 	pinQueueLength int64
 }
 
-func (dc *shuttleConnection) sendMessage(ctx context.Context, cmd *drpc.Command) error {
+func (dc *ShuttleConnection) sendMessage(ctx context.Context, cmd *drpc.Command) error {
 	select {
 	case dc.cmds <- cmd:
 		return nil
@@ -89,7 +89,7 @@ func (cm *ContentManager) registerShuttleConnection(handle string, hello *drpc.H
 		return nil, nil, err
 	}
 
-	d := &shuttleConnection{
+	d := &ShuttleConnection{
 		handle:   handle,
 		address:  hello.Address,
 		addrInfo: hello.AddrInfo,
@@ -266,14 +266,7 @@ func (cm *ContentManager) shuttleHostName(handle string) string {
 	return ""
 }
 
-type shuttleStorageStats struct {
-	BlockstoreSize uint64 `json:"blockstoreSize"`
-	BlockstoreFree uint64 `json:"blockstoreFree"`
-	PinCount       int64  `json:"pinCount"`
-	PinQueueLength int64  `json:"pinQueueLength"`
-}
-
-func (cm *ContentManager) shuttleStorageStats(handle string) *shuttleStorageStats {
+func (cm *ContentManager) shuttleStorageStats(handle string) *util.ShuttleStorageStats {
 	cm.shuttlesLk.Lock()
 	defer cm.shuttlesLk.Unlock()
 	d, ok := cm.shuttles[handle]
@@ -281,7 +274,7 @@ func (cm *ContentManager) shuttleStorageStats(handle string) *shuttleStorageStat
 		return nil
 	}
 
-	return &shuttleStorageStats{
+	return &util.ShuttleStorageStats{
 		BlockstoreSize: d.blockstoreSize,
 		BlockstoreFree: d.blockstoreFree,
 		PinCount:       d.pinCount,

--- a/util/retrieval.go
+++ b/util/retrieval.go
@@ -10,3 +10,8 @@ type RetrievalFailureRecord struct {
 	Content uint   `json:"content"`
 	Cid     DbCID  `json:"cid"`
 }
+
+type RetrievalProgress struct {
+	Wait   chan struct{}
+	EndErr error
+}

--- a/util/shuttle.go
+++ b/util/shuttle.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"sync"
+	"time"
+
+	"github.com/application-research/estuary/drpc"
+	"github.com/application-research/estuary/node"
+	"github.com/application-research/estuary/pinner"
+	"github.com/application-research/estuary/stagingbs"
+	"github.com/application-research/estuary/util/gateway"
+	"github.com/application-research/filclient"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/whyrusleeping/memo"
+	"go.opencensus.io/trace"
+	"gorm.io/gorm"
+)
+
+type InitShuttleResponse struct {
+	Handle string `json:"handle"`
+	Token  string `json:"token"`
+}
+
+type ShuttleStorageStats struct {
+	BlockstoreSize uint64 `json:"blockstoreSize"`
+	BlockstoreFree uint64 `json:"blockstoreFree"`
+	PinCount       int64  `json:"pinCount"`
+	PinQueueLength int64  `json:"pinQueueLength"`
+}
+
+type ShuttleListResponse struct {
+	Handle         string          `json:"handle"`
+	Token          string          `json:"token"`
+	Online         bool            `json:"online"`
+	LastConnection time.Time       `json:"lastConnection"`
+	AddrInfo       *peer.AddrInfo  `json:"addrInfo"`
+	Address        address.Address `json:"address"`
+	Hostname       string          `json:"hostname"`
+
+	StorageStats *ShuttleStorageStats `json:"storageStats"`
+}
+
+type ShuttleCreateContentBody struct {
+	Root         cid.Cid  `json:"root"`
+	Name         string   `json:"name"`
+	Collections  []string `json:"collections"`
+	Location     string   `json:"location"`
+	DagSplitRoot uint     `json:"dagSplitRoot"`
+	User         uint     `json:"user"`
+}
+
+type Shuttle struct {
+	Node       *node.Node
+	Api        api.Gateway
+	DB         *gorm.DB
+	PinMgr     *pinner.PinManager
+	Filc       *filclient.FilClient
+	StagingMgr *stagingbs.StagingBSMgr
+
+	GwayHandler *gateway.GatewayHandler
+
+	Tracer trace.Tracer
+
+	TcLk             sync.Mutex
+	TrackingChannels map[string]*ChanTrack
+
+	SplitLk          sync.Mutex
+	SplitsInProgress map[uint]bool
+
+	AddPinLk sync.Mutex
+
+	Outgoing chan *drpc.Message
+
+	Private            bool
+	DisableLocalAdding bool
+	Dev                bool
+
+	Hostname      string
+	EstuaryHost   string
+	ShuttleHandle string
+	ShuttleToken  string
+
+	CommpMemo *memo.Memoizer
+
+	AuthCache *lru.TwoQueueCache
+
+	RetrLk               sync.Mutex
+	RetrievalsInProgress map[uint]*RetrievalProgress
+
+	InflightCids   map[cid.Cid]uint
+	InflightCidsLk sync.Mutex
+}
+
+type ChanTrack struct {
+	Dbid uint
+	Last *filclient.ChannelState
+}


### PR DESCRIPTION
Following the great example of @marshall in #99 I removed a bunch of structs related to shuttles that were scattered around and put them in `util/shuttle.go` and `util/retrieval.go`.