### PR TITLE
Add BasicLimiter and ConnectionMananger configuration options to estuary and estuary-shuttle

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/network"
+	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
+	"github.com/stretchr/testify/assert"
+)
+
+func checkNodeConfig(t *testing.T, node *Node) {
+	assert := assert.New(t)
+	assert.NotEmpty(node.BlockstoreDir)
+	assert.NotEmpty(node.Libp2pKeyFile)
+	assert.NotEmpty(node.DatastoreDir)
+	assert.NotEmpty(node.WalletDir)
+
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.Conns, 0)
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.ConnsInbound, 0)
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.ConnsOutbound, 0)
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.Streams, 0)
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.StreamsInbound, 0)
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.StreamsOutbound, 0)
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.FD, 0)
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.MinMemory, int64(0))
+	assert.Greater(node.LimitsConfig.SystemLimitConfig.MaxMemory, node.LimitsConfig.SystemLimitConfig.MinMemory)
+
+	assert.Greater(node.LimitsConfig.TransientLimitConfig.Conns, 0)
+	assert.Greater(node.LimitsConfig.TransientLimitConfig.ConnsInbound, 0)
+	assert.Greater(node.LimitsConfig.TransientLimitConfig.ConnsOutbound, 0)
+	assert.Greater(node.LimitsConfig.TransientLimitConfig.Streams, 0)
+	assert.Greater(node.LimitsConfig.TransientLimitConfig.StreamsInbound, 0)
+	assert.Greater(node.LimitsConfig.TransientLimitConfig.StreamsOutbound, 0)
+	assert.Greater(node.LimitsConfig.TransientLimitConfig.FD, 0)
+
+	assert.NotEmpty(node.ListenAddrs)
+	assert.NotEmpty(node.ListenAddrs[0])
+
+	assert.Greater(node.ConnectionManagerConfig.LowWater, 0)
+	assert.Greater(node.ConnectionManagerConfig.HighWater, node.ConnectionManagerConfig.LowWater)
+}
+
+func TestEstuaryDefaultSanity(t *testing.T) {
+
+	assert := assert.New(t)
+	config := NewEstuary()
+
+	assert.NotEmpty(config.DataDir)
+	assert.NotEmpty(config.StagingDataDir)
+	assert.NotEmpty(config.DatabaseConnString)
+	assert.NotEmpty(config.ApiListen)
+	assert.NotEmpty(config.Hostname)
+
+	checkNodeConfig(t, &config.NodeConfig)
+}
+
+func TestShuttleDefaultSanity(t *testing.T) {
+
+	assert := assert.New(t)
+	config := NewShuttle()
+
+	assert.NotEmpty(config.DataDir)
+	assert.NotEmpty(config.StagingDataDir)
+	assert.NotEmpty(config.DatabaseConnString)
+	assert.NotEmpty(config.ApiListen)
+	assert.NotEmpty(config.EstuaryConfig.Api)
+
+	checkNodeConfig(t, &config.NodeConfig)
+}
+
+func TestApplyLimits(t *testing.T) {
+	assert := assert.New(t)
+	config := NewShuttle().NodeConfig.LimitsConfig
+
+	limiter := rcmgr.NewDefaultLimiter()
+	config.apply(limiter)
+
+	assert.Equal(limiter.SystemLimits.GetConnLimit(network.DirInbound), config.SystemLimitConfig.ConnsInbound)
+	assert.Equal(limiter.SystemLimits.GetConnLimit(network.DirOutbound), config.SystemLimitConfig.ConnsOutbound)
+	assert.Equal(limiter.SystemLimits.GetConnTotalLimit(), config.SystemLimitConfig.Conns)
+	assert.Equal(limiter.TransientLimits.GetConnLimit(network.DirInbound), config.TransientLimitConfig.ConnsInbound)
+	assert.Equal(limiter.TransientLimits.GetConnLimit(network.DirOutbound), config.TransientLimitConfig.ConnsOutbound)
+	assert.Equal(limiter.TransientLimits.GetConnTotalLimit(), config.TransientLimitConfig.Conns)
+	assert.Equal(limiter.SystemLimits.GetStreamLimit(network.DirInbound), config.SystemLimitConfig.StreamsInbound)
+	assert.Equal(limiter.SystemLimits.GetStreamLimit(network.DirOutbound), config.SystemLimitConfig.StreamsOutbound)
+	assert.Equal(limiter.SystemLimits.GetStreamTotalLimit(), config.SystemLimitConfig.Streams)
+	assert.Equal(limiter.TransientLimits.GetStreamLimit(network.DirInbound), config.TransientLimitConfig.StreamsInbound)
+	assert.Equal(limiter.TransientLimits.GetStreamLimit(network.DirOutbound), config.TransientLimitConfig.StreamsOutbound)
+	assert.Equal(limiter.TransientLimits.GetStreamTotalLimit(), config.TransientLimitConfig.Streams)
+	assert.Equal(limiter.SystemLimits.GetFDLimit(), config.SystemLimitConfig.FD)
+	assert.Equal(limiter.TransientLimits.GetFDLimit(), config.TransientLimitConfig.FD)
+}
+
+func TestEstuaryJSONRoundtrip(t *testing.T) {
+	assert := assert.New(t)
+	config := NewEstuary()
+	path := filepath.Join(os.TempDir(), "test.json")
+	save(config, path)
+	config2 := Estuary{}
+	load(&config2, path)
+	assert.Equal(config, &config2)
+}
+
+func TestShuttleJSONRoundtrip(t *testing.T) {
+	assert := assert.New(t)
+	config := NewShuttle()
+	path := filepath.Join(os.TempDir(), "test.json")
+	save(config, path)
+	config2 := Shuttle{}
+	load(&config2, path)
+	assert.Equal(config, &config2)
+}

--- a/config/connmgr.go
+++ b/config/connmgr.go
@@ -1,0 +1,6 @@
+package config
+
+type ConnectionManager struct {
+	HighWater int
+	LowWater  int
+}

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -116,6 +116,10 @@ func NewEstuary() *Estuary {
 					FD: 1024,
 				},
 			},
+			ConnectionManagerConfig: ConnectionManager{
+				LowWater:  2000,
+				HighWater: 3000,
+			},
 		},
 	}
 

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -87,6 +87,35 @@ func NewEstuary() *Estuary {
 			WriteLogDir:      "",
 			WriteLogTruncate: false,
 			NoLimiter:        true,
+
+			LimitsConfig: Limits{
+				SystemLimitConfig: SystemLimit{
+					MinMemory:      1 << 30,
+					MaxMemory:      10 << 30,
+					MemoryFraction: .2,
+
+					StreamsInbound:  64 << 10,
+					StreamsOutbound: 128 << 10,
+					Streams:         256 << 10,
+
+					ConnsInbound:  256,
+					ConnsOutbound: 256,
+					Conns:         1024,
+
+					FD: 8192,
+				},
+				TransientLimitConfig: TransientLimit{
+					StreamsInbound:  2 << 10,
+					StreamsOutbound: 4 << 10,
+					Streams:         4 << 10,
+
+					ConnsInbound:  256,
+					ConnsOutbound: 256,
+					Conns:         512,
+
+					FD: 1024,
+				},
+			},
 		},
 	}
 

--- a/config/limits.go
+++ b/config/limits.go
@@ -1,0 +1,49 @@
+package config
+
+import rcmgr "github.com/libp2p/go-libp2p-resource-manager"
+
+type SystemLimit struct {
+	MinMemory      int64
+	MaxMemory      int64
+	MemoryFraction float64
+
+	StreamsInbound  int
+	StreamsOutbound int
+	Streams         int
+
+	ConnsInbound  int
+	ConnsOutbound int
+	Conns         int
+
+	FD int
+}
+
+func (sl *SystemLimit) apply(lim *rcmgr.BasicLimiter) {
+	lim.SystemLimits = lim.SystemLimits.WithFDLimit(sl.FD).WithConnLimit(sl.ConnsInbound, sl.ConnsOutbound, sl.Conns).WithStreamLimit(sl.StreamsInbound, sl.StreamsOutbound, sl.Streams).WithMemoryLimit(sl.MemoryFraction, sl.MinMemory, sl.MaxMemory)
+}
+
+type TransientLimit struct {
+	StreamsInbound  int
+	StreamsOutbound int
+	Streams         int
+
+	ConnsInbound  int
+	ConnsOutbound int
+	Conns         int
+
+	FD int
+}
+
+func (tl *TransientLimit) apply(lim *rcmgr.BasicLimiter) {
+	lim.TransientLimits = lim.TransientLimits.WithFDLimit(tl.FD).WithConnLimit(tl.ConnsInbound, tl.ConnsOutbound, tl.Conns).WithStreamLimit(tl.StreamsInbound, tl.StreamsOutbound, tl.Streams)
+}
+
+type Limits struct {
+	SystemLimitConfig    SystemLimit
+	TransientLimitConfig TransientLimit
+}
+
+func (limits *Limits) apply(lim *rcmgr.BasicLimiter) {
+	limits.SystemLimitConfig.apply(lim)
+	limits.TransientLimitConfig.apply(lim)
+}

--- a/config/node.go
+++ b/config/node.go
@@ -20,8 +20,9 @@ type Node struct {
 
 	WalletDir string
 
-	BitswapConfig BitswapConfig
-	LimitsConfig  Limits
+	BitswapConfig           BitswapConfig
+	LimitsConfig            Limits
+	ConnectionManagerConfig ConnectionManager
 }
 
 type BitswapConfig struct {

--- a/config/node.go
+++ b/config/node.go
@@ -1,5 +1,7 @@
 package config
 
+import rcmgr "github.com/libp2p/go-libp2p-resource-manager"
+
 type Node struct {
 	ListenAddrs   []string `json:"Swarm"`
 	AnnounceAddrs []string `json:"Announce"`
@@ -19,6 +21,7 @@ type Node struct {
 	WalletDir string
 
 	BitswapConfig BitswapConfig
+	LimitsConfig  Limits
 }
 
 type BitswapConfig struct {
@@ -39,6 +42,12 @@ func (cfg *Node) HasListener(find string) bool {
 		}
 	}
 	return false
+}
+
+func (cfg *Node) GetLimiter() *rcmgr.BasicLimiter {
+	lim := rcmgr.NewDefaultLimiter()
+	cfg.LimitsConfig.apply(lim)
+	return lim
 }
 
 // Sets the root of many paths

--- a/config/shuttle.go
+++ b/config/shuttle.go
@@ -15,21 +15,20 @@ type EstuaryRemoteConfig struct {
 }
 
 type Shuttle struct {
-	DatabaseConnString      string
-	StagingDataDir          string
-	DataDir                 string
-	ApiListen               string
-	AutoRetrieve            bool
-	Hostname                string
-	Private                 bool
-	Dev                     bool
-	NoReloadPinQueue        bool
-	NodeConfig              Node
-	JaegerConfig            Jaeger
-	ContentConfig           Content
-	LoggingConfig           Logging
-	ConnectionManagerConfig ConnectionManager
-	EstuaryConfig           EstuaryRemoteConfig
+	DatabaseConnString string
+	StagingDataDir     string
+	DataDir            string
+	ApiListen          string
+	AutoRetrieve       bool
+	Hostname           string
+	Private            bool
+	Dev                bool
+	NoReloadPinQueue   bool
+	NodeConfig         Node
+	JaegerConfig       Jaeger
+	ContentConfig      Content
+	LoggingConfig      Logging
+	EstuaryConfig      EstuaryRemoteConfig
 }
 
 func (cfg *Shuttle) Load(filename string) error {
@@ -137,11 +136,12 @@ func NewShuttle() *Shuttle {
 					FD: 1024,
 				},
 			},
+			ConnectionManagerConfig: ConnectionManager{
+				LowWater:  2000,
+				HighWater: 3000,
+			},
 		},
-		ConnectionManagerConfig: ConnectionManager{
-			LowWater:  2000,
-			HighWater: 3000,
-		},
+
 		EstuaryConfig: EstuaryRemoteConfig{
 			Api:       "api.estuary.tech",
 			Handle:    "",

--- a/config/shuttle.go
+++ b/config/shuttle.go
@@ -108,6 +108,34 @@ func NewShuttle() *Shuttle {
 				TargetMessageSize:          16 << 10,
 			},
 			NoLimiter: true,
+			LimitsConfig: Limits{
+				SystemLimitConfig: SystemLimit{
+					MinMemory:      1 << 30,
+					MaxMemory:      10 << 30,
+					MemoryFraction: .2,
+
+					StreamsInbound:  64 << 10,
+					StreamsOutbound: 128 << 10,
+					Streams:         256 << 10,
+
+					ConnsInbound:  256,
+					ConnsOutbound: 256,
+					Conns:         1024,
+
+					FD: 8192,
+				},
+				TransientLimitConfig: TransientLimit{
+					StreamsInbound:  2 << 10,
+					StreamsOutbound: 4 << 10,
+					Streams:         4 << 10,
+
+					ConnsInbound:  256,
+					ConnsOutbound: 256,
+					Conns:         512,
+
+					FD: 1024,
+				},
+			},
 		},
 
 		EstuaryConfig: EstuaryRemoteConfig{

--- a/config/shuttle.go
+++ b/config/shuttle.go
@@ -15,20 +15,21 @@ type EstuaryRemoteConfig struct {
 }
 
 type Shuttle struct {
-	DatabaseConnString string
-	StagingDataDir     string
-	DataDir            string
-	ApiListen          string
-	AutoRetrieve       bool
-	Hostname           string
-	Private            bool
-	Dev                bool
-	NoReloadPinQueue   bool
-	NodeConfig         Node
-	JaegerConfig       Jaeger
-	ContentConfig      Content
-	LoggingConfig      Logging
-	EstuaryConfig      EstuaryRemoteConfig
+	DatabaseConnString      string
+	StagingDataDir          string
+	DataDir                 string
+	ApiListen               string
+	AutoRetrieve            bool
+	Hostname                string
+	Private                 bool
+	Dev                     bool
+	NoReloadPinQueue        bool
+	NodeConfig              Node
+	JaegerConfig            Jaeger
+	ContentConfig           Content
+	LoggingConfig           Logging
+	ConnectionManagerConfig ConnectionManager
+	EstuaryConfig           EstuaryRemoteConfig
 }
 
 func (cfg *Shuttle) Load(filename string) error {
@@ -137,7 +138,10 @@ func NewShuttle() *Shuttle {
 				},
 			},
 		},
-
+		ConnectionManagerConfig: ConnectionManager{
+			LowWater:  2000,
+			HighWater: 3000,
+		},
 		EstuaryConfig: EstuaryRemoteConfig{
 			Api:       "api.estuary.tech",
 			Handle:    "",

--- a/node/node.go
+++ b/node/node.go
@@ -142,7 +142,7 @@ func Setup(ctx context.Context, init NodeInitializer) (*Node, error) {
 
 	bwc := metrics.NewBandwidthCounter()
 
-	cmgr, err := connmgr.NewConnManager(2000, 3000)
+	cmgr, err := connmgr.NewConnManager(cfg.ConnectionManagerConfig.LowWater, cfg.ConnectionManagerConfig.HighWater)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -132,9 +132,7 @@ func Setup(ctx context.Context, init NodeInitializer) (*Node, error) {
 	if cfg.NoLimiter {
 		rcm, err = network.NullResourceManager, nil
 	} else {
-		lim := rcmgr.NewDefaultLimiter()
-		lim.SystemLimits = lim.SystemLimits.WithFDLimit(8192).WithConnLimit(256, 256, 1024).WithStreamLimit(64<<10, 128<<10, 256<<10).WithMemoryLimit(0.2, 1<<30, 10<<30)
-		lim.TransientLimits = lim.TransientLimits.WithConnLimit(256, 256, 512).WithFDLimit(1024).WithStreamLimit(2<<10, 4<<10, 4<<10)
+		lim := cfg.GetLimiter()
 		rcm, err = rcmgr.NewResourceManager(lim)
 	}
 


### PR DESCRIPTION
Closes #131 - The number of connections opened can be effectively limited using the estuary configuration file.