### PR TITLE
Change the content size limit to 31GiB512MiB, so it can fit within a sector size 32Gib.

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -54,7 +54,7 @@ var defaultReplication = 6
 // maxFilecoinContentSizeLimit = 31GiB512MiB
 const maxFilecoinContentSizeLimit = 33_822_867_456
 
-// minFilecoinContentSizeLimit = 0.24GiB (256 << 10)
+// minFilecoinContentSizeLimit = 256KiB (256 << 10)
 const minFilecoinContentSizeLimit = 262_144
 
 // Making default deal duration be three weeks less than the maximum to ensure

--- a/replication.go
+++ b/replication.go
@@ -51,7 +51,8 @@ import (
 
 var defaultReplication = 6
 
-const defaultContentSizeLimit = 34_000_000_000
+// defaultContentSizeLimit = 31GiB512MiB
+const defaultContentSizeLimit = 33_822_867_456
 
 // Making default deal duration be three weeks less than the maximum to ensure
 // miners who start their deals early dont run into issues


### PR DESCRIPTION
Currently, we are seeing issues of deals getting stuck in `StorageDealWaitingForData`. This happens when content uploaded, has a size greater than a sector and so will fit.

This PR changes the maximum content size limit to `31GiB512MiB`, so it can fit within a sector size of `32Gib`. It also, makes sure to do some proper preliminary checks (check the maximum and minimum content size, check that the user account has deal-making turned on, check that content has not been offloaded, etc) before creating a deal

This will make sure any newly uploaded content's deal, will likely get sealed and not fail due to content size being so large to fit into a sector.

PS: This does not add a content size limit to the content upload endpoints (`content/add`, `content/add-car`, `content/add-ipfs` and `content/create`), it only makes sure a piece to be sent to Filecoin (if bigger than 31GiB512MiB, is split into chunks) can fit into a sector. 

Maybe in the future, we can add an upload size limit on the upload endpoints to reject content uploads over a limit and suggest that users should split their files before uploading.

PS#2: This will not correct contents that are already stuck in `StorageDealWaitingForData`. 