### PR TITLE
chore: fix the username taken validation

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2880,7 +2880,7 @@ func (s *Server) handleRegisterUser(c echo.Context) error {
 		}
 	}
 
-	if exist != nil {
+	if exist != nil && strings.ToLower(exist.Username) == username {
 		return &util.HttpError{
 			Code:   http.StatusBadRequest,
 			Reason: util.ERR_USERNAME_TAKEN,

--- a/replication.go
+++ b/replication.go
@@ -1612,9 +1612,6 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 		if err != nil || deal == nil {
 			return DEAL_CHECK_UNKNOWN, fmt.Errorf("failed to lookup deal on chain: %w", err)
 		}
-		if deal != nil {
-			return DEAL_CHECK_UNKNOWN, fmt.Errorf("failed to lookup deal on chain: %w", err)
-		}
 
 		pcr, err := cm.lookupPieceCommRecord(content.Cid.CID)
 		if err != nil || pcr == nil {


### PR DESCRIPTION
Fix to validate the user pointer AND the actual username upon registration

# Verification

## Test data. Only 3 users available on my DB.
![image](https://user-images.githubusercontent.com/4479171/176317831-2a9072eb-4c94-4b02-abdb-a3ad15bd900e.png)

## Add new user
Add `alvinreyes2`
![image](https://user-images.githubusercontent.com/4479171/176317899-32aca8f3-1599-4fda-a47d-f8f4d01e0cea.png)

Added `alvinreyes2` successfully with the invite code
![image](https://user-images.githubusercontent.com/4479171/176318054-f31e45f5-b097-4879-90ba-b477d1a36f9f.png)

Tried adding `alvinreyes2` again
![image](https://user-images.githubusercontent.com/4479171/176318142-9e1b0dd1-8eb1-4922-a90c-9859815e4cbd.png)
