### PR TITLE
Remove leftover testing code from bsget

### DIFF
--- a/cmd/bsget/main.go
+++ b/cmd/bsget/main.go
@@ -14,7 +14,6 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	rhelp "github.com/libp2p/go-libp2p-routing-helpers"
 	"github.com/multiformats/go-multiaddr"
@@ -78,17 +77,7 @@ VERSION:
 
 		// set up libp2p node...
 		ctx := context.Background()
-		bytePk, err := crypto.ConfigDecodeKey("CAESQHHiijN4B16MLqKoQK/VgCBXy8fJ0PbLZWlr2x5HGGtxO/qPL96PDoD399cN2doCxG069r+wgs1rcOOPC8l+4Dk=")
-		if err != nil {
-			return err
-		}
-
-		pk, err := crypto.UnmarshalPrivateKey(bytePk)
-		if err != nil {
-			return err
-		}
-
-		h, err := libp2p.New(libp2p.Identity(pk))
+		h, err := libp2p.New()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I accidentally left some code that I was using to test autoretrieve on the `bsget` improvement branch (which got merged on #243 ). Removing it.

Context/curiosity: when testing autoretrieve I wanted a way to only see requests coming from my bsget peer so I could test it. The leftover code sets a predictable peer id so that on autoretrieve I could do something along the lines of:

```
if peerID != "bsget_peer_id" {
    return; // ignore if it's not bsget
}
```