### PR TITLE
Only upload content with size over defaultContentSizeLimit if splitting is enabled

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1098,7 +1098,7 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 		return err
 	}
 
-	// if splitting is disabled and uploaded content size is over content size limit
+	// if splitting is disabled and uploaded content size is greater than content size limit
 	// reject the upload, as it will only get stuck and deals will never be made for it
 	if !u.FlagSplitContent() && mpf.Size > util.DefaultContentSizeLimit {
 		return &util.HttpError{

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1220,7 +1220,7 @@ func (s *Shuttle) handleAddCar(c echo.Context, u *User) error {
 		}
 	}
 
-	// if splitting is disabled and uploaded content size is over content size limit
+	// if splitting is disabled and uploaded content size is greater than content size limit
 	// reject the upload, as it will only get stuck and deals will never be made for it
 	if !u.FlagSplitContent() {
 		bdWriter := &bytes.Buffer{}

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -850,6 +850,12 @@ type User struct {
 	AuthToken       string `json:"-"` // this struct shouldnt ever be serialized, but just in case...
 	StorageDisabled bool
 	AuthExpiry      time.Time
+
+	Flags int
+}
+
+func (u *User) FlagSplitContent() bool {
+	return u.Flags&8 != 0
 }
 
 func (d *Shuttle) checkTokenAuth(token string) (*User, error) {
@@ -906,6 +912,7 @@ func (d *Shuttle) checkTokenAuth(token string) (*User, error) {
 		AuthToken:       token,
 		AuthExpiry:      out.AuthExpiry,
 		StorageDisabled: out.Settings.ContentAddingDisabled,
+		Flags:           out.Settings.Flags,
 	}
 
 	d.authCache.Add(token, usr)
@@ -1091,12 +1098,21 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 		return err
 	}
 
+	// if splitting is disabled and uploaded content size is over content size limit
+	// reject the upload, as it will only get stuck and deals will never be made for it
+	if !u.FlagSplitContent() && mpf.Size > util.DefaultContentSizeLimit {
+		return &util.HttpError{
+			Code:    400,
+			Message: util.ERR_CONTENT_SIZE_OVER_LIMIT,
+			Details: fmt.Sprintf("content size %d bytes, is over upload size limit of %d bytes, and content splitting is not enabled, please reduce the content size", mpf.Size, util.DefaultContentSizeLimit),
+		}
+	}
+
 	fname := mpf.Filename
 	fi, err := mpf.Open()
 	if err != nil {
 		return err
 	}
-
 	defer fi.Close()
 
 	cic := util.ContentInCollection{
@@ -1202,6 +1218,28 @@ func (s *Shuttle) handleAddCar(c echo.Context, u *User) error {
 			Code:    400,
 			Message: util.ERR_CONTENT_ADDING_DISABLED,
 		}
+	}
+
+	// if splitting is disabled and uploaded content size is over content size limit
+	// reject the upload, as it will only get stuck and deals will never be made for it
+	if !u.FlagSplitContent() {
+		bdWriter := &bytes.Buffer{}
+		bdReader := io.TeeReader(c.Request().Body, bdWriter)
+
+		bdSize, err := io.Copy(ioutil.Discard, bdReader)
+		if err != nil {
+			return err
+		}
+
+		if bdSize > util.DefaultContentSizeLimit {
+			return &util.HttpError{
+				Code:    400,
+				Message: util.ERR_CONTENT_SIZE_OVER_LIMIT,
+				Details: fmt.Sprintf("content size %d bytes, is over upload size of limit %d bytes, and content splitting is not enabled, please reduce the content size", bdSize, util.DefaultContentSizeLimit),
+			}
+		}
+
+		c.Request().Body = ioutil.NopCloser(bdWriter)
 	}
 
 	bsid, bs, err := s.StagingMgr.AllocNew()

--- a/handlers.go
+++ b/handlers.go
@@ -546,7 +546,7 @@ func (s *Server) handleAddCar(c echo.Context, u *User) error {
 		}
 	}
 
-	// if splitting is disabled and uploaded content size is over content size limit
+	// if splitting is disabled and uploaded content size is greater than content size limit
 	// reject the upload, as it will only get stuck and deals will never be made for it
 	if !u.FlagSplitContent() {
 		bdWriter := &bytes.Buffer{}

--- a/handlers.go
+++ b/handlers.go
@@ -546,6 +546,28 @@ func (s *Server) handleAddCar(c echo.Context, u *User) error {
 		}
 	}
 
+	// if splitting is disabled and uploaded content size is over content size limit
+	// reject the upload, as it will only get stuck and deals will never be made for it
+	if !u.FlagSplitContent() {
+		bdWriter := &bytes.Buffer{}
+		bdReader := io.TeeReader(c.Request().Body, bdWriter)
+
+		bdSize, err := io.Copy(ioutil.Discard, bdReader)
+		if err != nil {
+			return err
+		}
+
+		if bdSize > util.DefaultContentSizeLimit {
+			return &util.HttpError{
+				Code:    400,
+				Message: util.ERR_CONTENT_SIZE_OVER_LIMIT,
+				Details: fmt.Sprintf("content size %d bytes, is over upload size of limit %d bytes, and content splitting is not enabled, please reduce the content size", bdSize, util.DefaultContentSizeLimit),
+			}
+		}
+
+		c.Request().Body = ioutil.NopCloser(bdWriter)
+	}
+
 	bsid, sbs, err := s.StagingMgr.AllocNew()
 	if err != nil {
 		return err
@@ -702,12 +724,21 @@ func (s *Server) handleAdd(c echo.Context, u *User) error {
 	if err != nil {
 		return err
 	}
-
 	defer form.RemoveAll()
 
 	mpf, err := c.FormFile("data")
 	if err != nil {
 		return err
+	}
+
+	// if splitting is disabled and uploaded content size is over content size limit
+	// reject the upload, as it will only get stuck and deals will never be made for it
+	if !u.FlagSplitContent() && mpf.Size > s.CM.contentSizeLimit {
+		return &util.HttpError{
+			Code:    400,
+			Message: util.ERR_CONTENT_SIZE_OVER_LIMIT,
+			Details: fmt.Sprintf("content size %d bytes, is over upload size limit of %d bytes, and content splitting is not enabled, please reduce the content size", mpf.Size, s.CM.contentSizeLimit),
+		}
 	}
 
 	filename := mpf.Filename
@@ -2928,6 +2959,7 @@ func (s *Server) handleGetViewer(c echo.Context, u *User) error {
 			ContentAddingDisabled: s.CM.contentAddingDisabled || u.StorageDisabled,
 			DealMakingDisabled:    s.CM.dealMakingDisabled(),
 			UploadEndpoints:       uep,
+			Flags:                 u.Flags,
 		},
 		AuthExpiry: u.authToken.Expiry,
 	})

--- a/handlers.go
+++ b/handlers.go
@@ -731,7 +731,7 @@ func (s *Server) handleAdd(c echo.Context, u *User) error {
 		return err
 	}
 
-	// if splitting is disabled and uploaded content size is over content size limit
+	// if splitting is disabled and uploaded content size is greater than content size limit
 	// reject the upload, as it will only get stuck and deals will never be made for it
 	if !u.FlagSplitContent() && mpf.Size > s.CM.contentSizeLimit {
 		return &util.HttpError{

--- a/util/content.go
+++ b/util/content.go
@@ -12,6 +12,8 @@ import (
 	unixfs "github.com/ipfs/go-unixfs"
 )
 
+const DefaultContentSizeLimit = 34_000_000_000
+
 type ContentType int64
 
 const (

--- a/util/http.go
+++ b/util/http.go
@@ -31,6 +31,7 @@ const (
 	ERR_INVITE_ALREADY_USED     = "ERR_INVITE_ALREADY_USED"
 	ERR_CONTENT_ADDING_DISABLED = "ERR_CONTENT_ADDING_DISABLED"
 	ERR_INVALID_INPUT           = "ERR_INVALID_INPUT"
+	ERR_CONTENT_SIZE_OVER_LIMIT = "ERR_CONTENT_SIZE_OVER_LIMIT"
 )
 
 type HttpError struct {
@@ -40,7 +41,10 @@ type HttpError struct {
 }
 
 func (he HttpError) Error() string {
-	return he.Message
+	if he.Details == "" {
+		return he.Message
+	}
+	return he.Message + ": " + he.Details
 }
 
 const (
@@ -122,6 +126,7 @@ type UserSettings struct {
 	DealMakingDisabled    bool `json:"dealMakingDisabled"`
 
 	UploadEndpoints []string `json:"uploadEndpoints"`
+	Flags           int      `json:"flags"`
 }
 
 type ViewerResponse struct {


### PR DESCRIPTION
Right now, when users upload contents with size over https://github.com/application-research/estuary/blob/master/replication.go#L55 and splitting is not enabled, such content gets stuck as deals will never be made for them leading to a not so good UX e.g https://filecoinproject.slack.com/archives/C016APFREQK/p1647824002708279

This PR tries to improve the UX by verifying that if splitting is not turned on, and the user is uploading content over the `defaultContentSizeLimit`, then we prevent the upload and notify the user.

Both primary and shuttle have been tested on both `add` and `add-car` endpoints for when content is over and under the defaultContentSizeLimit