### PR TITLE
fix empty meta on handleAddPin

### DIFF
--- a/pinning.go
+++ b/pinning.go
@@ -703,6 +703,8 @@ func (s *Server) handleAddPin(e echo.Context, u *User) error {
 	if err != nil {
 		return err
 	}
+	
+	status.Pin.Meta = pin.Meta
 
 	return e.JSON(202, status)
 }


### PR DESCRIPTION
`handleAddPin` receives a `meta` parameter in which the client can specify a `collection` as well as a `collectionPath` to where the pin must be saved. It handle the collection placing correctly but it fails to return the `meta` tag on the `status` variable on the JSON response. This adds the `meta` parameter to the status response.

Fixes #157 