### PR TITLE
Feat/support both verified and unverified deal making

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Then run:
 ./estuary --datadir=/path/to/storage --database=IF-YOU-NEED-THIS --logging
 ```
 
+NOTE: Estuary makes only verified deals by default and this requires the wallet address to have datacap(see https://verify.glif.io/). To make deals without datacap, it will require the wallet to have FIL, and the run command will need the `--verified-deal` option set to `false`.
+
+```sh
+./estuary --datadir=/path/to/storage --database=IF-YOU-NEED-THIS --logging --verified-deal=false
+```
+
 ## Running as daemon with Systemd
 
 The Makefile has a target that will install a generic but workable systemd service for estuary.

--- a/config/deal.go
+++ b/config/deal.go
@@ -3,4 +3,5 @@ package config
 type Deal struct {
 	FailOnTransferFailure bool `json:",omitempty"`
 	Disable               bool `json:",omitempty"`
+	Verified              bool `json:",omitempty"`
 }

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -59,6 +59,7 @@ func NewEstuary() *Estuary {
 		DealConfig: Deal{
 			Disable:               false,
 			FailOnTransferFailure: false,
+			Verified:              true,
 		},
 
 		ContentConfig: Content{

--- a/handlers.go
+++ b/handlers.go
@@ -2907,7 +2907,7 @@ func (s *Server) handleGetViewer(c echo.Context, u *User) error {
 		Miners:   s.getMinersOwnedByUser(u),
 		Settings: util.UserSettings{
 			Replication:           defaultReplication,
-			Verified:              true,
+			Verified:              s.CM.VerifiedDeal,
 			DealDuration:          dealDuration,
 			MaxStagingWait:        maxStagingZoneLifetime,
 			FileStagingThreshold:  int64(individualDealThreshold),

--- a/main.go
+++ b/main.go
@@ -194,6 +194,8 @@ func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Estuary
 			cfg.DisableFilecoinStorage = cctx.Bool("no-storage-cron")
 		case "disable-deal-making":
 			cfg.DealConfig.Disable = cctx.Bool("disable-deal-making")
+		case "verified-deal":
+			cfg.DealConfig.Verified = cctx.Bool("verified-deal")
 		case "fail-deals-on-transfer-failure":
 			cfg.DealConfig.FailOnTransferFailure = cctx.Bool("fail-deals-on-transfer-failure")
 		case "disable-local-content-adding":
@@ -311,6 +313,11 @@ func main() {
 			Name:  "disable-deal-making",
 			Usage: "do not create any new deals (existing deals will still be processed)",
 			Value: cfg.DealConfig.Disable,
+		},
+		&cli.BoolFlag{
+			Name:  "verified-deal",
+			Usage: "Defaults to makes deals as verified deal using datacap. Set to false to make deal as regular deal using real FIL(no datacap)",
+			Value: cfg.DealConfig.Verified,
 		},
 		&cli.BoolFlag{
 			Name:  "disable-content-adding",
@@ -531,6 +538,7 @@ func main() {
 		cm.FailDealOnTransferFailure = cfg.DealConfig.FailOnTransferFailure
 
 		cm.isDealMakingDisabled = cfg.DealConfig.Disable
+		cm.VerifiedDeal = cfg.DealConfig.Verified
 		cm.contentAddingDisabled = cfg.ContentConfig.DisableGlobalAdding
 		cm.localContentAddingDisabled = cfg.ContentConfig.DisableLocalAdding
 


### PR DESCRIPTION
Estuary currently only makes verified deals (which requires a data cap). 

This PR allows Estuary to be more flexible, to enable making verified/unverified deals

Context: https://filecoinproject.slack.com/archives/C016APFREQK/p1652148940464009