### PR TITLE
Properly set shuttle-proxy content url paths

### DIFF
--- a/cmd/shuttle-proxy/main.go
+++ b/cmd/shuttle-proxy/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/labstack/echo/v4"
@@ -104,19 +105,32 @@ func (p *Proxy) getEndpoints(c echo.Context) ([]string, error) {
 		return nil, c.String(code, err.Error())
 	}
 
-	if len(view.Settings.UploadEndpoints) == 0 {
-		return nil, fmt.Errorf("all upload endpoints are unavailable")
+	var endps []string
+	for _, endp := range view.Settings.UploadEndpoints {
+		u, err := url.Parse(endp)
+		if err != nil {
+			return nil, err
+		}
+		u.Path = ""
+		u.RawQuery = ""
+		u.Fragment = ""
+		endps = append(endps, u.String())
 	}
 
-	return view.Settings.UploadEndpoints, nil
+	if len(endps) == 0 {
+		return nil, fmt.Errorf("all upload endpoints are unavailable")
+	}
+	return endps, nil
 }
+
 func (p *Proxy) handleContentAdd(c echo.Context) error {
 	eps, err := p.getEndpoints(c)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", eps[0], c.Request().Body)
+	ep := eps[0]
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/content/add", ep), c.Request().Body)
 	if err != nil {
 		return err
 	}
@@ -140,26 +154,13 @@ func (p *Proxy) handleContentAdd(c echo.Context) error {
 }
 
 func (p *Proxy) handleAddCar(c echo.Context) error {
-	auth, err := util.ExtractAuth(c)
+	eps, err := p.getEndpoints(c)
 	if err != nil {
 		return err
 	}
 
-	view, code, err := p.getViewer(auth)
-	if err != nil {
-		// TODO: match error format of shuttles
-		return c.String(code, err.Error())
-	}
-
-	if len(view.Settings.UploadEndpoints) == 0 {
-		log.Errorf("no upload endpoints")
-		return c.JSON(500, map[string]string{
-			"error": "all upload endpoints are unavailable",
-		})
-	}
-
-	ep := view.Settings.UploadEndpoints[0]
-	req, err := http.NewRequest("POST", ep, c.Request().Body)
+	ep := eps[0]
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/content/add-car", ep), c.Request().Body)
 	if err != nil {
 		return err
 	}

--- a/cmd/shuttle-proxy/main.go
+++ b/cmd/shuttle-proxy/main.go
@@ -138,6 +138,10 @@ func (p *Proxy) handleContentAdd(c echo.Context) error {
 	req.Header = c.Request().Header.Clone()
 	req.Header.Set("Shuttle-Proxy", "true")
 
+	// propagate any query params
+	rq := c.Request().URL.Query()
+	req.URL.RawQuery = rq.Encode()
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err

--- a/cmd/shuttle-proxy/main.go
+++ b/cmd/shuttle-proxy/main.go
@@ -168,6 +168,10 @@ func (p *Proxy) handleAddCar(c echo.Context) error {
 	req.Header = c.Request().Header.Clone()
 	req.Header.Set("Shuttle-Proxy", "true")
 
+	// propagate any query params
+	rq := c.Request().URL.Query()
+	req.URL.RawQuery = rq.Encode()
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now, shuttle proxy content URLs paths for both `/content/add-car` and `/content/add` will always send both request to `content/add` on the shuttles and not the actual `/content/add-car` for the case of car file upload. This PR makes sure the file uploads are properly proxied to the right paths.

This should fix https://github.com/application-research/estuary/issues/162 