### PR TITLE
Report badly formatted config file

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -292,7 +292,10 @@ func main() {
 			Usage: "Saves a configuration file to the location specified by the config parameter",
 			Action: func(cctx *cli.Context) error {
 				configuration := cctx.String("config")
-				cfg.Load(configuration) // Assume error means no configuration file exists
+				err := cfg.Load(configuration)
+				if err != config.ErrNotInitialized { // still want to report parsing errors
+					return err
+				}
 				overrideSetOptions(app.Flags, cctx, cfg)
 				return cfg.Save(configuration)
 			},
@@ -301,10 +304,13 @@ func main() {
 
 	app.Action = func(cctx *cli.Context) error {
 
-		cfg.Load(cctx.String("config")) // Ignore error for now; eventually error out if no configuration file
+		err := cfg.Load(cctx.String("config"))
+		if err != config.ErrNotInitialized { // still want to report parsing errors
+			return err
+		}
 		overrideSetOptions(app.Flags, cctx, cfg)
 
-		err := cfg.Validate()
+		err = cfg.Validate()
 		if err != nil {
 			return err
 		}

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -293,7 +293,7 @@ func main() {
 			Action: func(cctx *cli.Context) error {
 				configuration := cctx.String("config")
 				err := cfg.Load(configuration)
-				if err != config.ErrNotInitialized { // still want to report parsing errors
+				if err != nil && err != config.ErrNotInitialized { // still want to report parsing errors
 					return err
 				}
 				overrideSetOptions(app.Flags, cctx, cfg)
@@ -305,9 +305,11 @@ func main() {
 	app.Action = func(cctx *cli.Context) error {
 
 		err := cfg.Load(cctx.String("config"))
-		if err != config.ErrNotInitialized { // still want to report parsing errors
+		if err != nil && err != config.ErrNotInitialized { // still want to report parsing errors
+			log.Error(err)
 			return err
 		}
+
 		overrideSetOptions(app.Flags, cctx, cfg)
 
 		err = cfg.Validate()
@@ -315,7 +317,7 @@ func main() {
 			return err
 		}
 
-		db, err := setupDatabase(cctx.String("database"))
+		db, err := setupDatabase(cfg.DatabaseConnString)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -359,7 +359,10 @@ func main() {
 			Name:  "setup",
 			Usage: "Creates an initial auth token under new user \"admin\"",
 			Action: func(cctx *cli.Context) error {
-				cfg.Load(cctx.String("config"))
+				err := cfg.Load(cctx.String("config"))
+				if err != config.ErrNotInitialized { // still want to report parsing errors
+					return err
+				}
 				overrideSetOptions(app.Flags, cctx, cfg)
 				db, err := setupDatabase(cfg)
 				if err != nil {
@@ -405,8 +408,10 @@ func main() {
 			Usage: "Saves a configuration file to the location specified by the config parameter",
 			Action: func(cctx *cli.Context) error {
 				configuration := cctx.String("config")
-				cfg.Load(configuration) // Assume error means no configuration file exists
-				log.Info("test")
+				err := cfg.Load(configuration)
+				if err != config.ErrNotInitialized { // still want to report parsing errors
+					return err
+				}
 				overrideSetOptions(app.Flags, cctx, cfg)
 				return cfg.Save(configuration)
 			},
@@ -414,7 +419,11 @@ func main() {
 	}
 	app.Action = func(cctx *cli.Context) error {
 
-		cfg.Load(cctx.String("config")) // Ignore error for now; eventually error out if no configuration file
+		err := cfg.Load(cctx.String("config"))
+		if err != config.ErrNotInitialized { // For backward compatibility, don't error if no config file
+			return err
+		}
+
 		overrideSetOptions(app.Flags, cctx, cfg)
 
 		db, err := setupDatabase(cfg)

--- a/main.go
+++ b/main.go
@@ -360,7 +360,7 @@ func main() {
 			Usage: "Creates an initial auth token under new user \"admin\"",
 			Action: func(cctx *cli.Context) error {
 				err := cfg.Load(cctx.String("config"))
-				if err != config.ErrNotInitialized { // still want to report parsing errors
+				if err != nil && err != config.ErrNotInitialized { // still want to report parsing errors
 					return err
 				}
 				overrideSetOptions(app.Flags, cctx, cfg)
@@ -409,7 +409,7 @@ func main() {
 			Action: func(cctx *cli.Context) error {
 				configuration := cctx.String("config")
 				err := cfg.Load(configuration)
-				if err != config.ErrNotInitialized { // still want to report parsing errors
+				if err != nil && err != config.ErrNotInitialized { // still want to report parsing errors
 					return err
 				}
 				overrideSetOptions(app.Flags, cctx, cfg)
@@ -420,7 +420,7 @@ func main() {
 	app.Action = func(cctx *cli.Context) error {
 
 		err := cfg.Load(cctx.String("config"))
-		if err != config.ErrNotInitialized { // For backward compatibility, don't error if no config file
+		if err != nil && err != config.ErrNotInitialized { // For backward compatibility, don't error if no config file
 			return err
 		}
 

--- a/node/node.go
+++ b/node/node.go
@@ -131,6 +131,7 @@ func Setup(ctx context.Context, init NodeInitializer) (*Node, error) {
 
 	if cfg.NoLimiter {
 		rcm, err = network.NullResourceManager, nil
+		log.Warnf("starting node with no resource limits")
 	} else {
 		lim := cfg.GetLimiter()
 		rcm, err = rcmgr.NewResourceManager(lim)


### PR DESCRIPTION
For backwards compatibility, my initial config development would ignore any errors loading the config file so that the case where the config file does not exist would not break anything (command line/environment config would be handled just as before).

However, this also ignores any formatting errors, causing the system to just silently fail to apply the configuration if there's a syntax error in the file. This is not friendly behavior.

This PR any the error returned by the config file loader. The case where the file does not exist is still ignored, but other errors are reported.