### PR TITLE
Collection CIDs (commit endpoint)

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -11,6 +11,7 @@ type Collection struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	UserID      uint   `json:"userId"`
+	CID         string `json:"cid"`
 }
 
 type CollectionRef struct {

--- a/handlers.go
+++ b/handlers.go
@@ -3163,7 +3163,7 @@ func (s *Server) handleAddContentsToCollection(c echo.Context, u *User) error {
 // @Tags         collections
 // @Produce      json
 // @Success      200  {object}  string
-// @Router       /collections/{collection-id}/commit [post]
+// @Router       /collections/{coluuid}/commit [post]
 func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
 	colid := c.Param("coluuid")
 
@@ -3176,14 +3176,28 @@ func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
 	if err := s.DB.Model(CollectionRef{}).
 		Where("collection = ?", col.ID).
 		Joins("left join contents on contents.id = collection_refs.content").
-		Select("contents.*").
+		Select("contents.*, collection_refs.path").
 		Scan(&contents).Error; err != nil {
 		return err
 	}
 
+	bserv := blockservice.New(s.Node.Blockstore, nil)
+	dserv := merkledag.NewDAGService(bserv)
+
+	// create DAG respecting directory structure
 	collectionNode := unixfs.EmptyDirNode()
+	dserv.Add(context.Background(), collectionNode)
 	for _, c := range contents {
-		collectionNode.AddRawLink(c.Name, &ipld.Link{
+		dirs, err := util.DirsFromPath(c.Path, c.Name)
+		if err != nil {
+			return err
+		}
+
+		lastDirNode, err := util.EnsurePathIsLinked(dirs, collectionNode, dserv)
+		if err != nil {
+			return err
+		}
+		lastDirNode.AddRawLink(c.Name, &ipld.Link{
 			Size: uint64(c.Size),
 			Cid:  c.Cid.CID,
 		})

--- a/handlers.go
+++ b/handlers.go
@@ -43,6 +43,7 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
 	merkledag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-unixfs"
 	uio "github.com/ipfs/go-unixfs/io"
 	car "github.com/ipld/go-car"
 	"github.com/labstack/echo/v4"
@@ -215,6 +216,8 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 	cols.POST("/create", withUser(s.handleCreateCollection))
 	cols.POST("/add-content", withUser(s.handleAddContentsToCollection))
 	cols.GET("/content/:coluuid", withUser(s.handleGetCollectionContents))
+	cols.POST("/:coluuid/commit", withUser(s.handleCommitCollection))
+
 	colfs := cols.Group("/fs")
 	colfs.GET("/list", withUser(s.handleColfsListDir))
 	colfs.POST("/add", withUser(s.handleColfsAdd))
@@ -3151,6 +3154,74 @@ func (s *Server) handleAddContentsToCollection(c echo.Context, u *User) error {
 	}
 
 	return c.JSON(200, map[string]string{})
+}
+
+// handleCommitCollection godoc
+// @Summary      Produce a CID of the collection contents
+// @Description  This endpoint is used to save the contents in a collection, producing a top-level CID that references all the current CIDs in the collection.
+// @Param        coluuid     path     string  true     "coluuid"
+// @Tags         collections
+// @Produce      json
+// @Success      200  {object}  string
+// @Router       /collections/{collection-id}/commit [post]
+func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
+	colid := c.Param("coluuid")
+
+	var col Collection
+	if err := s.DB.First(&col, "uuid = ? and user_id = ?", colid, u.ID).Error; err != nil {
+		return err
+	}
+
+	contents := []Content{}
+	if err := s.DB.Model(CollectionRef{}).
+		Where("collection = ?", col.ID).
+		Joins("left join contents on contents.id = collection_refs.content").
+		Select("contents.*").
+		Scan(&contents).Error; err != nil {
+		return err
+	}
+
+	collectionNode := unixfs.EmptyDirNode()
+	for _, c := range contents {
+		collectionNode.AddRawLink(c.Name, &ipld.Link{
+			Size: uint64(c.Size),
+			Cid:  c.Cid.CID,
+		})
+	}
+
+	// update DB with new collection CID
+	col.CID = collectionNode.Cid().String()
+	err := s.DB.Model(Collection{}).Where("id = ?", col.ID).UpdateColumn("c_id", collectionNode.Cid().String()).Error
+	if err != nil {
+		return err
+	}
+
+	// transform listen addresses (/ip/1.2.3.4/tcp/80) in full p2p multiaddresses
+	// e.g. /ip/1.2.3.4/tcp/80/p2p/12D3KooWCVTKbuvrZ9ton6zma5LNhCEeZyuFtxcDzDTmWh2qPtWM
+	fullP2pMultiAddrs := []multiaddr.Multiaddr{}
+	for _, listenAddr := range s.Node.Host.Addrs() {
+		fullP2pAddr := fmt.Sprintf("%s/p2p/%s", listenAddr, s.Node.Host.ID())
+		fullP2pMultiAddr, err := multiaddr.NewMultiaddr(fullP2pAddr)
+		if err != nil {
+			return err
+		}
+		fullP2pMultiAddrs = append(fullP2pMultiAddrs, fullP2pMultiAddr)
+	}
+
+	// transform multiaddresses into AddrInfo objects
+	peers, err := peer.AddrInfosFromP2pAddrs(fullP2pMultiAddrs...)
+	if err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+
+	pinstatus, err := s.CM.pinContent(ctx, u.ID, collectionNode.Cid(), collectionNode.Cid().String(), []*CollectionRef{}, peers, 0, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(200, pinstatus)
 }
 
 // handleGetCollectionContents godoc

--- a/handlers.go
+++ b/handlers.go
@@ -537,8 +537,8 @@ func (s *Server) handleAddIpfs(c echo.Context, u *User) error {
 			return c.JSON(302, map[string]string{"message": "content with given cid already preserved"})
 		}
 	}
-
-	pinstatus, err := s.CM.pinContent(ctx, u.ID, rcid, filename, cols, addrInfos, 0, nil)
+	makeDeal := true
+	pinstatus, err := s.CM.pinContent(ctx, u.ID, rcid, filename, cols, addrInfos, 0, nil, makeDeal)
 	if err != nil {
 		return err
 	}
@@ -3215,8 +3215,9 @@ func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
 	}
 
 	ctx := c.Request().Context()
+	makeDeal := false
 
-	pinstatus, err := s.CM.pinContent(ctx, u.ID, collectionNode.Cid(), collectionNode.Cid().String(), []*CollectionRef{}, peers, 0, nil)
+	pinstatus, err := s.CM.pinContent(ctx, u.ID, collectionNode.Cid(), collectionNode.Cid().String(), []*CollectionRef{}, peers, 0, nil, makeDeal)
 	if err != nil {
 		return err
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -3186,7 +3186,6 @@ func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
 
 	// create DAG respecting directory structure
 	collectionNode := unixfs.EmptyDirNode()
-	dserv.Add(context.Background(), collectionNode)
 	for _, c := range contents {
 		dirs, err := util.DirsFromPath(c.Path, c.Name)
 		if err != nil {
@@ -3202,6 +3201,7 @@ func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
 			Cid:  c.Cid.CID,
 		})
 	}
+	dserv.Add(context.Background(), collectionNode) // add new CID to local blockstore
 
 	// update DB with new collection CID
 	col.CID = collectionNode.Cid().String()

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ type Content struct {
 	Description string           `json:"description"`
 	Size        int64            `json:"size"`
 	Type        util.ContentType `json:"type"`
+	Path        string           `json:"path"`
 	Active      bool             `json:"active"`
 	Offloaded   bool             `json:"offloaded"`
 	Replication int              `json:"replication"`

--- a/pinner/pinmgr.go
+++ b/pinner/pinmgr.go
@@ -89,6 +89,8 @@ type PinningOperation struct {
 	SkipLimiter bool
 
 	lk sync.Mutex
+
+	MakeDeal bool
 }
 
 func (po *PinningOperation) fail(err error) {

--- a/pinning.go
+++ b/pinning.go
@@ -149,11 +149,12 @@ func (cm *ContentManager) refreshPinQueue() error {
 	// Need to fix this, probably best option is just to add a 'replace' field
 	// to content, could be interesting to see the graph of replacements
 	// anyways
+	makeDeal := true
 	for _, c := range toPin {
 		if c.Location == "local" {
-			cm.addPinToQueue(c, nil, 0, true)
+			cm.addPinToQueue(c, nil, 0, makeDeal)
 		} else {
-			if err := cm.pinContentOnShuttle(context.TODO(), c, nil, 0, c.Location, true); err != nil {
+			if err := cm.pinContentOnShuttle(context.TODO(), c, nil, 0, c.Location, makeDeal); err != nil {
 				log.Errorf("failed to send pin message to shuttle: %s", err)
 				time.Sleep(time.Millisecond * 100)
 			}

--- a/pinning.go
+++ b/pinning.go
@@ -113,7 +113,9 @@ func (s *Server) doPinning(ctx context.Context, op *pinner.PinningOperation, cb 
 		return err
 	}
 
-	s.CM.ToCheck <- op.ContId
+	if op.MakeDeal {
+		s.CM.ToCheck <- op.ContId
+	}
 
 	if op.Replace > 0 {
 		if err := s.CM.RemoveContent(ctx, op.Replace, true); err != nil {
@@ -149,9 +151,9 @@ func (cm *ContentManager) refreshPinQueue() error {
 	// anyways
 	for _, c := range toPin {
 		if c.Location == "local" {
-			cm.addPinToQueue(c, nil, 0)
+			cm.addPinToQueue(c, nil, 0, true)
 		} else {
-			if err := cm.pinContentOnShuttle(context.TODO(), c, nil, 0, c.Location); err != nil {
+			if err := cm.pinContentOnShuttle(context.TODO(), c, nil, 0, c.Location, true); err != nil {
 				log.Errorf("failed to send pin message to shuttle: %s", err)
 				time.Sleep(time.Millisecond * 100)
 			}
@@ -161,7 +163,7 @@ func (cm *ContentManager) refreshPinQueue() error {
 	return nil
 }
 
-func (cm *ContentManager) pinContent(ctx context.Context, user uint, obj cid.Cid, name string, cols []*CollectionRef, peers []peer.AddrInfo, replace uint, meta map[string]interface{}) (*types.IpfsPinStatus, error) {
+func (cm *ContentManager) pinContent(ctx context.Context, user uint, obj cid.Cid, name string, cols []*CollectionRef, peers []peer.AddrInfo, replace uint, meta map[string]interface{}, makeDeal bool) (*types.IpfsPinStatus, error) {
 	loc, err := cm.selectLocationForContent(ctx, obj, user)
 	if err != nil {
 		return nil, xerrors.Errorf("selecting location for content failed: %w", err)
@@ -213,9 +215,9 @@ func (cm *ContentManager) pinContent(ctx context.Context, user uint, obj cid.Cid
 	}
 
 	if loc == "local" {
-		cm.addPinToQueue(cont, peers, replace)
+		cm.addPinToQueue(cont, peers, replace, makeDeal)
 	} else {
-		if err := cm.pinContentOnShuttle(ctx, cont, peers, replace, loc); err != nil {
+		if err := cm.pinContentOnShuttle(ctx, cont, peers, replace, loc, makeDeal); err != nil {
 			return nil, err
 		}
 	}
@@ -223,7 +225,7 @@ func (cm *ContentManager) pinContent(ctx context.Context, user uint, obj cid.Cid
 	return cm.pinStatus(cont)
 }
 
-func (cm *ContentManager) addPinToQueue(cont Content, peers []peer.AddrInfo, replace uint) {
+func (cm *ContentManager) addPinToQueue(cont Content, peers []peer.AddrInfo, replace uint, makeDeal bool) {
 	if cont.Location != "local" {
 		log.Errorf("calling addPinToQueue on non-local content")
 	}
@@ -238,6 +240,7 @@ func (cm *ContentManager) addPinToQueue(cont Content, peers []peer.AddrInfo, rep
 		Status:   "queued",
 		Replace:  replace,
 		Location: cont.Location,
+		MakeDeal: makeDeal,
 	}
 
 	cm.pinLk.Lock()
@@ -248,7 +251,7 @@ func (cm *ContentManager) addPinToQueue(cont Content, peers []peer.AddrInfo, rep
 	cm.pinMgr.Add(op)
 }
 
-func (cm *ContentManager) pinContentOnShuttle(ctx context.Context, cont Content, peers []peer.AddrInfo, replace uint, handle string) error {
+func (cm *ContentManager) pinContentOnShuttle(ctx context.Context, cont Content, peers []peer.AddrInfo, replace uint, handle string, makeDeal bool) error {
 	ctx, span := cm.tracer.Start(ctx, "pinContentOnShuttle", trace.WithAttributes(
 		attribute.String("handle", handle),
 		attribute.String("CID", cont.Cid.CID.String()),
@@ -279,6 +282,7 @@ func (cm *ContentManager) pinContentOnShuttle(ctx context.Context, cont Content,
 		Status:   "queued",
 		Replace:  replace,
 		Location: handle,
+		MakeDeal: makeDeal,
 	}
 
 	cm.pinLk.Lock()
@@ -699,11 +703,12 @@ func (s *Server) handleAddPin(e echo.Context, u *User) error {
 		return err
 	}
 
-	status, err := s.CM.pinContent(ctx, u.ID, obj, pin.Name, cols, addrInfos, 0, pin.Meta)
+	makeDeal := true
+	status, err := s.CM.pinContent(ctx, u.ID, obj, pin.Name, cols, addrInfos, 0, pin.Meta, makeDeal)
 	if err != nil {
 		return err
 	}
-	
+
 	status.Pin.Meta = pin.Meta
 
 	return e.JSON(202, status)
@@ -787,7 +792,8 @@ func (s *Server) handleReplacePin(e echo.Context, u *User) error {
 		return err
 	}
 
-	status, err := s.CM.pinContent(ctx, u.ID, obj, pin.Name, nil, addrInfos, uint(id), pin.Meta)
+	makeDeal := true
+	status, err := s.CM.pinContent(ctx, u.ID, obj, pin.Name, nil, addrInfos, uint(id), pin.Meta, makeDeal)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds the `/collections/commit/:coluuid` endpoint, to which you can `POST` to get a CID that references all the files in that collection in that point in time. The CID gets pinned to the Estuary node and can be used to reference those files in that point in time. The functioning is very similar to an SVG (aka Git-like programs), thus the `commit` name of the endpoint.

Testing: `curl -X POST -H "Authorization: Bearer $YOUR-APIKEY" "localhost:3004/collections/commit/YOUR-COLLECTION-UUID" | jq`

Implements #137 