### PR TITLE
Autoretrieve index updater job

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func (s *Server) updateAutoretrieveIndex(tickInterval time.Duration, quit chan s
 					fmt.Println("online: ", ar) // TODO: remove
 				}
 			} else {
-				fmt.Println("no autoretrieve servers online")
+				log.Info("no autoretrieve servers online")
 			}
 		case <-quit:
 			ticker.Stop()
@@ -507,10 +507,11 @@ func main() {
 
 		// start autoretrieve index updater task every INDEX_UPDATE_INTERVAL minutes
 
-		if os.Getenv("INDEX_UPDATE_INTERVAL") == "" {
-			os.Setenv("INDEX_UPDATE_INTERVAL", "720")
+		updateInterval, ok := os.LookupEnv("INDEX_UPDATE_INTERVAL")
+		if !ok {
+			updateInterval = "720"
 		}
-		intervalMinutes, err := strconv.Atoi(os.Getenv("INDEX_UPDATE_INTERVAL"))
+		intervalMinutes, err := strconv.Atoi(updateInterval)
 		if err != nil {
 			return err
 		}
@@ -540,6 +541,8 @@ type Autoretrieve struct {
 	Handle         string `gorm:"unique"`
 	Token          string `gorm:"unique"`
 	LastConnection time.Time
+	PeerID         string `gorm:"unique"`
+	Addresses      string
 }
 
 func setupDatabase(cctx *cli.Context) (*gorm.DB, error) {

--- a/util/retrieval.go
+++ b/util/retrieval.go
@@ -1,8 +1,12 @@
 package util
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
 	"gorm.io/gorm"
 )
 
@@ -21,23 +25,61 @@ type RetrievalProgress struct {
 }
 
 type HeartbeatAutoretrieveResponse struct {
-	Handle         string    `json:"handle"`
-	LastConnection time.Time `json:"lastConnection"`
+	Handle         string         `json:"handle"`
+	LastConnection time.Time      `json:"lastConnection"`
+	AddrInfo       *peer.AddrInfo `json:"addrInfo"`
 }
 
 type AutoretrieveListResponse struct {
-	Handle string `json:"handle"`
-	Token  string `json:"token"`
-	// Online         bool            `json:"online"`
-	LastConnection time.Time `json:"lastConnection"`
-	// AddrInfo       *peer.AddrInfo  `json:"addrInfo"`
-	// Address        address.Address `json:"address"`
-	// Hostname       string          `json:"hostname"`
-
+	Handle         string         `json:"handle"`
+	LastConnection time.Time      `json:"lastConnection"`
+	AddrInfo       *peer.AddrInfo `json:"addrInfo"`
 }
 
-type InitAutoretrieveResponse struct {
-	Handle         string    `json:"handle"`
-	Token          string    `json:"token"`
-	LastConnection time.Time `json:"lastConnection"`
+type AutoretrieveInitResponse struct {
+	Handle         string         `json:"handle"`
+	Token          string         `json:"token"`
+	LastConnection time.Time      `json:"lastConnection"`
+	AddrInfo       *peer.AddrInfo `json:"addrInfo"`
+}
+
+// ValidateAddresses checks to see if all multiaddresses are valid
+// returns empty []string if all multiaddresses are valid strings
+// returns a list of all invalid multiaddresses if any is invalid
+func validateAddresses(addresses []string) []string {
+	var invalidAddresses []string
+	for _, addr := range addresses {
+		_, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			invalidAddresses = append(invalidAddresses, addr)
+		}
+	}
+	return invalidAddresses
+}
+
+func ValidatePeerInfo(peerID string, addresses []string) (*peer.AddrInfo, error) {
+	// check if peerid format is correct
+	_, err := peer.IDFromString(peerID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid peerID")
+	}
+
+	if len(addresses) == 0 || addresses[0] == "" {
+		return nil, fmt.Errorf("no addresses provided")
+	}
+
+	// check if multiaddresses formats are correct
+	invalidAddrs := validateAddresses(addresses)
+	if len(invalidAddrs) != 0 {
+		return nil, fmt.Errorf("invalid address(es): %s", strings.Join(invalidAddrs, ", "))
+	}
+
+	// any of the multiaddresses of the peer should work to get addrInfo
+	// we get the first one
+	addrInfo, err := peer.AddrInfoFromString(addresses[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return addrInfo, nil
 }


### PR DESCRIPTION
This PR adds additional functionality to the `autoretrieve` endpoints. It takes address and peerID data on the `init` API call so it can tell the indexes about the autoretrieve server.

## Larger context
Basically there's this server called [autoretrieve](https://github.com/application-research/autoretrieve) that acts as a compatibility gateway from the last version of IPFS protocol (bitswap) to the newer one  (graphsync). As estuary doesn't support bitswap, we want people to be able to query autoretrieve with bitswap, and then autoretrieve will query estuary using graphsync. To do this, we need to update the indexer nodes (who hold information about where which CID is) to say "all CIDs that are in estuary can be found in the autoretrieve node".
Then the use case becomes: peer asks indexer where CID is > idexer tells autoretrieve has it > peer asks autoretrieve > autoretrieve gets it from estuary using graphsync > autoretrieve serves it to peer using bitswap.
This PR allows autoretrieve servers to tell estuary they're up using the heartbeat endpoint

## Testing
First we run the estuary node with an update interval of 1min (default is 720 or 1h)
```
INDEX_UPDATE_INTERVAL=1 ./estuary --datadir=mystorage --logging
```

Then we start `ipfs daemon` and list its ID information, we'll use its peerID and addresses for testing, but you can skip this step if you already have a valid peerID at hand
```
ipfs daemon
ipfs id
```

Now we can register a new autoretrieve server with our peerID
```
curl -X POST -H "Authorization: Bearer YOUR_API_KEY" "localhost:3004/admin/autoretrieve/init" -d "peerId=YOUR_PEER_ID&addresses=ONE_OR_MORE_ADDRESSES_SEPARATED_BY_COMMA" | jq
```

Finally we can send heartbeats using the `SECRET` we got from the `init` endpoint
```
curl -X POST -H "Authorization: Bearer YOUR_SECRET_KEY" "localhost:3004/autoretrieve/heartbeat" | jq
``` 
**Obs**: ignore the branch name here