### PR TITLE
chore: added net/addrs for shuttle

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -988,6 +988,7 @@ func (s *Shuttle) ServeAPI() error {
 	e.HTTPErrorHandler = util.ErrorHandler
 
 	e.GET("/health", s.handleHealth)
+	e.GET("/net/addrs", s.handleNetAddrs)
 	e.GET("/viewer", withUser(s.handleGetViewer), s.AuthRequired(util.PermLevelUser))
 
 	e.GET("/gw/:path", func(e echo.Context) error {
@@ -1746,6 +1747,23 @@ func (s *Shuttle) getUpdatePacket() (*drpc.ShuttleUpdate, error) {
 func (s *Shuttle) handleHealth(c echo.Context) error {
 	return c.JSON(200, map[string]string{
 		"status": "ok",
+	})
+}
+
+// handleNetAddrs godoc
+// @Summary      Net Addrs
+// @Description  This endpoint is used to get net addrs
+// @Tags         net
+// @Produce      json
+// @Success      200  {array}  string
+// @Router       /net/addrs [get]
+func (s *Shuttle) handleNetAddrs(c echo.Context) error {
+	id := s.Node.Host.ID()
+	addrs := s.Node.Host.Addrs()
+
+	return c.JSON(200, map[string]interface{}{
+		"id":        id,
+		"addresses": addrs,
 	})
 }
 


### PR DESCRIPTION
# Changes

Simple PR to add /net/addrs for shuttle nodes. This is to allow clients to view the multiaddrs of a shuttle.

# Verification Tests
Tested the endpoint using Postman
![Uploading image.png…]()

