### PR TITLE
Fix collection inconsistencies on /content/add

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1100,8 +1100,8 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 	defer fi.Close()
 
 	cic := util.ContentInCollection{
-		CollectionID:   c.FormValue("coluuid"),
-		CollectionPath: c.FormValue("colpath"),
+		CollectionID:   c.QueryParam("coluuid"),
+		CollectionPath: c.QueryParam("colpath"),
 	}
 
 	bsid, bs, err := s.StagingMgr.AllocNew()
@@ -1373,6 +1373,7 @@ func (s *Shuttle) addrsForShuttle() []string {
 }
 
 func (s *Shuttle) createContent(ctx context.Context, u *User, root cid.Cid, fname string, cic util.ContentInCollection) (uint, error) {
+	log.Debugf("createContent> cid: %v, filename: %s, collection: %+v", root, fname, cic)
 
 	data, err := json.Marshal(util.ContentCreateBody{
 		ContentInCollection: cic,

--- a/collections.go
+++ b/collections.go
@@ -17,7 +17,7 @@ type Collection struct {
 type CollectionRef struct {
 	ID         uint `gorm:"primaryKey"`
 	CreatedAt  time.Time
-	Collection uint `gorm:"index:,option:CONCURRENTLY"`
-	Content    uint `gorm:"index:,option:CONCURRENTLY"`
-	Path       *string
+	Collection uint    `gorm:"index:,option:CONCURRENTLY; not null"`
+	Content    uint    `gorm:"index:,option:CONCURRENTLY;not null"`
+	Path       *string `gorm:"not null"`
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -24,6 +24,19 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/system/config": {
+            "get": {
+                "description": "This endpoint is used to get system configs.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get systems(estuary/shuttle) config",
+                "responses": {}
+            }
+        },
         "/admin/users": {
             "get": {
                 "description": "This endpoint is used to get all users.",
@@ -333,6 +346,18 @@ const docTemplate = `{
                         "name": "file",
                         "in": "formData",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Collection UUID",
+                        "name": "coluuid",
+                        "in": "path"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Collection path",
+                        "name": "colpath",
+                        "in": "path"
                     }
                 ],
                 "responses": {}

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -17,6 +17,19 @@
   "host": "api.estuary.tech",
   "basePath": "/",
   "paths": {
+    "/admin/system/config": {
+      "get": {
+        "description": "This endpoint is used to get system configs.",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get systems(estuary/shuttle) config",
+        "responses": {}
+      }
+    },
     "/admin/users": {
       "get": {
         "description": "This endpoint is used to get all users.",
@@ -326,6 +339,18 @@
             "name": "file",
             "in": "formData",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "Collection UUID",
+            "name": "coluuid",
+            "in": "path"
+          },
+          {
+            "type": "string",
+            "description": "Collection path",
+            "name": "colpath",
+            "in": "path"
           }
         ],
         "responses": {}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -110,6 +110,15 @@ info:
   title: Estuary API
   version: 0.0.0
 paths:
+  /admin/system/config:
+    get:
+      description: This endpoint is used to get system configs.
+      produces:
+        - application/json
+      responses: {}
+      summary: Get systems(estuary/shuttle) config
+      tags:
+        - admin
   /admin/users:
     get:
       description: This endpoint is used to get all users.
@@ -314,6 +323,14 @@ paths:
           name: file
           required: true
           type: file
+        - description: Collection UUID
+          in: path
+          name: coluuid
+          type: string
+        - description: Collection path
+          in: path
+          name: colpath
+          type: string
       produces:
         - application/json
       responses: {}


### PR DESCRIPTION
Inspired by #168 this PR does the following:
1. fixes `/content/add` so it doesn't create `CollectionRef`s that have a `null` path field
2. changes the database to require a couple fields on `collection_refs` to be not null
3. makes `coluuid` and `colpath` query parameters on `/content/add`, not form values (consistent with other endpoints that use collections)
4. makes `/collections/fs/list` return an empty list instead of `null` when no entries are found