### PR TITLE
Add autoretrieve init (create token) endpoint

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -282,6 +282,9 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 	shuttle.POST("/init", s.handleShuttleInit)
 	shuttle.GET("/list", s.handleShuttleList)
 
+	autoretrieve := admin.Group("/autoretrieve")
+	autoretrieve.POST("/init", s.handleAutoretrieveInit)
+
 	e.GET("/shuttle/conn", s.handleShuttleConnection)
 	e.POST("/shuttle/content/create", s.handleShuttleCreateContent, s.withShuttleAuth())
 
@@ -3584,6 +3587,26 @@ func (s *Server) handleShuttleConnection(c echo.Context) error {
 		}
 	}).ServeHTTP(c.Response(), c.Request())
 	return nil
+}
+
+type initAutoretrieveResponse struct {
+	Handle string `json:"handle"`
+	Token  string `json:"token"`
+}
+
+func (s *Server) handleAutoretrieveInit(c echo.Context) error {
+	autoretrieve := &Autoretrieve{
+		Handle: "AUTORETRIEVE" + uuid.New().String() + "HANDLE",
+		Token:  "SECRET" + uuid.New().String() + "SECRET",
+	}
+	if err := s.DB.Create(autoretrieve).Error; err != nil {
+		return err
+	}
+
+	return c.JSON(200, &initAutoretrieveResponse{
+		Handle: autoretrieve.Handle,
+		Token:  autoretrieve.Token,
+	})
 }
 
 type allDealsQuery struct {

--- a/handlers.go
+++ b/handlers.go
@@ -284,6 +284,7 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 
 	autoretrieve := admin.Group("/autoretrieve")
 	autoretrieve.POST("/init", s.handleAutoretrieveInit)
+	autoretrieve.POST("/list", s.handleAutoretrieveList)
 
 	e.GET("/shuttle/conn", s.handleShuttleConnection)
 	e.POST("/shuttle/content/create", s.handleShuttleCreateContent, s.withShuttleAuth())
@@ -3607,6 +3608,35 @@ func (s *Server) handleAutoretrieveInit(c echo.Context) error {
 		Handle: autoretrieve.Handle,
 		Token:  autoretrieve.Token,
 	})
+}
+
+type autoretrieveListResponse struct {
+	Handle string `json:"handle"`
+	Token  string `json:"token"`
+	// Online         bool            `json:"online"`
+	// LastConnection time.Time       `json:"lastConnection"`
+	// AddrInfo       *peer.AddrInfo  `json:"addrInfo"`
+	// Address        address.Address `json:"address"`
+	// Hostname       string          `json:"hostname"`
+
+	// StorageStats *shuttleStorageStats `json:"storageStats"`
+}
+
+func (s *Server) handleAutoretrieveList(c echo.Context) error {
+	var autoretrieves []Autoretrieve
+	if err := s.DB.Find(&autoretrieves).Error; err != nil {
+		return err
+	}
+
+	var out []autoretrieveListResponse
+	for _, a := range autoretrieves {
+		out = append(out, autoretrieveListResponse{
+			Handle: a.Handle,
+			Token:  a.Token,
+		})
+	}
+
+	return c.JSON(200, out)
 }
 
 type allDealsQuery struct {

--- a/main.go
+++ b/main.go
@@ -487,6 +487,13 @@ func main() {
 	}
 }
 
+type Autoretrieve struct {
+	gorm.Model
+
+	Handle string `gorm:"unique"`
+	Token  string `gorm:"unique"`
+}
+
 func setupDatabase(cctx *cli.Context) (*gorm.DB, error) {
 	dbval := cctx.String("database")
 
@@ -523,6 +530,8 @@ func setupDatabase(cctx *cli.Context) (*gorm.DB, error) {
 	db.AutoMigrate(&InviteCode{})
 
 	db.AutoMigrate(&Shuttle{})
+
+	db.AutoMigrate(&Autoretrieve{})
 
 	// 'manually' add unique composite index on collection fields because gorms syntax for it is tricky
 	if err := db.Exec("create unique index if not exists collection_refs_paths on collection_refs (path,collection)").Error; err != nil {


### PR DESCRIPTION
This will enable us to register autoretrieve servers just as we register shuttles. In fact, pretty much all the code is a copy of what we do on shuttles for the time being.