### PR TITLE
Do not double log echo HTTP errors

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -96,34 +96,7 @@ func (s *Server) ServeAPI(srv string, logging bool, lsteptok string, cachedir st
 	}
 
 	e.Use(s.tracingMiddleware)
-	e.HTTPErrorHandler = func(err error, ctx echo.Context) {
-		var herr *util.HttpError
-		if xerrors.As(err, &herr) {
-			res := map[string]string{
-				"error": herr.Message,
-			}
-			if herr.Details != "" {
-				res["details"] = herr.Details
-			}
-			ctx.JSON(herr.Code, res)
-			return
-		}
-
-		var echoErr *echo.HTTPError
-		if xerrors.As(err, &echoErr) {
-			ctx.JSON(echoErr.Code, map[string]interface{}{
-				"error": echoErr.Message,
-			})
-			return
-		}
-
-		log.Errorf("handler error: %s", err)
-
-		// TODO: returning all errors out to the user smells potentially bad
-		_ = ctx.JSON(500, map[string]interface{}{
-			"error": err.Error(),
-		})
-	}
+	e.HTTPErrorHandler = util.ErrorHandler
 
 	e.GET("/debug/pprof/:prof", serveProfile)
 	e.GET("/debug/cpuprofile", serveCpuProfile)

--- a/util/http.go
+++ b/util/http.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -137,7 +138,6 @@ type ViewerResponse struct {
 }
 
 func ErrorHandler(err error, ctx echo.Context) {
-	log.Errorf("handler error: %s", err)
 	var herr *HttpError
 	if xerrors.As(err, &herr) {
 		res := map[string]string{
@@ -146,6 +146,8 @@ func ErrorHandler(err error, ctx echo.Context) {
 		if herr.Details != "" {
 			res["details"] = herr.Details
 		}
+
+		log.Errorf("handler error: %s", err)
 		ctx.JSON(herr.Code, res)
 		return
 	}
@@ -158,8 +160,8 @@ func ErrorHandler(err error, ctx echo.Context) {
 		return
 	}
 
-	// TODO: returning all errors out to the user smells potentially bad
+	log.Errorf("handler error: %s", err)
 	_ = ctx.JSON(500, map[string]interface{}{
-		"error": err.Error(),
+		"error": http.StatusText(http.StatusInternalServerError),
 	})
 }


### PR DESCRIPTION
Currently, echo HTTP error floods Grafana and gets in the way when investigating issues. I do not think we should be logging echo HTTP errors explicitly since these errors are already logged by the logging middleware and so it is redundant and misleading (since it shows up as `ERROR` e.g `No Content`). 

E.g - all of this error is not useful - took me days to know what is going on (and it is not actionable)
<img width="1269" alt="Screenshot 2022-05-24 at 17 49 56" src="https://user-images.githubusercontent.com/13554411/170089839-cd299244-8625-40d6-92a1-2d60efba723c.png">


This PR is a minor refactor and moves explicit logging to non-echo HTTP error handlers