### PR TITLE
reduce logging

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -1490,7 +1490,7 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 		attribute.Int("deal", int(d.ID)),
 	))
 	defer span.End()
-	log.Infow("checking deal", "miner", d.Miner, "content", d.Content, "dbid", d.ID)
+	log.Debugw("checking deal", "miner", d.Miner, "content", d.Content, "dbid", d.ID)
 
 	maddr, err := d.MinerAddr()
 	if err != nil {
@@ -1542,7 +1542,7 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 
 	// case where deal isnt yet on chain...
 
-	log.Infow("checking deal status", "miner", maddr, "propcid", d.PropCid.CID, "dealUUID", d.DealUUID)
+	log.Debugw("checking deal status", "miner", maddr, "propcid", d.PropCid.CID, "dealUUID", d.DealUUID)
 	subctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 


### PR DESCRIPTION
Logs are spammed by these lines, so dropping level to debug to save disk space.

```why@sv-m1:/data/estuary$ grep -o "estuary/.*.go.*" estuary-logs | cut -f 2 -d "/" | cut -f 1 | sort | uniq -c | sort -nr
  51014 replication.go:1404
   9961 replication.go:1442
   9442 replication.go:374
   6744 shuttle.go:122
   3012 shuttle.go:293
   2083 replication.go:2240
   1778 replication.go:1352
   1323 replication.go:1833
   1188 replication.go:1583
   1014 shuttle.go:288
    515 replication.go:1115
    350 replication.go:554
    320 replication.go:1480
    297 replication.go:866
    295 replication.go:1568
    260 replication.go:379
    226 handlers.go:2043 SLOW SQL >= 200ms
    202 replication.go:2706 SLOW SQL >= 200ms
    200 replication.go:833
    150 replication.go:2204
    122 replication.go:2050
    119 replication.go:1447
     92 pinning.go:641 SLOW SQL >= 200ms
     76 replication.go:1323
     71 ranking.go:70 SLOW SQL >= 200ms
     63 replication.go:1498
     60 pinning.go:151
     56 replication.go:1354
     56 pinning.go:738
     50 replication.go:665
     39 replication.go:1494
     39 handlers.go:76
     38 replication.go:1820
     30 handlers.go:2043 record not found
     28 handlers.go:2675 SLOW SQL >= 200ms
     18 replication.go:580
     17 replication.go:315 SLOW SQL >= 200ms
     15 replication.go:384
     15 handlers.go:2604 SLOW SQL >= 200ms
     15 handlers.go:2600 SLOW SQL >= 200ms
     12 replication.go:2905
     12 pinning.go:745 SLOW SQL >= 200ms
     10 replication.go:2337
      6 replication.go:1302
      5 replication.go:1512
      2 replication.go:369 SLOW SQL >= 200ms
      2 handlers.go:3216
      1 replication.go:687
      1 replication.go:683 SLOW SQL >= 200ms
      1 replication.go:292 SLOW SQL >= 200ms
      1 replication.go:2734 SLOW SQL >= 200ms
      1 replication.go:2170 SLOW SQL >= 200ms
      1 pinning.go:135 SLOW SQL >= 200ms
      1 main.go:343
      1 main.go:339 SLOW SQL >= 200ms
      1 main.go:333
      1 handlers.go:338 SLOW SQL >= 200ms
      1 handlers.go:2276 SLOW SQL >= 200ms```