### PR TITLE
First step towards forklifting some go-ipfs configuration functionality into estuary

### DIFF
--- a/cmd/estuary-shuttle/init.go
+++ b/cmd/estuary-shuttle/init.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+
+	"github.com/application-research/estuary/config"
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+)
+
+type Initializer struct {
+	cfg *config.Config
+}
+
+func (init Initializer) Config() *config.Config {
+	return init.cfg
+}
+
+func (init Initializer) BlockstoreWrap(blk blockstore.Blockstore) (blockstore.Blockstore, error) {
+	return blk, nil
+}
+
+func (init Initializer) KeyProviderFunc(context.Context) (<-chan cid.Cid, error) {
+	return nil, nil
+}

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -235,6 +235,7 @@ func main() {
 				MaxOutstandingBytesPerPeer: cctx.Int64("bitswap-max-work-per-peer"),
 				TargetMessageSize:          cctx.Int("bitswap-target-message-size"),
 			},
+			NoLimiter: true,
 		}
 
 		init := Initializer{cfg}

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/application-research/estuary/config"
 	estumetrics "github.com/application-research/estuary/metrics"
 	"github.com/application-research/estuary/util/gateway"
 	"github.com/application-research/filclient/retrievehelper"
@@ -219,7 +220,7 @@ func main() {
 			listens = append(listens, "/ip4/0.0.0.0/tcp/6747/ws")
 		}
 
-		cfg := &node.Config{
+		cfg := &config.Config{
 			ListenAddrs:       listens,
 			Blockstore:        bsdir,
 			WriteLog:          wlog,
@@ -230,7 +231,7 @@ func main() {
 			Datastore:         filepath.Join(ddir, "leveldb"),
 			WalletDir:         filepath.Join(ddir, "wallet"),
 			AnnounceAddrs:     cctx.StringSlice("announce-addr"),
-			BitswapConfig: node.BitswapConfig{
+			BitswapConfig: config.BitswapConfig{
 				MaxOutstandingBytesPerPeer: cctx.Int64("bitswap-max-work-per-peer"),
 				TargetMessageSize:          cctx.Int("bitswap-target-message-size"),
 			},

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -237,7 +237,9 @@ func main() {
 			},
 		}
 
-		nd, err := node.Setup(context.TODO(), cfg)
+		init := Initializer{cfg}
+
+		nd, err := node.Setup(context.TODO(), init)
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	HardFlushWriteLog bool
 	WriteLogTruncate  bool
 	NoBlockstoreCache bool
+	NoLimiter         bool
 
 	Libp2pKeyFile string
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,12 +1,5 @@
 package config
 
-import (
-	"context"
-
-	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-)
-
 type Config struct {
 	ListenAddrs   []string
 	AnnounceAddrs []string
@@ -25,10 +18,6 @@ type Config struct {
 	WalletDir string
 
 	BitswapConfig BitswapConfig
-
-	BlockstoreWrap func(blockstore.Blockstore) (blockstore.Blockstore, error)
-
-	KeyProviderFunc func(context.Context) (<-chan cid.Cid, error)
 }
 
 type BitswapConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+)
+
+type Config struct {
+	ListenAddrs   []string
+	AnnounceAddrs []string
+
+	Blockstore string
+
+	WriteLog          string
+	HardFlushWriteLog bool
+	WriteLogTruncate  bool
+	NoBlockstoreCache bool
+
+	Libp2pKeyFile string
+
+	Datastore string
+
+	WalletDir string
+
+	BitswapConfig BitswapConfig
+
+	BlockstoreWrap func(blockstore.Blockstore) (blockstore.Blockstore, error)
+
+	KeyProviderFunc func(context.Context) (<-chan cid.Cid, error)
+}
+
+type BitswapConfig struct {
+	MaxOutstandingBytesPerPeer int64
+	TargetMessageSize          int
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,13 @@
 package config
 
+/*
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+*/
+
 type Config struct {
 	ListenAddrs   []string
 	AnnounceAddrs []string
@@ -23,4 +31,40 @@ type Config struct {
 type BitswapConfig struct {
 	MaxOutstandingBytesPerPeer int64
 	TargetMessageSize          int
+}
+
+func (cfg *Config) load(filename string) error {
+	/*
+		f, err := os.Open(filename)
+		if err != nil {
+			if os.IsNotExist(err) {
+				err = ErrNotInitialized
+			}
+			return err
+		}
+		defer f.Close()
+		if err := json.NewDecoder(f).Decode(cfg); err != nil {
+			return fmt.Errorf("failure to decode config: %s", err)
+		}
+	*/
+	return nil
+}
+
+// WriteConfigFile writes the config from `cfg` into `filename`.
+func WriteConfigFile(filename string, cfg interface{}) error {
+	/*
+		err := os.MkdirAll(filepath.Dir(filename), 0755)
+		if err != nil {
+			return err
+		}
+
+		f, err := atomicfile.New(filename, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		return encode(f, cfg)
+	*/
+	return nil
 }

--- a/init.go
+++ b/init.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+
+	"github.com/application-research/estuary/config"
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"gorm.io/gorm"
+)
+
+type Initializer struct {
+	cfg            *config.Config
+	db             *gorm.DB
+	trackingBstore *TrackingBlockstore
+}
+
+func (init Initializer) Config() *config.Config {
+	return init.cfg
+}
+
+func (init Initializer) BlockstoreWrap(bs blockstore.Blockstore) (blockstore.Blockstore, error) {
+	init.trackingBstore = NewTrackingBlockstore(bs, init.db)
+	return init.trackingBstore, nil
+}
+
+func (init Initializer) KeyProviderFunc(rpctx context.Context) (<-chan cid.Cid, error) {
+	log.Infof("running key provider func")
+	out := make(chan cid.Cid)
+	go func() {
+		defer close(out)
+
+		var contents []Content
+		if err := init.db.Find(&contents, "active").Error; err != nil {
+			log.Errorf("failed to load contents for reproviding: %s", err)
+			return
+		}
+		log.Infof("key provider func returning %d values", len(contents))
+
+		for _, c := range contents {
+			select {
+			case out <- c.Cid.CID:
+			case <-rpctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}

--- a/init.go
+++ b/init.go
@@ -15,16 +15,16 @@ type Initializer struct {
 	trackingBstore *TrackingBlockstore
 }
 
-func (init Initializer) Config() *config.Config {
+func (init *Initializer) Config() *config.Config {
 	return init.cfg
 }
 
-func (init Initializer) BlockstoreWrap(bs blockstore.Blockstore) (blockstore.Blockstore, error) {
+func (init *Initializer) BlockstoreWrap(bs blockstore.Blockstore) (blockstore.Blockstore, error) {
 	init.trackingBstore = NewTrackingBlockstore(bs, init.db)
 	return init.trackingBstore, nil
 }
 
-func (init Initializer) KeyProviderFunc(rpctx context.Context) (<-chan cid.Cid, error) {
+func (init *Initializer) KeyProviderFunc(rpctx context.Context) (<-chan cid.Cid, error) {
 	log.Infof("running key provider func")
 	out := make(chan cid.Cid)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -307,7 +307,7 @@ func main() {
 
 		init := Initializer{cfg, db, nil}
 
-		nd, err := node.Setup(context.Background(), init)
+		nd, err := node.Setup(context.Background(), &init)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -288,6 +288,7 @@ func main() {
 			Datastore:        filepath.Join(ddir, "estuary-leveldb"),
 			WalletDir:        filepath.Join(ddir, "estuary-wallet"),
 			WriteLogTruncate: cctx.Bool("write-log-truncate"),
+			NoLimiter:        true,
 		}
 
 		if wl := cctx.String("write-log"); wl != "" {

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"go.opencensus.io/stats/view"
 
 	"github.com/application-research/estuary/build"
+	"github.com/application-research/estuary/config"
 	drpc "github.com/application-research/estuary/drpc"
 	"github.com/application-research/estuary/metrics"
 	"github.com/application-research/estuary/node"
@@ -279,7 +280,7 @@ func main() {
 		if bs := cctx.String("blockstore"); bs != "" {
 			bstore = bs
 		}
-		cfg := &node.Config{
+		cfg := &config.Config{
 			ListenAddrs: []string{
 				"/ip4/0.0.0.0/tcp/6744",
 			},

--- a/node/node.go
+++ b/node/node.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/application-research/estuary/config"
+	rcmgr "github.com/application-research/estuary/node/modules/lp2p"
 	migratebs "github.com/application-research/estuary/util/migratebs"
 	"github.com/application-research/filclient/keystore"
 	autobatch "github.com/application-research/go-bs-autobatch"
@@ -34,7 +35,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	metrics "github.com/libp2p/go-libp2p-core/metrics"
-	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
@@ -126,20 +126,18 @@ func Setup(ctx context.Context, init NodeInitializer) (*Node, error) {
 		return nil, err
 	}
 
-	/*
-		lim := rcmgr.NewDefaultLimiter()
-		lim.SystemLimits = lim.SystemLimits.WithFDLimit(8192).WithConnLimit(16<<10, 32<<10, 32<<10).WithStreamLimit(64<<10, 128<<10, 256<<10).WithMemoryLimit(0.2, 1<<30, 10<<30)
-		lim.TransientLimits = lim.TransientLimits.WithConnLimit(1024, 2048, 2048).WithFDLimit(1024).WithStreamLimit(2<<10, 4<<10, 4<<10)
-		rcm, err := rcmgr.NewResourceManager(lim)
+	lim := rcmgr.NewDefaultLimiter()
+	lim.SystemLimits = lim.SystemLimits.WithFDLimit(8192).WithConnLimit(256, 256, 1024).WithStreamLimit(64<<10, 128<<10, 256<<10).WithMemoryLimit(0.2, 1<<30, 10<<30)
+	lim.TransientLimits = lim.TransientLimits.WithConnLimit(256, 256, 512).WithFDLimit(1024).WithStreamLimit(2<<10, 4<<10, 4<<10)
+	rcm, err := rcmgr.NewResourceManager(lim)
 
-		if err != nil {
-			return nil, err
-		}
-	*/
+	if err != nil {
+		return nil, err
+	}
 
 	bwc := metrics.NewBandwidthCounter()
 
-	cmgr, err := connmgr.NewConnManager(2000, 3000)
+	cmgr, err := connmgr.NewConnManager(200, 400)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +148,7 @@ func Setup(ctx context.Context, init NodeInitializer) (*Node, error) {
 		libp2p.Identity(peerkey),
 		libp2p.BandwidthReporter(bwc),
 		libp2p.DefaultTransports,
-		libp2p.ResourceManager(network.NullResourceManager),
+		libp2p.ResourceManager(rcm),
 	}
 
 	if len(cfg.AnnounceAddrs) > 0 {

--- a/node/node.go
+++ b/node/node.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/application-research/estuary/config"
 	migratebs "github.com/application-research/estuary/util/migratebs"
 	"github.com/application-research/filclient/keystore"
 	autobatch "github.com/application-research/go-bs-autobatch"
@@ -102,39 +103,10 @@ type Node struct {
 
 	Bwc *metrics.BandwidthCounter
 
-	Config *Config
+	Config *config.Config
 }
 
-type Config struct {
-	ListenAddrs   []string
-	AnnounceAddrs []string
-
-	Blockstore string
-
-	WriteLog          string
-	HardFlushWriteLog bool
-	WriteLogTruncate  bool
-	NoBlockstoreCache bool
-
-	Libp2pKeyFile string
-
-	Datastore string
-
-	WalletDir string
-
-	BitswapConfig BitswapConfig
-
-	BlockstoreWrap func(blockstore.Blockstore) (blockstore.Blockstore, error)
-
-	KeyProviderFunc func(context.Context) (<-chan cid.Cid, error)
-}
-
-type BitswapConfig struct {
-	MaxOutstandingBytesPerPeer int64
-	TargetMessageSize          int
-}
-
-func Setup(ctx context.Context, cfg *Config) (*Node, error) {
+func Setup(ctx context.Context, cfg *config.Config) (*Node, error) {
 
 	peerkey, err := loadOrInitPeerKey(cfg.Libp2pKeyFile)
 	if err != nil {


### PR DESCRIPTION
estuary/node is configured by a  Config struct in the node package, which has some function pointers which allow initialization code specific to estuary or estuary-shuttle to be injected.

This PR removes the function pointers from Config and moves it into a config package, where additional functionality (notably for reading/writing a json confif file) will be added.

Function pointers are replaced by an interface defined in node which we implement independently for estuary and estuary-shuttle