### PR TITLE
properly count file size

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2857,9 +2857,10 @@ type userStatsResponse struct {
 // @Router       /user/stats [get]
 func (s *Server) handleGetUserStats(c echo.Context, u *User) error {
 	var stats userStatsResponse
-	if err := s.DB.Model(Content{}).Where("user_id = ?", u.ID).
-		Select("SUM(size) as total_size,COUNT(1) as num_pins").
-		Scan(&stats).Error; err != nil {
+	if err := s.DB.Raw(` SELECT
+						(SELECT SUM(size) FROM contents where user_id = ? AND aggregated_in = 0) as total_size,
+						(SELECT COUNT(1) FROM contents where user_id = ?) as num_pins`,
+		u.ID, u.ID).Scan(&stats).Error; err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently, the API response for the UI that shows the files incorrectly doubles the file size. This is because it counts both aggregates and their contents. This PR fixes this issue by properly counting content sizes for all 3 possible scenarios estuary can have;

1 - When content is not aggregated and not a split content (`aggregated_in = 0`) - content size is counted directly.
2 - When content is aggregated (`aggregated_in > 0`) - the aggregate content size is counted
3 - When content is a split - it will take either option 1 or 2 - so the above rules will apply

before
<img width="1261" alt="Screenshot 2022-05-24 at 15 17 39" src="https://user-images.githubusercontent.com/13554411/170058162-a7e43b76-37b9-499f-826a-d733f8bf8dc0.png">

After
<img width="1254" alt="Screenshot 2022-05-24 at 15 15 39" src="https://user-images.githubusercontent.com/13554411/170058190-6e1e05e5-1db6-4c29-b49c-a9a1fd2dcd80.png">


closes https://github.com/application-research/estuary-www/issues/38