### PR TITLE
Mark failed deal data transfer as failed and stop restarting it 

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1655,7 +1655,7 @@ func (d *Shuttle) onPinStatusUpdate(cont uint, location string, status types.Pin
 
 	go func() {
 		if err := d.sendRpcMessage(context.TODO(), &drpc.Message{
-			Op: "UpdatePinStatus",
+			Op: drpc.OP_UpdatePinStatus,
 			Params: drpc.MsgParams{
 				UpdatePinStatus: &drpc.UpdatePinStatus{
 					DBID:   cont,

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -67,7 +67,7 @@ func (d *Shuttle) sendRpcMessage(ctx context.Context, msg *drpc.Message) error {
 	// if a span is contained in `ctx` its SpanContext will be carried in the message, otherwise
 	// a noopspan context will be carried and ignored by the receiver.
 	msg.TraceCarrier = drpc.NewTraceCarrier(trace.SpanFromContext(ctx).SpanContext())
-	log.Infof("sending rpc message: %s", msg.Op)
+	log.Debugf("sending rpc message: %s", msg.Op)
 	select {
 	case d.outgoing <- msg:
 		return nil
@@ -109,7 +109,7 @@ func (d *Shuttle) addPin(ctx context.Context, contid uint, data cid.Cid, user ui
 			// that notification
 
 			if err := d.sendRpcMessage(ctx, &drpc.Message{
-				Op: "UpdatePinStatus",
+				Op: drpc.OP_UpdatePinStatus,
 				Params: drpc.MsgParams{
 					UpdatePinStatus: &drpc.UpdatePinStatus{
 						DBID:   contid,
@@ -650,9 +650,9 @@ func (s *Shuttle) handleRpcRestartTransfer(ctx context.Context, req *drpc.Restar
 		s.sendTransferStatusUpdate(ctx, &drpc.TransferStatus{
 			Chanid: req.ChanID.String(),
 			State:  st,
+			Failed: true,
 		})
 		return fmt.Errorf("cannot restart transfer with status: %d", st.Status)
 	}
-
 	return s.Filc.RestartTransfer(ctx, &req.ChanID)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -1697,10 +1697,9 @@ func (s *Server) handleTransferRestart(c echo.Context) error {
 		return err
 	}
 
-	if err := s.CM.RestartTransfer(ctx, cont.Location, chanid); err != nil {
+	if err := s.CM.RestartTransfer(ctx, cont.Location, chanid, deal.ID); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -820,16 +820,15 @@ func (s *Server) RestartAllTransfersForLocation(ctx context.Context, loc string)
 			continue
 		}
 
-		if err := s.CM.RestartTransfer(ctx, loc, chid); err != nil {
+		if err := s.CM.RestartTransfer(ctx, loc, chid, d.ID); err != nil {
 			log.Errorf("failed to restart transfer: %s", err)
 			continue
 		}
 	}
-
 	return nil
 }
 
-func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chanid datatransfer.ChannelID) error {
+func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chanid datatransfer.ChannelID, dealID uint) error {
 	if loc == "local" {
 		st, err := cm.FilClient.TransferStatus(ctx, &chanid)
 		if err != nil {
@@ -837,12 +836,16 @@ func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chani
 		}
 
 		if util.TransferTerminated(st) {
-			return fmt.Errorf("deal in database as being in progress, but data transfer is terminated: %d", st.Status)
+			if err := cm.DB.Model(contentDeal{}).Where("id = ?", dealID).UpdateColumns(map[string]interface{}{
+				"failed":    true,
+				"failed_at": time.Now(),
+			}).Error; err != nil {
+				return err
+			}
+			return fmt.Errorf("deal in database is in progress, but data transfer is terminated: %d", st.Status)
 		}
-
 		return cm.FilClient.RestartTransfer(ctx, &chanid)
 	}
-
 	return cm.sendRestartTransferCmd(ctx, loc, chanid)
 }
 

--- a/shuttle.go
+++ b/shuttle.go
@@ -340,11 +340,17 @@ func (cm *ContentManager) handleRpcTransferStatus(ctx context.Context, handle st
 			return oerr
 		}
 
-		cm.updateTransferStatus(ctx, handle, cd.ID, &filclient.ChannelState{
+		if err := cm.DB.Model(contentDeal{}).Where("id = ?", cd.ID).UpdateColumns(map[string]interface{}{
+			"failed":    true,
+			"failed_at": time.Now(),
+		}).Error; err != nil {
+			return err
+		}
+
+		param.State = &filclient.ChannelState{
 			Status:  datatransfer.Failed,
 			Message: fmt.Sprintf("failure from shuttle %s: %s", handle, param.Message),
-		})
-		return nil
+		}
 	}
 	cm.updateTransferStatus(ctx, handle, cd.ID, param.State)
 	return nil


### PR DESCRIPTION
Mark failed deal data transfer as `failed` so it won't be picked up perpetually for retry.

closes https://github.com/application-research/estuary/issues/305