### PR TITLE
chore: remove duplicate fields on ShuttleCreateContentBody

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1421,10 +1421,13 @@ func (s *Shuttle) shuttleCreateContent(ctx context.Context, uid uint, root cid.C
 	}
 
 	data, err := json.Marshal(&util.ShuttleCreateContentBody{
-		Root:         root,
-		Name:         fname,
+		ContentCreateBody: util.ContentCreateBody{
+			Root:     root.String(),
+			Name:     fname,
+			Location: s.shuttleHandle,
+		},
+
 		Collections:  cols,
-		Location:     s.shuttleHandle,
 		DagSplitRoot: dagsplitroot,
 		User:         uid,
 	})

--- a/handlers.go
+++ b/handlers.go
@@ -4926,8 +4926,17 @@ func (s *Server) handleShuttleCreateContent(c echo.Context) error {
 
 	log.Infow("handle shuttle create content", "root", req.Root, "user", req.User, "dsr", req.DagSplitRoot, "name", req.Name)
 
+	root, err := cid.Decode(req.Root)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]interface{}{
+			"error": map[string]interface{}{
+				"reason": err,
+			},
+		})
+	}
+
 	content := &Content{
-		Cid:         util.DbCID{req.Root},
+		Cid:         util.DbCID{root},
 		Name:        req.Name,
 		Active:      false,
 		Pinning:     false,

--- a/util/shuttle.go
+++ b/util/shuttle.go
@@ -45,10 +45,8 @@ type ShuttleListResponse struct {
 }
 
 type ShuttleCreateContentBody struct {
-	Root         cid.Cid  `json:"root"`
-	Name         string   `json:"name"`
+	ContentCreateBody
 	Collections  []string `json:"collections"`
-	Location     string   `json:"location"`
 	DagSplitRoot uint     `json:"dagSplitRoot"`
 	User         uint     `json:"user"`
 }


### PR DESCRIPTION
# Changes

Simple PR to remove duplicate fields on `ShuttleCreateContentBody` and reuse `ContentCreateBody` for it instead

# Resolves

https://github.com/application-research/estuary/issues/266
