### PR TITLE
feat: add support for log-level cli flag

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -76,6 +76,29 @@ var appVersion string
 
 var log = logging.Logger("shuttle").With("app_version", appVersion)
 
+func before(cctx *cli.Context) error {
+	level := "INFO"
+	if util.IsVeryVerbose {
+		level = "DEBUG"
+	}
+
+	logging.SetLogLevel("dt-impl", level)
+	logging.SetLogLevel("shuttle", level)
+	logging.SetLogLevel("paych", level)
+	logging.SetLogLevel("filclient", level)
+	logging.SetLogLevel("dt_graphsync", level)
+	logging.SetLogLevel("graphsync_allocator", level)
+	logging.SetLogLevel("dt-chanmon", level)
+	logging.SetLogLevel("markets", level)
+	logging.SetLogLevel("data_transfer_network", level)
+	logging.SetLogLevel("rpc", level)
+	logging.SetLogLevel("bs-wal", level)
+	logging.SetLogLevel("bs-migrate", level)
+	logging.SetLogLevel("rcmgr", level)
+
+	return nil
+}
+
 func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Shuttle) error {
 	for _, flag := range flags {
 		name := flag.Names()[0]
@@ -163,20 +186,6 @@ func main() {
 	utc, _ := time.LoadLocation("UTC")
 	time.Local = utc
 
-	logging.SetLogLevel("dt-impl", "debug")
-	logging.SetLogLevel("shuttle", "debug")
-	logging.SetLogLevel("paych", "debug")
-	logging.SetLogLevel("filclient", "debug")
-	logging.SetLogLevel("dt_graphsync", "debug")
-	logging.SetLogLevel("graphsync_allocator", "info")
-	logging.SetLogLevel("dt-chanmon", "debug")
-	logging.SetLogLevel("markets", "debug")
-	logging.SetLogLevel("data_transfer_network", "debug")
-	logging.SetLogLevel("rpc", "info")
-	logging.SetLogLevel("bs-wal", "info")
-	logging.SetLogLevel("bs-migrate", "info")
-	logging.SetLogLevel("rcmgr", "debug")
-
 	hDir, err := homedir.Dir()
 	if err != nil {
 		log.Fatalf("could not determine homedir for shuttle app: %+v", err)
@@ -187,7 +196,10 @@ func main() {
 
 	cfg := config.NewShuttle(appVersion)
 
+	app.Before = before
+
 	app.Flags = []cli.Flag{
+		util.FlagVeryVerbose,
 		&cli.StringFlag{
 			Name:  "repo",
 			Value: "~/.lotus",

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -77,7 +77,7 @@ var appVersion string
 var log = logging.Logger("shuttle").With("app_version", appVersion)
 
 func before(cctx *cli.Context) error {
-	level := util.LogLevl
+	level := util.LogLevel
 
 	logging.SetLogLevel("dt-impl", level)
 	logging.SetLogLevel("shuttle", level)
@@ -196,7 +196,7 @@ func main() {
 	app.Before = before
 
 	app.Flags = []cli.Flag{
-		util.FlagLogLevl,
+		util.FlagLogLevel,
 		&cli.StringFlag{
 			Name:  "repo",
 			Value: "~/.lotus",

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -77,10 +77,7 @@ var appVersion string
 var log = logging.Logger("shuttle").With("app_version", appVersion)
 
 func before(cctx *cli.Context) error {
-	level := "INFO"
-	if util.IsVeryVerbose {
-		level = "DEBUG"
-	}
+	level := util.LogLevl
 
 	logging.SetLogLevel("dt-impl", level)
 	logging.SetLogLevel("shuttle", level)
@@ -199,7 +196,7 @@ func main() {
 	app.Before = before
 
 	app.Flags = []cli.Flag{
-		util.FlagVeryVerbose,
+		util.FlagLogLevl,
 		&cli.StringFlag{
 			Name:  "repo",
 			Value: "~/.lotus",

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -401,7 +401,6 @@ func (s *Shuttle) handleRpcPrepareForDataRequest(ctx context.Context, cmd *drpc.
 	if err != nil {
 		return fmt.Errorf("preparing for data request: %w", err)
 	}
-
 	return nil
 }
 
@@ -416,7 +415,6 @@ func (s *Shuttle) handleRpcCleanupPreparedRequest(ctx context.Context, cmd *drpc
 	if err != nil {
 		return fmt.Errorf("cleaning up prepared request: %w", err)
 	}
-
 	return nil
 }
 
@@ -468,7 +466,7 @@ func (d *Shuttle) sendTransferStatusUpdate(ctx context.Context, st *drpc.Transfe
 	if st.State != nil {
 		extra = fmt.Sprintf("%d %s", st.State.Status, st.State.Message)
 	}
-	log.Infof("sending transfer status update: %d %s", st.DealDBID, extra)
+	log.Debugf("sending transfer status update: %d %s", st.DealDBID, extra)
 	if err := d.sendRpcMessage(ctx, &drpc.Message{
 		Op: drpc.OP_TransferStatus,
 		Params: drpc.MsgParams{
@@ -522,7 +520,6 @@ func (s *Shuttle) handleRpcUnpinContent(ctx context.Context, req *drpc.UnpinCont
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -640,7 +637,7 @@ func (s *Shuttle) handleRpcSplitContent(ctx context.Context, req *drpc.SplitCont
 }
 
 func (s *Shuttle) handleRpcRestartTransfer(ctx context.Context, req *drpc.RestartTransfer) error {
-	log.Infof("restarting data transfer: %s", req.ChanID)
+	log.Debugf("restarting data transfer: %s", req.ChanID)
 	st, err := s.Filc.TransferStatus(ctx, &req.ChanID)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -159,6 +159,27 @@ func (s *Server) updateAutoretrieveIndex(tickInterval time.Duration, quit chan s
 	}
 }
 
+func before(cctx *cli.Context) error {
+	level := "INFO"
+	if util.IsVeryVerbose {
+		level = "DEBUG"
+	}
+
+	_ = logging.SetLogLevel("dt-impl", level)
+	_ = logging.SetLogLevel("estuary", level)
+	_ = logging.SetLogLevel("paych", level)
+	_ = logging.SetLogLevel("filclient", level)
+	_ = logging.SetLogLevel("dt_graphsync", level)
+	_ = logging.SetLogLevel("dt-chanmon", level)
+	_ = logging.SetLogLevel("markets", level)
+	_ = logging.SetLogLevel("data_transfer_network", level)
+	_ = logging.SetLogLevel("rpc", level)
+	_ = logging.SetLogLevel("bs-wal", level)
+	_ = logging.SetLogLevel("provider.batched", level)
+	_ = logging.SetLogLevel("bs-migrate", level)
+	return nil
+}
+
 func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Estuary) error {
 	for _, flag := range flags {
 		name := flag.Names()[0]
@@ -258,20 +279,6 @@ func main() {
 	utc, _ := time.LoadLocation("UTC")
 	time.Local = utc
 
-	logging.SetLogLevel("dt-impl", "debug")
-	logging.SetLogLevel("estuary", "debug")
-	logging.SetLogLevel("paych", "debug")
-	logging.SetLogLevel("filclient", "debug")
-	logging.SetLogLevel("dt_graphsync", "debug")
-	//logging.SetLogLevel("graphsync_allocator", "debug")
-	logging.SetLogLevel("dt-chanmon", "debug")
-	logging.SetLogLevel("markets", "debug")
-	logging.SetLogLevel("data_transfer_network", "debug")
-	logging.SetLogLevel("rpc", "info")
-	logging.SetLogLevel("bs-wal", "info")
-	logging.SetLogLevel("provider.batched", "info")
-	logging.SetLogLevel("bs-migrate", "info")
-
 	hDir, err := homedir.Dir()
 	if err != nil {
 		log.Fatalf("could not determine homedir for estuary app: %+v", err)
@@ -284,7 +291,10 @@ func main() {
 
 	app.Usage = "Estuary server CLI"
 
+	app.Before = before
+
 	app.Flags = []cli.Flag{
+		util.FlagVeryVerbose,
 		&cli.StringFlag{
 			Name:  "repo",
 			Value: "~/.lotus",

--- a/main.go
+++ b/main.go
@@ -160,10 +160,7 @@ func (s *Server) updateAutoretrieveIndex(tickInterval time.Duration, quit chan s
 }
 
 func before(cctx *cli.Context) error {
-	level := "INFO"
-	if util.IsVeryVerbose {
-		level = "DEBUG"
-	}
+	level := util.LogLevl
 
 	_ = logging.SetLogLevel("dt-impl", level)
 	_ = logging.SetLogLevel("estuary", level)
@@ -294,7 +291,7 @@ func main() {
 	app.Before = before
 
 	app.Flags = []cli.Flag{
-		util.FlagVeryVerbose,
+		util.FlagLogLevl,
 		&cli.StringFlag{
 			Name:  "repo",
 			Value: "~/.lotus",

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func (s *Server) updateAutoretrieveIndex(tickInterval time.Duration, quit chan s
 }
 
 func before(cctx *cli.Context) error {
-	level := util.LogLevl
+	level := util.LogLevel
 
 	_ = logging.SetLogLevel("dt-impl", level)
 	_ = logging.SetLogLevel("estuary", level)
@@ -291,7 +291,7 @@ func main() {
 	app.Before = before
 
 	app.Flags = []cli.Flag{
-		util.FlagLogLevl,
+		util.FlagLogLevel,
 		&cli.StringFlag{
 			Name:  "repo",
 			Value: "~/.lotus",

--- a/shuttle.go
+++ b/shuttle.go
@@ -156,7 +156,7 @@ func (cm *ContentManager) processShuttleMessage(handle string, msg *drpc.Message
 	ctx, span := cm.tracer.Start(ctx, "processShuttleMessage")
 	defer span.End()
 
-	log.Infof("handling shuttle message: %s", msg.Op)
+	log.Debugf("handling shuttle message: %s", msg.Op)
 	switch msg.Op {
 	case drpc.OP_UpdatePinStatus:
 		ups := msg.Params.UpdatePinStatus
@@ -331,12 +331,12 @@ func (cm *ContentManager) handleRpcTransferStarted(ctx context.Context, handle s
 		return xerrors.Errorf("failed to update deal with channel ID: %w", err)
 	}
 
-	log.Infow("Started data transfer on shuttle", "chanid", param.Chanid, "shuttle", handle)
+	log.Debugw("Started data transfer on shuttle", "chanid", param.Chanid, "shuttle", handle)
 	return nil
 }
 
 func (cm *ContentManager) handleRpcTransferStatus(ctx context.Context, handle string, param *drpc.TransferStatus) error {
-	log.Infof("handling transfer status rpc update: %d %v", param.DealDBID, param.State == nil)
+	log.Debugf("handling transfer status rpc update: %d %v", param.DealDBID, param.State == nil)
 
 	var cd contentDeal
 	if param.DealDBID != 0 {

--- a/util/cli.go
+++ b/util/cli.go
@@ -2,11 +2,11 @@ package util
 
 import cli "github.com/urfave/cli/v2"
 
-var IsVeryVerbose bool
+var LogLevl string
 
-var FlagVeryVerbose = &cli.BoolFlag{
-	Name:        "vv",
-	Usage:       "enables very verbose mode, useful for debugging",
-	Value:       false,
-	Destination: &IsVeryVerbose,
+var FlagLogLevl = &cli.StringFlag{
+	Name:        "log-level",
+	Usage:       "sets the log level, defaults to INFO",
+	Value:       "INFO",
+	Destination: &LogLevl,
 }

--- a/util/cli.go
+++ b/util/cli.go
@@ -2,11 +2,11 @@ package util
 
 import cli "github.com/urfave/cli/v2"
 
-var LogLevl string
+var LogLevel string
 
-var FlagLogLevl = &cli.StringFlag{
+var FlagLogLevel = &cli.StringFlag{
 	Name:        "log-level",
 	Usage:       "sets the log level, defaults to INFO",
 	Value:       "INFO",
-	Destination: &LogLevl,
+	Destination: &LogLevel,
 }

--- a/util/cli.go
+++ b/util/cli.go
@@ -1,0 +1,12 @@
+package util
+
+import cli "github.com/urfave/cli/v2"
+
+var IsVeryVerbose bool
+
+var FlagVeryVerbose = &cli.BoolFlag{
+	Name:        "vv",
+	Usage:       "enables very verbose mode, useful for debugging",
+	Value:       false,
+	Destination: &IsVeryVerbose,
+}


### PR DESCRIPTION
Add support for `log-level` cli flag. Defaults to `info`

`./estuary --datadir=`

<img width="1069" alt="Screenshot 2022-07-14 at 18 04 24" src="https://user-images.githubusercontent.com/13554411/179041846-e19190c7-5781-4cf1-83d8-3dd617861eff.png">


`./estuary --log-levl=debug --datadir=`
<img width="1067" alt="Screenshot 2022-07-14 at 18 05 04" src="https://user-images.githubusercontent.com/13554411/179041901-b45f020d-0c9f-489b-bc44-5949862266da.png">


closes https://github.com/application-research/estuary/issues/185