### PR TITLE
Change ContentCreateBody.Root field data type to string

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1203,7 +1203,7 @@ func (s *Shuttle) createContent(ctx context.Context, u *User, root cid.Cid, fnam
 
 	data, err := json.Marshal(util.ContentCreateBody{
 		ContentInCollection: cic,
-		Root:                root,
+		Root:                root.String(),
 		Name:                fname,
 		Location:            s.shuttleHandle,
 	})

--- a/handlers.go
+++ b/handlers.go
@@ -4125,6 +4125,10 @@ func (s *Server) handleCreateContent(c echo.Context, u *User) error {
 		return err
 	}
 
+	rootCID, err := cid.Decode(req.Root)
+	if err != nil {
+		return err
+	}
 	var col Collection
 	if req.Collection != "" {
 		if err := s.DB.First(&col, "uuid = ?", req.Collection).Error; err != nil {
@@ -4137,7 +4141,7 @@ func (s *Server) handleCreateContent(c echo.Context, u *User) error {
 	}
 
 	content := &Content{
-		Cid:         util.DbCID{req.Root},
+		Cid:         util.DbCID{CID: rootCID},
 		Name:        req.Name,
 		Active:      false,
 		Pinning:     false,

--- a/util/content.go
+++ b/util/content.go
@@ -37,7 +37,7 @@ type ContentAddResponse struct {
 type ContentCreateBody struct {
 	ContentInCollection
 
-	Root     cid.Cid     `json:"root"`
+	Root     string      `json:"root"`
 	Name     string      `json:"name"`
 	Location string      `json:"location"`
 	Type     ContentType `json:"type"`


### PR DESCRIPTION
Currently, on the `/content/create` endpoint, the `ContentCreateBody.Root` field has a type`(cid.Cid)` that echo cannot bind to (we can't send that type over the wire as json). It fails with the error;

<img width="1432" alt="Screenshot 2022-03-29 at 18 40 22" src="https://user-images.githubusercontent.com/13554411/160673543-39874d01-0c82-4e59-bd0e-47c729022a93.png">

The `ContentCreateBody.Root` field type has to be changed to a `string`, this PR does just that (see below test image)

<img width="1438" alt="Screenshot 2022-03-29 at 18 44 17" src="https://user-images.githubusercontent.com/13554411/160673969-4347a58d-0352-4629-a208-a27a71472c42.png">
