### PR TITLE
chore: prevent returning a null deal metrics info

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -3811,8 +3811,15 @@ func (s *Server) handleMetricsDealOnChain(c echo.Context) error {
 	val, err := s.cacher.Get("public/metrics", time.Minute*2, func() (interface{}, error) {
 		return s.computeDealMetrics()
 	})
+
 	if err != nil {
 		return err
+	}
+
+	//	Make sure we don't return a nil val.
+	dealMetrics := val.([]*dealMetricsInfo)
+	if len(dealMetrics) < 1 {
+		return c.JSON(http.StatusOK, []*dealMetricsInfo{})
 	}
 
 	return c.JSON(http.StatusOK, val)


### PR DESCRIPTION
# Changes

Simple PR to ensure that the deals-on-chain (dealMetricsInfo) array will always return an array type. This prevents the frontend `estuary-www` from failing. A fix on on `estuary-www` will accompany this fix to check the return value before rendering the `ecosystem` page.