### PR TITLE
handle shuttle getViewer error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /bsget
 /benchest
 /estuary-shuttle
+/shuttle-proxy
 
 estuary-blocks/*
 blocks/*

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ CLEAN+=build/.update-modules
 # export CGO_CFLAGS+=-Wno-stringop-overflow
 
 .PHONY: build
-build: deps estuary shuttle barge benchest bsget
+build: deps estuary shuttle barge benchest bsget shuttle-proxy
 
 .PHONY: deps
 deps: $(BUILD_DEPS)
@@ -88,6 +88,11 @@ BINS+=benchest
 bsget:
 	go build $(GOFLAGS) -o bsget ./cmd/bsget
 BINS+=bsget
+
+.PHONY: shuttle-proxy
+shuttle-proxy:
+	go build $(GOFLAGS) -o shuttle-proxy ./cmd/shuttle-proxy
+BINS+=shuttle-proxy
 
 .PHONY: install
 install: estuary


### PR DESCRIPTION
Currently, shuttle-proxy this https://github.com/application-research/estuary/blob/master/cmd/shuttle-proxy/main.go#L105 does not return any error even if the `getViewer` returns an error. This causes it to panic at https://github.com/application-research/estuary/blob/master/cmd/shuttle-proxy/main.go#L132. 

This PR makes sure the above does not happen. It also adds shuttle-proxy to build (I could easily test with this).