### PR TITLE
Remove DB.Debug() from various places

### DIFF
--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -178,7 +178,7 @@ func (s *Shuttle) objectsForPin(ctx context.Context, pin uint) ([]*Object, error
 	defer span.End()
 
 	var objects []*Object
-	if err := s.DB.Debug().Model(ObjRef{}).Where("pin = ?", pin).
+	if err := s.DB.Model(ObjRef{}).Where("pin = ?", pin).
 		Joins("left join objects on obj_refs.object = objects.id").
 		Select("objects.*").
 		Scan(&objects).Error; err != nil {

--- a/gc.go
+++ b/gc.go
@@ -121,7 +121,7 @@ func (cm *ContentManager) RemoveContent(ctx context.Context, c uint, now bool) e
 	}
 
 	// TODO: copied from the offloading method, need to refactor this into something better
-	q := cm.DB.Debug().Model(&ObjRef{}).
+	q := cm.DB.Model(&ObjRef{}).
 		Select("cid").
 		Joins("left join objects on obj_refs.object = objects.id").
 		Group("cid").

--- a/handlers.go
+++ b/handlers.go
@@ -1671,7 +1671,7 @@ type getInvitesResp struct {
 
 func (s *Server) handleAdminGetInvites(c echo.Context) error {
 	var invites []getInvitesResp
-	if err := s.DB.Debug().Model(&InviteCode{}).
+	if err := s.DB.Model(&InviteCode{}).
 		Select("code, username, (?) as claimed_by", s.DB.Table("users").Select("username").Where("id = invite_codes.claimed_by")).
 		//Where("claimed_by IS NULL").
 		Joins("left join users on users.id = invite_codes.created_by").
@@ -3174,8 +3174,7 @@ func (s *Server) handleGetCollectionContents(c echo.Context, u *User) error {
 	}
 
 	contents := []Content{}
-	if err := s.DB.Debug().
-		Model(CollectionRef{}).
+	if err := s.DB.Model(CollectionRef{}).
 		Where("collection = ?", col.ID).
 		Joins("left join contents on contents.id = collection_refs.content").
 		Select("contents.*").


### PR DESCRIPTION
I found `DB.Debug()` in a few places of the codebase after @whyrusleeping's [comment](https://github.com/application-research/estuary/pull/171/files#r864272843). Removed them