### PR TITLE
chore: added extensive lookup function on public/stats - total obj_ref

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -3700,11 +3700,6 @@ func (s *Server) computePublicStats() (*publicStatsResponse, error) {
 		return nil, err
 	}
 
-	//	this can be resource expensive but we are already caching it.
-	if err := s.DB.Table("obj_refs").Count(&stats.TotalObjectsRef).Error; err != nil {
-		return nil, err
-	}
-
 	return &stats, nil
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -3654,10 +3654,11 @@ func (s *Server) handleAdminGetUsers(c echo.Context) error {
 }
 
 type publicStatsResponse struct {
-	TotalStorage     int64 `json:"totalStorage"`
-	TotalFilesStored int64 `json:"totalFiles"`
-	DealsOnChain     int64 `json:"dealsOnChain"`
-	TotalObjectsRef  int64 `json:"totalObjectsRef"`
+	TotalStorage       int64 `json:"totalStorage"`
+	TotalFilesStored   int64 `json:"totalFiles"`
+	DealsOnChain       int64 `json:"dealsOnChain"`
+	TotalObjectsRef    int64 `json:"totalObjectsRef"`
+	TotalBytesUploaded int64 `json:"totalBytesUploaded"`
 }
 
 // handlePublicStats godoc
@@ -3678,6 +3679,7 @@ func (s *Server) handlePublicStats(c echo.Context) error {
 
 	// reuse the original stats and add the ones from the extensive lookup function.
 	val.(*publicStatsResponse).TotalObjectsRef = valExt.(*publicStatsResponse).TotalObjectsRef
+	val.(*publicStatsResponse).TotalBytesUploaded = valExt.(*publicStatsResponse).TotalBytesUploaded
 
 	if err != nil {
 		return err
@@ -3708,6 +3710,10 @@ func (s *Server) computePublicStatsWithExtensiveLookups() (*publicStatsResponse,
 
 	//	this can be resource expensive but we are already caching it.
 	if err := s.DB.Table("obj_refs").Count(&stats.TotalObjectsRef).Error; err != nil {
+		return nil, err
+	}
+
+	if err := s.DB.Table("objects").Select("SUM(size)").Find(&stats.TotalBytesUploaded).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Change
Simple change to add the count of obj_ref and sum of object (size). Added this on a new function to separate the caching expiration. 

# Verification
## Total Objects Response
![image](https://user-images.githubusercontent.com/4479171/174819693-d3413178-64e6-45ce-aa75-8410b82c4120.png)

## Total Objects on DB
![image](https://user-images.githubusercontent.com/4479171/174814391-fa76ee45-7bdd-44e0-8831-6c0430cab393.png)


