### PR TITLE
check that collection id matches user id before returning 403

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -4638,10 +4638,12 @@ func (s *Server) handleCreateContent(c echo.Context, u *User) error {
 			return err
 		}
 
-		return &util.HttpError{
-			Code:    http.StatusForbidden,
-			Reason:  util.ERR_NOT_AUTHORIZED,
-			Details: fmt.Sprintf("attempted to create content in collection %s not owned by the user (%d)", c, u.ID),
+		if col.UserID != u.ID {
+			return &util.HttpError{
+				Code:    http.StatusForbidden,
+				Reason:  util.ERR_NOT_AUTHORIZED,
+				Details: fmt.Sprintf("attempted to create content in collection %s not owned by the user (%d)", c, u.ID),
+			}
 		}
 	}
 


### PR DESCRIPTION
This bug was introduced in this refactor -- https://github.com/application-research/estuary/commit/41a9e7d64e97683012f8f0fe97823bd9ce0389df#diff-56307bdb7ded67ebe516f562b90384407b21b2d34e8b5766b42602e1fb9705f0L4617

So right now we always return a 403 if a collection id is not specified.

Might fix https://github.com/application-research/estuary/issues/323