### PR TITLE
chore: check if the auth token is empty before starting the tracer

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2632,14 +2632,17 @@ func (s *Server) checkTokenAuth(token string) (*User, error) {
 func (s *Server) AuthRequired(level int) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			ctx, span := s.tracer.Start(c.Request().Context(), "authCheck")
-			defer span.End()
-			c.SetRequest(c.Request().WithContext(ctx))
 
+			//	Check first if the Token is available. We should not continue if the
+			//	token isn't even available.
 			auth, err := util.ExtractAuth(c)
 			if err != nil {
 				return err
 			}
+
+			ctx, span := s.tracer.Start(c.Request().Context(), "authCheck")
+			defer span.End()
+			c.SetRequest(c.Request().WithContext(ctx))
 
 			u, err := s.checkTokenAuth(auth)
 			if err != nil {

--- a/util/http.go
+++ b/util/http.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"regexp"
 	"strings"
 	"time"
 
@@ -48,10 +49,20 @@ const (
 
 func ExtractAuth(c echo.Context) (string, error) {
 	auth := c.Request().Header.Get("Authorization")
-	if auth == "" {
+	//	undefined will be the auth value if ESTUARY_TOKEN cookie is removed.
+	if auth == "" || auth == "undefined" {
 		return "", &HttpError{
 			Code:    403,
 			Message: ERR_AUTH_MISSING,
+		}
+	}
+
+	//	if auth is not missing, check format first before extracting
+	match, _ := regexp.MatchString("EST(.*)ARY", auth)
+	if match == false {
+		return "", &HttpError{
+			Code:    403,
+			Message: ERR_INVALID_AUTH,
 		}
 	}
 


### PR DESCRIPTION
# Change

An issue was raised regarding unnecessary tracer/checks on estuary for request that doesn't come with a non-empty auth token. This is a valid concern since anyone can basically run unlimited request to the API endpoints which can cause DDOS on our endpoints. 

This PR checks the auth token first for endpoints that requires AUTHORIZATION only. 

# Related PR
https://github.com/application-research/estuary/issues/180
