### PR TITLE
Fixes #338 : Salted plaintext passwords 

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2852,7 +2852,7 @@ func (s *Server) AuthRequired(level int) echo.MiddlewareFunc {
 
 type registerBody struct {
 	Username     string `json:"username"`
-	PasswordHash string `json:"passwordHash"`
+	Password	 string `json:"passwordHash"`
 	InviteCode   string `json:"inviteCode"`
 }
 
@@ -2896,10 +2896,13 @@ func (s *Server) handleRegisterUser(c echo.Context) error {
 		}
 	}
 
+	salt := uuid.New().String()
+
 	newUser := &User{
 		Username: username,
 		UUID:     uuid.New().String(),
-		PassHash: reg.PasswordHash,
+		Salt:     salt,
+		PassHash: util.GetPasswordHash(reg.Password, salt),
 		Perm:     util.PermLevelUser,
 	}
 
@@ -2933,7 +2936,7 @@ func (s *Server) handleRegisterUser(c echo.Context) error {
 
 type loginBody struct {
 	Username string `json:"username"`
-	PassHash string `json:"passwordHash"`
+	Password string `json:"passwordHash"`
 }
 
 type loginResponse struct {
@@ -2958,7 +2961,9 @@ func (s *Server) handleLoginUser(c echo.Context) error {
 		return err
 	}
 
-	if user.PassHash != body.PassHash {
+	
+	
+	if user.PassHash != util.GetPasswordHash(body.Password, user.Salt) {
 		return &util.HttpError{
 			Code:   http.StatusForbidden,
 			Reason: util.ERR_INVALID_PASSWORD,
@@ -2977,7 +2982,7 @@ func (s *Server) handleLoginUser(c echo.Context) error {
 }
 
 type changePasswordParams struct {
-	NewPassHash string `json:"newPasswordHash"`
+	NewPassword string `json:"newPasswordHash"`
 }
 
 func (s *Server) handleUserChangePassword(c echo.Context, u *User) error {
@@ -2986,7 +2991,14 @@ func (s *Server) handleUserChangePassword(c echo.Context, u *User) error {
 		return err
 	}
 
-	if err := s.DB.Model(User{}).Where("id = ?", u.ID).Update("pass_hash", params.NewPassHash).Error; err != nil {
+	salt := uuid.New().String()
+	
+	updatedUserColumns := &User{
+		Salt:     salt,
+		PassHash: util.GetPasswordHash(params.NewPassword, salt),
+	}
+
+	if err := s.DB.Model(User{}).Where("id = ?", u.ID).Updates(updatedUserColumns).Error; err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -477,7 +477,8 @@ func main() {
 				})
 
 				username := "admin"
-				passHash := ""
+				password := ""
+				salt:= ""
 
 				if err := quietdb.First(&User{}, "username = ?", username).Error; err == nil {
 					return fmt.Errorf("an admin user already exists")
@@ -486,7 +487,8 @@ func main() {
 				newUser := &User{
 					UUID:     uuid.New().String(),
 					Username: username,
-					PassHash: passHash,
+					Salt:	  salt,
+					PassHash: util.GetPasswordHash(password, salt),
 					Perm:     100,
 				}
 				if err := db.Create(newUser).Error; err != nil {

--- a/users.go
+++ b/users.go
@@ -11,6 +11,7 @@ type User struct {
 	gorm.Model
 	UUID     string `gorm:"unique"`
 	Username string `gorm:"unique"`
+	Salt     string 
 	PassHash string
 	DID      string
 

--- a/util/auth.go
+++ b/util/auth.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 )
@@ -22,4 +23,9 @@ func IsCollectionOwner(uID, entityID uint) error {
 
 func IsContentOwner(uID, entityID uint) error {
 	return isEntityOwner(uID, entityID, "content")
+}
+
+func GetPasswordHash(password, salt string) string {
+	passHashBytes := sha256.Sum256([]byte(password + "." + salt))
+	return string(passHashBytes[:])
 }


### PR DESCRIPTION
Fixes #338 

Added 🧂 to Users schema. Salting at registration and Change password. On Login plaintext is hashed and compared with hashed passwords in DB. This makes the login incompatible with the existing DB of old passwords without a proper migration. 