### PR TITLE
Wrap error with more context when pinning contents

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1460,7 +1460,7 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 	*/
 
 	if err := d.Provide(ctx, op.Obj); err != nil {
-		return errors.Wrapf(err, "failed to Provide - contID(%d), cid(%s)", op.ContId, op.Obj.String())
+		return errors.Wrapf(err, "failed to provide - contID(%d), cid(%s)", op.ContId, op.Obj.String())
 	}
 	return nil
 }

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1552,7 +1552,7 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 		return node.Links(), nil
 	}, root, cset.Visit, merkledag.Concurrent())
 	if err != nil {
-		return errors.Wrap(err, "failed to Walk DAG")
+		return errors.Wrap(err, "failed to walk DAG")
 	}
 
 	span.SetAttributes(

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/application-research/filclient/retrievehelper"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
@@ -1124,18 +1125,19 @@ func (s *Shuttle) Provide(ctx context.Context, c cid.Cid) error {
 
 	if s.Node.FullRT.Ready() {
 		if err := s.Node.FullRT.Provide(subCtx, c, true); err != nil {
-			return fmt.Errorf("failed to provide newly added content: %w", err)
+			return errors.Wrap(err, "failed to provide newly added content")
 		}
 	} else {
 		log.Warnf("fullrt not in ready state, falling back to standard dht provide")
 		if err := s.Node.Dht.Provide(subCtx, c, true); err != nil {
-			return fmt.Errorf("fallback provide failed: %w", err)
+			return errors.Wrap(err, "fallback provide failed")
 		}
 	}
 
 	go func() {
 		if err := s.Node.Provider.Provide(c); err != nil {
 			log.Warnf("providing failed: ", err)
+			return
 		}
 		log.Infof("providing complete")
 	}()
@@ -1446,7 +1448,7 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 		}
 		*/
 
-		return err
+		return errors.Wrapf(err, "failed to addDatabaseTrackingToContent - contID(%d), cid(%s)", op.ContId, op.Obj.String())
 	}
 
 	/*
@@ -1458,9 +1460,8 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 	*/
 
 	if err := d.Provide(ctx, op.Obj); err != nil {
-		log.Warn(err)
+		return errors.Wrapf(err, "failed to Provide - contID(%d), cid(%s)", op.ContId, op.Obj.String())
 	}
-
 	return nil
 }
 
@@ -1473,7 +1474,7 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 
 	var dbpin Pin
 	if err := d.DB.First(&dbpin, "content = ?", contid).Error; err != nil {
-		return err
+		return errors.Wrap(err, "failed to retrieve content")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -1525,7 +1526,7 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 
 		node, err := dserv.Get(ctx, c)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to Get CID node")
 		}
 
 		cb(int64(len(node.RawData())))
@@ -1551,7 +1552,7 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 		return node.Links(), nil
 	}, root, cset.Visit, merkledag.Concurrent())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to Walk DAG")
 	}
 
 	span.SetAttributes(
@@ -1560,7 +1561,7 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 	)
 
 	if err := d.DB.CreateInBatches(objects, 300).Error; err != nil {
-		return xerrors.Errorf("failed to create objects in db: %w", err)
+		return errors.Wrap(err, "failed to create objects in db")
 	}
 
 	if err := d.DB.Model(Pin{}).Where("content = ?", contid).UpdateColumns(map[string]interface{}{
@@ -1568,7 +1569,7 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 		"size":    totalSize,
 		"pinning": false,
 	}).Error; err != nil {
-		return xerrors.Errorf("failed to update content in database: %w", err)
+		return errors.Wrap(err, "failed to update content in database")
 	}
 
 	refs := make([]ObjRef, len(objects))
@@ -1578,7 +1579,7 @@ func (d *Shuttle) addDatabaseTrackingToContent(ctx context.Context, contid uint,
 	}
 
 	if err := d.DB.CreateInBatches(refs, 500).Error; err != nil {
-		return xerrors.Errorf("failed to create refs: %w", err)
+		return errors.Wrap(err, "failed to create refs")
 	}
 
 	d.sendPinCompleteMessage(ctx, dbpin.Content, totalSize, objects)

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1109,7 +1109,7 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 	}
 
 	if err := s.Provide(ctx, nd.Cid()); err != nil {
-		log.Warn(err)
+		log.Warnf("failed to provide: %+v", err)
 	}
 
 	return c.JSON(200, &util.ContentAddResponse{
@@ -1136,7 +1136,7 @@ func (s *Shuttle) Provide(ctx context.Context, c cid.Cid) error {
 
 	go func() {
 		if err := s.Node.Provider.Provide(c); err != nil {
-			log.Warnf("providing failed: ", err)
+			log.Warnf("providing failed: %s", err)
 			return
 		}
 		log.Infof("providing complete")

--- a/pinner/pinmgr.go
+++ b/pinner/pinmgr.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/pkg/errors"
 )
 
 var log = logging.Logger("pinner")
@@ -174,7 +175,7 @@ func (pm *PinManager) doPinning(op *PinningOperation) error {
 	}); err != nil {
 		op.fail(err)
 		pm.StatusChangeFunc(op.ContId, "failed")
-		return err
+		return errors.Wrap(err, "shuttle RunPinFunc failed")
 	}
 	op.complete()
 	pm.StatusChangeFunc(op.ContId, "pinned")
@@ -281,7 +282,7 @@ func (pm *PinManager) Run(workers int) {
 func (pm *PinManager) pinWorker() {
 	for op := range pm.pinQueueOut {
 		if err := pm.doPinning(op); err != nil {
-			log.Errorf("pinning queue error: %s", err)
+			log.Errorf("pinning queue error: %+v", err)
 		}
 		pm.pinComplete <- op
 	}

--- a/pinning.go
+++ b/pinning.go
@@ -124,14 +124,14 @@ func (s *Server) doPinning(ctx context.Context, op *pinner.PinningOperation, cb 
 	go func() {
 		// this provide call goes out immediately
 		if err := s.Node.FullRT.Provide(ctx, op.Obj, true); err != nil {
-			log.Infof("provider broadcast failed: %s", err)
+			log.Warnf("provider broadcast failed: %s", err)
 		}
 	}()
 
 	go func() {
 		// this one adds to a queue
 		if err := s.Node.Provider.Provide(op.Obj); err != nil {
-			log.Infof("providing failed: %s", err)
+			log.Warnf("providing failed: %s", err)
 		}
 	}()
 	return nil

--- a/pinning.go
+++ b/pinning.go
@@ -121,19 +121,16 @@ func (s *Server) doPinning(ctx context.Context, op *pinner.PinningOperation, cb 
 		}
 	}
 
-	go func() {
-		// this provide call goes out immediately
-		if err := s.Node.FullRT.Provide(ctx, op.Obj, true); err != nil {
-			log.Warnf("provider broadcast failed: %s", err)
-		}
-	}()
+	// this provide call goes out immediately
+	if err := s.Node.FullRT.Provide(ctx, op.Obj, true); err != nil {
+		log.Warnf("provider broadcast failed: %s", err)
+	}
 
-	go func() {
-		// this one adds to a queue
-		if err := s.Node.Provider.Provide(op.Obj); err != nil {
-			log.Warnf("providing failed: %s", err)
-		}
-	}()
+	// this one adds to a queue
+	if err := s.Node.Provider.Provide(op.Obj); err != nil {
+		log.Warnf("providing failed: %s", err)
+	}
+
 	return nil
 }
 

--- a/pinning.go
+++ b/pinning.go
@@ -703,7 +703,6 @@ func (s *Server) handleAddPin(e echo.Context, u *User) error {
 	if err != nil {
 		return err
 	}
-
 	status.Pin.Meta = pin.Meta
 
 	return e.JSON(202, status)

--- a/pinning.go
+++ b/pinning.go
@@ -121,16 +121,19 @@ func (s *Server) doPinning(ctx context.Context, op *pinner.PinningOperation, cb 
 		}
 	}
 
-	// this provide call goes out immediately
-	if err := s.Node.FullRT.Provide(ctx, op.Obj, true); err != nil {
-		log.Infof("provider broadcast failed: %s", err)
-	}
+	go func() {
+		// this provide call goes out immediately
+		if err := s.Node.FullRT.Provide(ctx, op.Obj, true); err != nil {
+			log.Infof("provider broadcast failed: %s", err)
+		}
+	}()
 
-	// this one adds to a queue
-	if err := s.Node.Provider.Provide(op.Obj); err != nil {
-		log.Infof("providing failed: %s", err)
-	}
-
+	go func() {
+		// this one adds to a queue
+		if err := s.Node.Provider.Provide(op.Obj); err != nil {
+			log.Infof("providing failed: %s", err)
+		}
+	}()
 	return nil
 }
 
@@ -703,7 +706,7 @@ func (s *Server) handleAddPin(e echo.Context, u *User) error {
 	if err != nil {
 		return err
 	}
-	
+
 	status.Pin.Meta = pin.Meta
 
 	return e.JSON(202, status)


### PR DESCRIPTION
When looking at the logs on Grafana, I notice we have so many `context canceled` errors when pinning contents.

<img width="1262" alt="Screenshot 2022-05-10 at 22 11 29" src="https://user-images.githubusercontent.com/13554411/167722830-1ad532fb-e172-495d-a6ec-e131e934cfba.png">

Currently, It is hard to tell why this is happening. This PR makes some changes to wrap the errors with additional context, so we can easily trace what is going on, so as to provide a fix if one is required.