### PR TITLE
Bug: properly init session-based node getter to find dag blocks using bitswap

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1490,7 +1490,7 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 
 	bserv := blockservice.New(d.Node.Blockstore, d.Node.Bitswap)
 	dserv := merkledag.NewDAGService(bserv)
-	dsess := merkledag.NewSession(ctx, dserv)
+	dsess := dserv.Session(ctx)
 
 	if err := d.addDatabaseTrackingToContent(ctx, op.ContId, dsess, d.Node.Blockstore, op.Obj, cb); err != nil {
 		// pinning failed, we wont try again. mark pin as dead

--- a/pinning.go
+++ b/pinning.go
@@ -129,7 +129,7 @@ func (s *Server) doPinning(ctx context.Context, op *pinner.PinningOperation, cb 
 
 	bserv := blockservice.New(s.Node.Blockstore, s.Node.Bitswap)
 	dserv := merkledag.NewDAGService(bserv)
-	dsess := merkledag.NewSession(ctx, dserv)
+	dsess := dserv.Session(ctx)
 
 	if err := s.CM.addDatabaseTrackingToContent(ctx, op.ContId, dsess, op.Obj, cb); err != nil {
 		return err


### PR DESCRIPTION
This PR properly init session-based node getter to find dag blocks using Bitswap when a CID is pinned using the pinning service endpoint. 

Currently, the request to the pinning endpoint to pin contents will fail when it tries to walk the dag to find the blocks since it expects to use an exchange (Bitswap) and is not correctly initialized, so we have a lot of these errors;

```
2022-07-08 18:49:43 | {"level":"error","ts":"2022-07-08T17:49:43.160Z","logger":"pinner","caller":"pinner/pinmgr.go:308","msg":"pinning queue error: context canceled\nfailed to walk DAG\nmain.(*Shuttle).addDatabaseTrackingToContent\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1609\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1495\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nfailed to addDatabaseTrackingToContent - contID(32652720), cid(bafybeibxe2b2zr7agfsmthilepl6mb37dw2g4cfpe7x2si7jcs5qutkvfi)\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1505\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nshuttle RunPinFunc failed\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:202\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263"}
-- | --
  |   | 2022-07-08 18:49:41 | {"level":"error","ts":"2022-07-08T17:49:41.484Z","logger":"pinner","caller":"pinner/pinmgr.go:308","msg":"pinning queue error: context canceled\nfailed to walk DAG\nmain.(*Shuttle).addDatabaseTrackingToContent\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1609\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1495\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nfailed to addDatabaseTrackingToContent - contID(32652719), cid(bafybeibxe2b2zr7agfsmthilepl6mb37dw2g4cfpe7x2si7jcs5qutkvfi)\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1505\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nshuttle RunPinFunc failed\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:202\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263"}
  |   | 2022-07-08 18:49:25 | {"level":"error","ts":"2022-07-08T17:49:24.958Z","logger":"pinner","caller":"pinner/pinmgr.go:308","msg":"pinning queue error: context canceled\nfailed to walk DAG\nmain.(*Shuttle).addDatabaseTrackingToContent\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1609\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1495\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nfailed to addDatabaseTrackingToContent - contID(32652716), cid(bafybeig7lesryo2wsoslqmz6zo3djjlmqvh56s6r5wjnwp6aidlu6jjcp4)\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1505\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nshuttle RunPinFunc failed\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:202\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263"}
  |   | 2022-07-08 18:49:23 | {"level":"error","ts":"2022-07-08T17:49:23.771Z","logger":"pinner","caller":"pinner/pinmgr.go:308","msg":"pinning queue error: context canceled\nfailed to walk DAG\nmain.(*Shuttle).addDatabaseTrackingToContent\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1609\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1495\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nfailed to addDatabaseTrackingToContent - contID(32652715), cid(bafybeig7lesryo2wsoslqmz6zo3djjlmqvh56s6r5wjnwp6aidlu6jjcp4)\nmain.(*Shuttle).doPinning\n\t/home/ubuntu/estuary/cmd/estuary-shuttle/main.go:1505\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:192\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263\nshuttle RunPinFunc failed\ngithub.com/application-research/estuary/pinner.(*PinManager).doPinning\n\t/home/ubuntu/estuary/pinner/pinmgr.go:202\ngithub.com/application-research/estuary/pinner.(*PinManager).pinWorker\n\t/home/ubuntu/estuary/pinner/pinmgr.go:307\nruntime.goexit\n\t/snap/go/9854/src/runtime/asm_arm64.s:1263"}
```

I have tested this locally, and now works as expected.
