### PR TITLE
Added ARM binary to release and updated archive format to tar.gz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         submodules: true
     - name: Build binary for ${{ matrix.version }}
       run: |
-        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} jlogelin/estuary-base:latest /bin/sh -c "make"
+        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} ${{ secrets.DOCKERHUB_ORG }}/estuary-base:latest /bin/sh -c "make"
     - name: Prepare build artifact for stashing
       run: |
         mkdir release
@@ -62,7 +62,7 @@ jobs:
 
     - name: Build binary for ${{ matrix.version }}
       run: |
-        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} jlogelin/estuary-base:linux-arm64 /bin/sh -c "cp /build/* extern/filecoin-ffi/ && touch extern/filecoin-ffi/.install-filcrypto && make"
+        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} ${{ secrets.DOCKERHUB_ORG }}/estuary-base:linux-arm64 /bin/sh -c "cp /build/* extern/filecoin-ffi/ && touch extern/filecoin-ffi/.install-filcrypto && make"
     
     - name: Prepare build artifact for stashing
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,44 @@ jobs:
       with:
         name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
         path: ./release
+  
+  build_linux_arm64:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        version: ['linux/arm64']
+        include:
+        # add the GO naming convention for OS ($GOOS) and architecture ($GOARCH)
+        # instead of using Linux' naming convention (version items).
+          - version: linux/arm64
+            OS: linux
+            ARCH: arm64
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    
+    - name: Install QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: linux/arm64
 
+    - name: Build binary for ${{ matrix.version }}
+      run: |
+        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} jlogelin/estuary-base:linux-arm64 /bin/sh -c "cp /build/* extern/filecoin-ffi/ && touch extern/filecoin-ffi/.install-filcrypto && make"
+    
+    - name: Prepare build artifact for stashing
+      run: |
+        mkdir release
+        mv ./estuary ./estuary-shuttle ./barge ./benchest ./bsget ./shuttle-proxy ./release
+    
+    # The build artifact can be identified by the trailing sha of the git commit
+    - name: Stash the build artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
+        path: ./release
+  
   build_macos_amd64:
     runs-on: macos-latest
     strategy:
@@ -80,7 +117,7 @@ jobs:
   # And the previous build jobs have been successful
   create_release:
     runs-on: ubuntu-20.04
-    needs: [build_linux_amd64, build_macos_amd64]
+    needs: [build_linux_amd64, build_linux_arm64, build_macos_amd64]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
     - name: Create Release
@@ -111,13 +148,16 @@ jobs:
     needs: create_release # release must be created before this job can start
     strategy:
       matrix:
-        version: ['linux-amd64', 'darwin-amd64']
+        version: ['linux-amd64', 'linux-arm64', 'darwin-amd64']
         # add the GO naming convention for OS ($GOOS) and architecture ($GOARCH)
         # instead of using Linux' naming convention (version items).
         include:
           - version: linux-amd64
             OS: linux
             ARCH: amd64
+          - version: linux-arm64
+            OS: linux
+            ARCH: arm64
           - version: darwin-amd64
             OS: darwin
             ARCH: amd64
@@ -140,9 +180,14 @@ jobs:
         VERSION: ${{ steps.get_version.outputs.VERSION }}
       run: |
         mv ./estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}/* .
-        test -f ./estuary && chmod +x ./estuary #only on linux & darwin needed
-        zip -j estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.zip ./*
-        sha256sum estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.zip > estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.zip.sha256
+        test -f ./estuary && chmod +x ./estuary
+        test -f ./estuary-shuttle && chmod +x ./estuary-shuttle
+        test -f ./barge && chmod +x ./barge
+        test -f ./benchest && chmod +x ./benchest
+        test -f ./bsget && chmod +x ./bsget
+        test -f ./shuttle-proxy && chmod +x ./shuttle-proxy
+        tar -czvf estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.tar.gz ./*
+        sha256sum estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.tar.gz > estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.tar.gz.sha256
     # Download the previously uploaded artifact which contains the release URL
     - name: Retrieve stashed release URL
       uses: actions/download-artifact@v1
@@ -159,10 +204,10 @@ jobs:
       env:
         VERSION: ${{ steps.get_version.outputs.VERSION }}
       run: |
-        echo ::set-output name=ARTIFACT_PATH::./estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.zip
-        echo ::set-output name=ARTIFACT_NAME::estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.zip
-        echo ::set-output name=ARTIFACT_PATH_SHA::./estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.zip.sha256
-        echo ::set-output name=ARTIFACT_NAME_SHA::estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.zip.sha256
+        echo ::set-output name=ARTIFACT_PATH::./estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.tar.gz
+        echo ::set-output name=ARTIFACT_NAME::estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.tar.gz
+        echo ::set-output name=ARTIFACT_PATH_SHA::./estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.tar.gz.sha256
+        echo ::set-output name=ARTIFACT_NAME_SHA::estuary-$VERSION-${{ matrix.OS }}-${{ matrix.ARCH }}.tar.gz.sha256
     # Finally upload the artifact to the corresponding release
     - name: Upload Release Artifact ${{ matrix.version }}
       uses: actions/upload-release-asset@v1.0.1


### PR DESCRIPTION
Added ARM binary build using qemu build step and shrunk-wrapped container image. We have to use qemu emulation because github actions only support amd images natively. Conceptually cool, but in reality this slows full ARM builds down to around 6-8 hours! The current workaround is to prebuild the image builded with `filecoin-ffi` binaries.
