### PR TITLE
increase providing timeout to 15secs

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1144,7 +1144,7 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 }
 
 func (s *Shuttle) Provide(ctx context.Context, c cid.Cid) error {
-	subCtx, cancel := context.WithTimeout(ctx, time.Second*10)
+	subCtx, cancel := context.WithTimeout(ctx, time.Second*15)
 	defer cancel()
 
 	if s.Node.FullRT.Ready() {


### PR DESCRIPTION
Right now, the providing context timeout of 10 secs, is not sufficient. After testing, it turns out 15secs is just enough. 

Closes https://github.com/application-research/estuary/issues/228