### PR TITLE
Properly implement refreshPinQueue on node startup

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1070,7 +1070,7 @@ func (cm *ContentManager) addDatabaseTrackingToContent(ctx context.Context, cont
 	if err != nil {
 		return err
 	}
-	return cm.addObjectsToDatabase(ctx, cont, dserv, root, objects, "local")
+	return cm.addObjectsToDatabase(ctx, cont, dserv, root, objects, util.ContentLocationLocal)
 }
 
 func (cm *ContentManager) addDatabaseTracking(ctx context.Context, u *User, dserv ipld.NodeGetter, root cid.Cid, filename string, replication int) (*Content, error) {
@@ -1084,7 +1084,7 @@ func (cm *ContentManager) addDatabaseTracking(ctx context.Context, u *User, dser
 		Pinning:     true,
 		UserID:      u.ID,
 		Replication: replication,
-		Location:    "local",
+		Location:    util.ContentLocationLocal,
 	}
 
 	if err := cm.DB.Create(content).Error; err != nil {
@@ -4110,7 +4110,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 		fixedAggregateSize = true
 	}
 
-	if cont.Location != "local" {
+	if cont.Location != util.ContentLocationLocal {
 		return c.JSON(http.StatusOK, map[string]interface{}{
 			"deals":              deals,
 			"content":            cont,
@@ -5248,7 +5248,7 @@ func (s *Server) checkGatewayRedirect(proto string, cc cid.Cid, segs []string) (
 		return "", err
 	}
 
-	if cont.Location == "local" {
+	if cont.Location == util.ContentLocationLocal {
 		return "", nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -678,7 +678,7 @@ func main() {
 		go func() {
 			time.Sleep(time.Second * 10)
 
-			if err := s.RestartAllTransfersForLocation(context.TODO(), "local"); err != nil {
+			if err := s.RestartAllTransfersForLocation(cctx.Context, util.ContentLocationLocal); err != nil {
 				log.Errorf("failed to restart transfers: %s", err)
 			}
 		}()
@@ -838,7 +838,7 @@ func (s *Server) RestartAllTransfersForLocation(ctx context.Context, loc string)
 }
 
 func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chanid datatransfer.ChannelID) error {
-	if loc == "local" {
+	if loc == util.ContentLocationLocal {
 		st, err := cm.FilClient.TransferStatus(ctx, &chanid)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -647,16 +647,10 @@ func main() {
 		go cm.ContentWatcher()
 		go cm.handleShuttleMessages(cctx.Context, cfg.ShuttleMessageHandlers) // register workers/handlers to process shuttle rpc messages from a channel(queue)
 
+		// refresh pin queue for local contents
 		if !cm.contentAddingDisabled {
 			go func() {
-				// TODO - resume pin removal request
-
-				// wait for shuttles to reconnect
-				// This is a bit of a hack, and theres probably a better way to
-				// solve this. but its good enough for now
-				time.Sleep(time.Second * 10)
-
-				if err := cm.refreshPinQueue(); err != nil {
+				if err := cm.refreshPinQueue(cctx.Context, util.ContentLocationLocal); err != nil {
 					log.Errorf("failed to refresh pin queue: %s", err)
 				}
 			}()

--- a/offloading.go
+++ b/offloading.go
@@ -142,7 +142,7 @@ func (cm *ContentManager) OffloadContents(ctx context.Context, conts []uint) (in
 			return 0, err
 		}
 
-		if cont.Location == "local" {
+		if cont.Location == util.ContentLocationLocal {
 			local = append(local, cont.ID)
 		} else {
 			remote[cont.Location] = append(remote[cont.Location], cont.ID)
@@ -180,7 +180,7 @@ func (cm *ContentManager) OffloadContents(ctx context.Context, conts []uint) (in
 			}
 
 			for _, c := range children {
-				if cont.Location == "local" {
+				if cont.Location == util.ContentLocationLocal {
 					local = append(local, c.ID)
 				} else {
 					remote[cont.Location] = append(remote[cont.Location], c.ID)

--- a/pinning.go
+++ b/pinning.go
@@ -156,15 +156,15 @@ func (s *Server) PinStatusFunc(contID uint, location string, status types.Pinnin
 }
 
 func (cm *ContentManager) refreshPinQueue(ctx context.Context, contentLoc string) error {
-	log.Debugf("trying to refresh pin queue for %s contents", contentLoc)
+	log.Infof("trying to refresh pin queue for %s contents", contentLoc)
 
-	var toPin []Content
-	if err := cm.DB.Find(&toPin, "pinning and not active and not failed and not aggregate and location=?", contentLoc).Error; err != nil {
+	var contents []Content
+	if err := cm.DB.Find(&contents, "pinning and not active and not failed and not aggregate and location=?", contentLoc).Error; err != nil {
 		return err
 	}
 
 	makeDeal := true
-	for _, c := range toPin {
+	for _, c := range contents {
 		select {
 		case <-ctx.Done():
 			log.Debugf("refresh pin queue canceled for %s contents", contentLoc)

--- a/pinning.go
+++ b/pinning.go
@@ -81,7 +81,7 @@ func (cm *ContentManager) pinStatus(cont Content, origins []*peer.AddrInfo) (*ty
 }
 
 func (cm *ContentManager) pinDelegatesForContent(cont Content) []string {
-	if cont.Location == "local" {
+	if cont.Location == util.ContentLocationLocal {
 		var out []string
 		for _, a := range cm.Host.Addrs() {
 			out = append(out, fmt.Sprintf("%s/p2p/%s", a, cm.Host.ID()))
@@ -247,7 +247,7 @@ func (cm *ContentManager) pinContent(ctx context.Context, user uint, obj cid.Cid
 		}
 	}
 
-	if loc == "local" {
+	if loc == util.ContentLocationLocal {
 		cm.addPinToQueue(cont, origins, replaceID, makeDeal)
 	} else {
 		if err := cm.pinContentOnShuttle(ctx, cont, origins, replaceID, loc, makeDeal); err != nil {
@@ -258,7 +258,7 @@ func (cm *ContentManager) pinContent(ctx context.Context, user uint, obj cid.Cid
 }
 
 func (cm *ContentManager) addPinToQueue(cont Content, peers []*peer.AddrInfo, replaceID uint, makeDeal bool) {
-	if cont.Location != "local" {
+	if cont.Location != util.ContentLocationLocal {
 		log.Errorf("calling addPinToQueue on non-local content")
 	}
 
@@ -372,8 +372,7 @@ func (cm *ContentManager) selectLocationForContent(ctx context.Context, obj cid.
 		if cm.localContentAddingDisabled {
 			return "", fmt.Errorf("no shuttles available and local content adding disabled")
 		}
-
-		return "local", nil
+		return util.ContentLocationLocal, nil
 	}
 
 	// TODO: take into account existing staging zones and their primary
@@ -424,8 +423,7 @@ func (cm *ContentManager) selectLocationForRetrieval(ctx context.Context, cont C
 		if cm.localContentAddingDisabled {
 			return "", fmt.Errorf("no shuttles available and local content adding disabled")
 		}
-
-		return "local", nil
+		return util.ContentLocationLocal, nil
 	}
 
 	// prefer the shuttle the content is already on

--- a/shuttle.go
+++ b/shuttle.go
@@ -37,9 +37,9 @@ type Shuttle struct {
 }
 
 type ShuttleConnection struct {
-	handle  string
-	cmds    chan *drpc.Command
-	closing chan struct{}
+	handle string
+	cmds   chan *drpc.Command
+	ctx    context.Context
 
 	hostname string
 	addrInfo peer.AddrInfo
@@ -54,11 +54,11 @@ type ShuttleConnection struct {
 	pinQueueLength int64
 }
 
-func (dc *ShuttleConnection) sendMessage(ctx context.Context, cmd *drpc.Command) error {
+func (sc *ShuttleConnection) sendMessage(ctx context.Context, cmd *drpc.Command) error {
 	select {
-	case dc.cmds <- cmd:
+	case sc.cmds <- cmd:
 		return nil
-	case <-dc.closing:
+	case <-sc.ctx.Done():
 		return ErrNoShuttleConnection
 	case <-ctx.Done():
 		return ctx.Err()
@@ -89,29 +89,39 @@ func (cm *ContentManager) registerShuttleConnection(handle string, hello *drpc.H
 		return nil, nil, err
 	}
 
-	d := &ShuttleConnection{
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sc := &ShuttleConnection{
 		handle:   handle,
 		address:  hello.Address,
 		addrInfo: hello.AddrInfo,
 		hostname: hello.Host,
 		cmds:     make(chan *drpc.Command, 32),
-		closing:  make(chan struct{}),
+		ctx:      ctx,
 		private:  hello.Private,
 	}
 
-	cm.shuttles[handle] = d
+	// when a shuttle connects, refresh its pin queue
+	if !cm.contentAddingDisabled {
+		go func() {
+			if err := cm.refreshPinQueue(ctx, handle); err != nil {
+				log.Errorf("failed to refresh shuttle: %s pin queue: %s", handle, err)
+			}
+		}()
+	}
 
-	return d.cmds, func() {
-		close(d.closing)
+	cm.shuttles[handle] = sc
+
+	return sc.cmds, func() {
+		cancel()
 		cm.shuttlesLk.Lock()
 		outd, ok := cm.shuttles[handle]
 		if ok {
-			if outd == d {
+			if outd == sc {
 				delete(cm.shuttles, handle)
 			}
 		}
 		cm.shuttlesLk.Unlock()
-
 	}, nil
 }
 
@@ -248,14 +258,14 @@ func (cm *ContentManager) sendShuttleCommand(ctx context.Context, handle string,
 
 func (cm *ContentManager) shuttleIsOnline(handle string) bool {
 	cm.shuttlesLk.Lock()
-	d, ok := cm.shuttles[handle]
+	sc, ok := cm.shuttles[handle]
 	cm.shuttlesLk.Unlock()
 	if !ok {
 		return false
 	}
 
 	select {
-	case <-d.closing:
+	case <-sc.ctx.Done():
 		return false
 	default:
 		return true

--- a/util/content.go
+++ b/util/content.go
@@ -13,6 +13,7 @@ import (
 )
 
 const DefaultContentSizeLimit = 34_000_000_000
+const ContentLocationLocal = "local"
 
 type ContentType int64
 


### PR DESCRIPTION
This PR improves the implementation of `refreshPinQueue` to make sure it works for local and shuttle deterministically.

Closes https://github.com/application-research/estuary/issues/310