### PR TITLE
Fix isValidAuth function

### DIFF
--- a/util/http.go
+++ b/util/http.go
@@ -60,8 +60,8 @@ func isValidAuth(authStr string) bool {
 	}
 	// only get the uuid from the string
 	uuidStr := strings.ReplaceAll(authStr, "SECRET", "")
-	uuidStr = strings.ReplaceAll(authStr, "EST", "")
-	uuidStr = strings.ReplaceAll(authStr, "ARY", "")
+	uuidStr = strings.ReplaceAll(uuidStr, "EST", "")
+	uuidStr = strings.ReplaceAll(uuidStr, "ARY", "")
 
 	// check if uuid is valid
 	_, err := uuid.Parse(uuidStr)

--- a/util/http.go
+++ b/util/http.go
@@ -97,13 +97,15 @@ func ExtractAuth(c echo.Context) (string, error) {
 		}
 	}
 
-	//	if auth is not missing, check format first before extracting
-	if !isValidAuth(parts[1]) {
-		return "", &HttpError{
-			Code:    403,
-			Message: ERR_WRONG_AUTH_FORMAT,
+	/*
+		//	if auth is not missing, check format first before extracting
+		if !isValidAuth(parts[1]) {
+			return "", &HttpError{
+				Code:    403,
+				Message: ERR_WRONG_AUTH_FORMAT,
+			}
 		}
-	}
+	*/
 
 	return parts[1], nil
 }

--- a/util/http.go
+++ b/util/http.go
@@ -97,15 +97,13 @@ func ExtractAuth(c echo.Context) (string, error) {
 		}
 	}
 
-	/*
-		//	if auth is not missing, check format first before extracting
-		if !isValidAuth(parts[1]) {
-			return "", &HttpError{
-				Code:    403,
-				Message: ERR_WRONG_AUTH_FORMAT,
-			}
+	//	if auth is not missing, check format first before extracting
+	if !isValidAuth(parts[1]) {
+		return "", &HttpError{
+			Code:    403,
+			Message: ERR_WRONG_AUTH_FORMAT,
 		}
-	*/
+	}
 
 	return parts[1], nil
 }

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type isValidAuthTest struct {
+	inpAuthStr string
+	expected   bool
+}
+
+var validAuthTests = []isValidAuthTest{
+	isValidAuthTest{"ESTsomethingARY", false},
+	isValidAuthTest{"ESTsomething", false},
+	isValidAuthTest{"EST6054be81-a71f-436a-a09d-33338bbc9066dARY", false}, // invalid uuid length
+	isValidAuthTest{"EST6054be81-a71f-436a-a09d-8e68bbc9066dARY", true},
+	isValidAuthTest{"SECRET8cd64b42-4b71-457d-bbf7-a9a94fc04909SECRET", true},
+}
+
+func TestIsValidAuth(t *testing.T) {
+	//check your test scenario here
+	for _, test := range validAuthTests {
+		assert.Equal(t, isValidAuth(test.inpAuthStr), test.expected)
+	}
+}


### PR DESCRIPTION
#204 introduces a bug where it doesn't correctly trim the `EST`, `ARY` and `SECRET` parts of an auth string before calling `uuid.Parse`, and thus causes it to fail. This fixes that.