### PR TITLE
properly announce provided cids via shuttle

### DIFF
--- a/cmd/estuary-shuttle/init.go
+++ b/cmd/estuary-shuttle/init.go
@@ -6,10 +6,12 @@ import (
 	"github.com/application-research/estuary/config"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"gorm.io/gorm"
 )
 
 type Initializer struct {
 	cfg *config.Config
+	db  *gorm.DB
 }
 
 func (init Initializer) Config() *config.Config {
@@ -20,6 +22,26 @@ func (init Initializer) BlockstoreWrap(blk blockstore.Blockstore) (blockstore.Bl
 	return blk, nil
 }
 
-func (init Initializer) KeyProviderFunc(context.Context) (<-chan cid.Cid, error) {
-	return nil, nil
+func (init Initializer) KeyProviderFunc(ctx context.Context) (<-chan cid.Cid, error) {
+	log.Infof("running key provider func")
+	out := make(chan cid.Cid)
+	go func() {
+		defer close(out)
+
+		var pins []Pin
+		if err := init.db.Find(&pins, "active").Error; err != nil {
+			log.Errorf("failed to load pins for reproviding: %s", err)
+			return
+		}
+		log.Infof("key provider func returning %d values", len(pins))
+
+		for _, c := range pins {
+			select {
+			case out <- c.Cid.CID:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
 }

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -238,7 +238,12 @@ func main() {
 			NoLimiter: true,
 		}
 
-		init := Initializer{cfg}
+		db, err := setupDatabase(cctx.String("database"))
+		if err != nil {
+			return err
+		}
+
+		init := Initializer{cfg, db}
 
 		nd, err := node.Setup(context.TODO(), init)
 		if err != nil {
@@ -260,11 +265,6 @@ func main() {
 		rhost := routed.Wrap(nd.Host, nd.FilDht)
 
 		filc, err := filclient.NewClient(rhost, api, nd.Wallet, defaddr, nd.Blockstore, nd.Datastore, ddir)
-		if err != nil {
-			return err
-		}
-
-		db, err := setupDatabase(cctx.String("database"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
These werent being announced, so content hosted through shuttles wasnt easily available after the initial announcement dropped off the network