### PR TITLE
try to provide even if origin connection fails

### DIFF
--- a/pinning.go
+++ b/pinning.go
@@ -99,21 +99,10 @@ func (s *Server) doPinning(ctx context.Context, op *pinner.PinningOperation, cb 
 	ctx, span := s.tracer.Start(ctx, "doPinning")
 	defer span.End()
 
-	connectedToAtLeastOne := false
 	for _, pi := range op.Peers {
-		if err := s.Node.Host.Connect(ctx, pi); err != nil && s.Node.Host.ID() != pi.ID {
+		if err := s.Node.Host.Connect(ctx, pi); err != nil {
 			log.Warnf("failed to connect to origin node for pinning operation: %s", err)
-		} else {
-			//	Check if it's trying to connect to itself since we only want to check if the
-			//	the connection is between the host and the external/other peers.
-			connectedToAtLeastOne = true
 		}
-	}
-
-	//	If it can't connect to any legitimate provider peers, then we fail the entire operation.
-	if !connectedToAtLeastOne {
-		log.Errorf("unable to connect to any of the provider peers for pinning operation")
-		return nil
 	}
 
 	bserv := blockservice.New(s.Node.Blockstore, s.Node.Bitswap)


### PR DESCRIPTION
This PR is reverting https://github.com/application-research/estuary/issues/182. When providing content, estuary should try to provide content even if the origins connection fails based on https://ipfs.github.io/pinning-services-api-spec/#section/Provider-hints/Pin.origins. 

The UI does not send peers (which is optional based on the pinning spec), from https://github.com/application-research/estuary/issues/182, Estuary will fail when users call the content upload by ipfs. This PR reverts it so everything works as expected


