### PR TITLE
Preventing making a deal with providers if DataCap is low

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -1405,7 +1405,7 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content Content, do
 		if bl.VerifiedClientBalance.LessThan(big.NewIntUnsigned(uint64(abi.UnpaddedPieceSize(content.Size).Padded()))) {
 			// how do we notify admin to top up datacap?
 			done(time.Minute * 60) // retry an hour later - hopefully datacap has been topped up
-			return errors.Wrap(err, "will not make deal, client address dataCap is lower than content size")
+			return errors.Wrapf(err, "will not make deal, client address dataCap:%d GiB is lower than content size:%d GiB", big.Div(*bl.VerifiedClientBalance, big.NewIntUnsigned(uint64(1073741824))), abi.UnpaddedPieceSize(content.Size).Padded()/1073741824)
 		}
 
 		go func() {

--- a/replication.go
+++ b/replication.go
@@ -1404,7 +1404,6 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content Content, do
 
 		if bl.VerifiedClientBalance.LessThan(big.NewIntUnsigned(uint64(abi.UnpaddedPieceSize(content.Size).Padded()))) {
 			// how do we notify admin to top up datacap?
-			done(time.Minute * 60) // retry an hour later - hopefully datacap has been topped up
 			return errors.Wrapf(err, "will not make deal, client address dataCap:%d GiB is lower than content size:%d GiB", big.Div(*bl.VerifiedClientBalance, big.NewIntUnsigned(uint64(1073741824))), abi.UnpaddedPieceSize(content.Size).Padded()/1073741824)
 		}
 


### PR DESCRIPTION
This PR will make sure we don't make deals and endup with error like ` deal rejected: verified deal DataCap too small for proposed piece size`. It closes  https://github.com/application-research/estuary/issues/21