### PR TITLE
verify should support identical CIDs with different versions and base

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1331,10 +1331,11 @@ func (s *Server) handleGetContentByCid(c echo.Context) error {
 		return err
 	}
 
-	// TODO: check both cidv0 and v1 for dag-pb cids
+	v0 := cid.NewCidV0(obj.Hash())
+	v1 := cid.NewCidV1(obj.Prefix().Codec, obj.Hash())
 
 	var contents []Content
-	if err := s.DB.Find(&contents, "cid = ? and active", obj.Bytes()).Error; err != nil {
+	if err := s.DB.Debug().Find(&contents, "(cid=? or cid=?) and active", v0.Bytes(), v1.Bytes()).Error; err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently, the `verify-cid` endpoint only supports `cidv1` see ([bug: Verify doesn't match against identical CIDs with different versions](https://github.com/application-research/estuary/issues/81)). This PR will allow support for both `cidv1` (and it's various base) and `cidv0`.

Below are test for the same CID for;

cidv1
<img width="750" alt="Screenshot 2022-05-18 at 15 51 27" src="https://user-images.githubusercontent.com/13554411/169094222-d4c75c46-7791-462f-a0f6-df3bcb512bb5.png">

cidv1 base64url
<img width="782" alt="Screenshot 2022-05-18 at 15 50 22" src="https://user-images.githubusercontent.com/13554411/169094466-be719676-5559-4b40-a12e-ac24ae280b58.png">

cidv0
<img width="769" alt="Screenshot 2022-05-18 at 15 50 52" src="https://user-images.githubusercontent.com/13554411/169094357-49a79f5a-a934-4e85-aa8e-c8bb74abceb0.png">




closes https://github.com/application-research/estuary/issues/81