### PR TITLE
chore: backward compatibility of password check

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2850,9 +2850,9 @@ func (s *Server) AuthRequired(level int) echo.MiddlewareFunc {
 }
 
 type registerBody struct {
-	Username     string `json:"username"`
-	Password	 string `json:"passwordHash"`
-	InviteCode   string `json:"inviteCode"`
+	Username   string `json:"username"`
+	Password   string `json:"passwordHash"`
+	InviteCode string `json:"inviteCode"`
 }
 
 func (s *Server) handleRegisterUser(c echo.Context) error {
@@ -2960,9 +2960,9 @@ func (s *Server) handleLoginUser(c echo.Context) error {
 		return err
 	}
 
-	
-	
-	if user.PassHash != util.GetPasswordHash(body.Password, user.Salt) {
+	//	validate password
+	if ((user.Salt != "") && user.PassHash != util.GetPasswordHash(body.Password, user.Salt)) ||
+		((user.Salt == "") && (user.PassHash != body.Password)) {
 		return &util.HttpError{
 			Code:   http.StatusForbidden,
 			Reason: util.ERR_INVALID_PASSWORD,
@@ -2991,7 +2991,7 @@ func (s *Server) handleUserChangePassword(c echo.Context, u *User) error {
 	}
 
 	salt := uuid.New().String()
-	
+
 	updatedUserColumns := &User{
 		Salt:     salt,
 		PassHash: util.GetPasswordHash(params.NewPassword, salt),


### PR DESCRIPTION
# Changes

Now that we have the addition of `salt` as part of the password, we need to be able to handle the old passwords without salts. This ensures that old passwords will still work as is and will be migrated to the new password hashing version when the users decides to change their password.

# Verification (note: verified on localhost)
![image](https://user-images.githubusercontent.com/4479171/181119993-e94db989-39f7-4dac-b7dd-cc2167c7a5f0.png)

## verified with old account password change
old account: alvinreyesold 
https://user-images.githubusercontent.com/4479171/181120397-b742dc1b-2548-4190-8951-c0dea1fa8c27.mp4

## verified with new account password change
new account: alvinreyes 
https://user-images.githubusercontent.com/4479171/181120580-d9e81194-00f3-431c-961f-b975153316ee.mp4

