### PR TITLE
Fix/report-correct-error-when-shuttle-is-not-online

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -321,6 +322,10 @@ func main() {
 		db, err := setupDatabase(cfg.DatabaseConnString)
 		if err != nil {
 			return err
+		}
+
+		if len(cfg.NodeConfig.AnnounceAddrs) == 0 && !cfg.Dev {
+			return errors.New("running shuttle in prod mode requires announce-addr")
 		}
 
 		init := Initializer{&cfg.NodeConfig, db}

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -323,10 +323,6 @@ func main() {
 			return err
 		}
 
-		if len(cfg.NodeConfig.AnnounceAddrs) == 0 && !cfg.Dev {
-			return errors.New("running shuttle in prod mode requires announce-addr")
-		}
-
 		init := Initializer{&cfg.NodeConfig, db}
 
 		nd, err := node.Setup(context.TODO(), init)

--- a/replication.go
+++ b/replication.go
@@ -2204,6 +2204,11 @@ func (cm *ContentManager) sendProposalV120(ctx context.Context, contentLoc strin
 			return nil, false, xerrors.Errorf("preparing for data request: %w", err)
 		}
 	} else {
+		// first check if shuttle is online
+		if !cm.shuttleIsOnline(contentLoc) {
+			return nil, false, xerrors.Errorf("shuttle is not online: %s", contentLoc)
+		}
+
 		addrInfo := cm.shuttleAddrInfo(contentLoc)
 		// TODO: This is the address that the shuttle reports to the Estuary
 		// primary node, but is it ok if it's also the address reported
@@ -2211,7 +2216,7 @@ func (cm *ContentManager) sendProposalV120(ctx context.Context, contentLoc strin
 		// that mean that messages from Estuary primary node would go through
 		// public internet to get to shuttle?
 		if addrInfo == nil || len(addrInfo.Addrs) == 0 {
-			return nil, false, xerrors.Errorf("shuttle is not online: %s", contentLoc)
+			return nil, false, xerrors.Errorf("no address found for shuttle: %s", contentLoc)
 		}
 		addrstr := addrInfo.Addrs[0].String() + "/p2p/" + addrInfo.ID.String()
 		announceAddr, err = multiaddr.NewMultiaddr(addrstr)

--- a/replication.go
+++ b/replication.go
@@ -2211,7 +2211,7 @@ func (cm *ContentManager) sendProposalV120(ctx context.Context, contentLoc strin
 		// that mean that messages from Estuary primary node would go through
 		// public internet to get to shuttle?
 		if addrInfo == nil || len(addrInfo.Addrs) == 0 {
-			return nil, false, xerrors.Errorf("no announce address found for shuttle: %s", contentLoc)
+			return nil, false, xerrors.Errorf("shuttle is not online: %s", contentLoc)
 		}
 		addrstr := addrInfo.Addrs[0].String() + "/p2p/" + addrInfo.ID.String()
 		announceAddr, err = multiaddr.NewMultiaddr(addrstr)


### PR DESCRIPTION
- For boost deals, if shuttle addr is nil, it means shuttle is not online - the error should say so