### PR TITLE
fix incorrect pin count when filtering

### DIFF
--- a/pinning.go
+++ b/pinning.go
@@ -547,8 +547,11 @@ func (s *Server) handleListPins(e echo.Context, u *User) error {
 		}
 	}
 
+	if len(out) == 0 {
+		out = make([]*types.IpfsPinStatus, 0)
+	}
 	return e.JSON(200, map[string]interface{}{
-		"count":   len(contents),
+		"count":   len(out),
 		"results": out,
 	})
 }


### PR DESCRIPTION
When querying for `/pinning/pins?status=SOMESTATUS` the API was actually listing the count of the original query (before applying the status filter). So for instance if you had 15 pins total but only 2 of them were queued and you requested `/pinning/pins?status=queued` you would get a `count` of 15 instead of 2.

Fixes #124 