### PR TITLE
Sequentially handle shuttle Rpc messages

### DIFF
--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -67,7 +67,7 @@ func (d *Shuttle) sendRpcMessage(ctx context.Context, msg *drpc.Message) error {
 	// if a span is contained in `ctx` its SpanContext will be carried in the message, otherwise
 	// a noopspan context will be carried and ignored by the receiver.
 	msg.TraceCarrier = drpc.NewTraceCarrier(trace.SpanFromContext(ctx).SpanContext())
-	log.Infof("sending rpc message: %s", msg.Op)
+	log.Debugf("sending rpc message: %s", msg.Op)
 	select {
 	case d.outgoing <- msg:
 		return nil

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -155,6 +155,7 @@ type Message struct {
 	Op           string
 	Params       MsgParams
 	TraceCarrier *TraceCarrier `json:",omitempty"`
+	Handle       string
 }
 
 // HasTraceCarrier returns true iff Message `m` contains a trace.

--- a/handlers.go
+++ b/handlers.go
@@ -4399,10 +4399,8 @@ func (s *Server) handleShuttleConnection(c echo.Context) error {
 			}
 
 			go func(msg *drpc.Message) {
-				if err := s.CM.processShuttleMessage(shuttle.Handle, msg); err != nil {
-					log.Errorf("failed to process message from shuttle: %s", err)
-					return
-				}
+				msg.Handle = shuttle.Handle
+				s.CM.IncomingRPCMessages <- msg
 			}(&msg)
 		}
 	}).ServeHTTP(c.Response(), c.Request())

--- a/main.go
+++ b/main.go
@@ -638,6 +638,7 @@ func main() {
 		}
 
 		go cm.ContentWatcher()
+		go cm.handleShuttleMessages(cctx.Context)
 
 		if !cm.contentAddingDisabled {
 			go func() {

--- a/replication.go
+++ b/replication.go
@@ -121,6 +121,8 @@ type ContentManager struct {
 	VerifiedDeal bool
 
 	DisableFilecoinStorage bool
+
+	IncomingRPCMessages chan *drpc.Message
 }
 
 func (cm *ContentManager) isInflight(c cid.Cid) bool {
@@ -338,6 +340,7 @@ func NewContentManager(db *gorm.DB, api api.Gateway, fc *filclient.FilClient, tb
 		Replication:                cfg.Replication,
 		tracer:                     otel.Tracer("replicator"),
 		DisableFilecoinStorage:     cfg.DisableFilecoinStorage,
+		IncomingRPCMessages:        make(chan *drpc.Message),
 	}
 	qm := newQueueManager(func(c uint) {
 		cm.ToCheck <- c

--- a/shuttle.go
+++ b/shuttle.go
@@ -117,6 +117,19 @@ func (cm *ContentManager) registerShuttleConnection(handle string, hello *drpc.H
 
 var ErrNilParams = fmt.Errorf("shuttle message had nil params")
 
+func (cm *ContentManager) handleShuttleMessages(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-cm.IncomingRPCMessages:
+			if err := cm.processShuttleMessage(msg.Handle, msg); err != nil {
+				log.Errorf("failed to process message from shuttle: %s", err)
+			}
+		}
+	}
+}
+
 func (cm *ContentManager) processShuttleMessage(handle string, msg *drpc.Message) error {
 	ctx := context.TODO()
 


### PR DESCRIPTION
This will help make sure the primary node is not overwhelmed while handling messages from all shuttles and writing to DB