### PR TITLE
Fixing gosec issues and adding gosec on scan on master push and pull request

### DIFF
--- a/.github/workflows/secops.yml
+++ b/.github/workflows/secops.yml
@@ -1,0 +1,20 @@
+name: Run Gosec
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...

--- a/cmd/benchest/main.go
+++ b/cmd/benchest/main.go
@@ -45,7 +45,10 @@ func getApp() *cli.App {
 
 func getFile(cctx *cli.Context) (io.Reader, string, error) {
 	buf := make([]byte, 1024*1024)
-	rand.Read(buf)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, "", err
+	}
 
 	return bytes.NewReader(buf), fmt.Sprintf("goodfile-%x", buf[:4]), nil
 }
@@ -149,7 +152,7 @@ var benchAddResultCmd = &cli.Command{
 			Value: "",
 		},
 	},
-	Action: func(cctx *cli.Context) error {
+	Action: func(cctx *cli.Context) (err error) {
 		if !cctx.Args().Present() {
 			return fmt.Errorf("must pass filename")
 		}
@@ -163,7 +166,11 @@ var benchAddResultCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		defer fi.Close()
+		defer func() {
+			if errC := fi.Close(); errC != nil {
+				err = errC
+			}
+		}()
 
 		dec := json.NewDecoder(fi)
 		for {
@@ -268,8 +275,13 @@ func RunBenchAddFile(name string, fi io.Reader, host string, estToken string) (*
 	if err != nil {
 		return nil, err
 	}
-	io.Copy(part, fi)
-	mw.Close()
+	if _, err = io.Copy(part, fi); err != nil {
+		return nil, err
+	}
+	err = mw.Close()
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("https://%s/content/add", host), buf)
 	if err != nil {
@@ -418,7 +430,10 @@ func benchFetch(c string) (*fetchStats, error) {
 	}
 	firstByteAt := time.Now()
 
-	io.Copy(io.Discard, br)
+	_, err = io.Copy(io.Discard, br)
+	if err != nil {
+		return nil, fmt.Errorf("copying bytes failed: %w ", err)
+	}
 	endTime := time.Now()
 
 	return &fetchStats{

--- a/cmd/estuary-shuttle/data.go
+++ b/cmd/estuary-shuttle/data.go
@@ -54,10 +54,19 @@ func setupDatabase(dbval string) (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	db.AutoMigrate(&Pin{})
-	db.AutoMigrate(&Object{})
-	db.AutoMigrate(&ObjRef{})
+	if err := migrateSchemas(db); err != nil {
+		return nil, err
+	}
 
 	return db, nil
+}
+
+func migrateSchemas(db *gorm.DB) error {
+	if err := db.AutoMigrate(
+		&Pin{},
+		&Object{},
+		&ObjRef{}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	//#nosec G108 - exposing the profiling endpoint is expected
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -807,12 +807,14 @@ func (d *Shuttle) RunRpcConnection() error {
 	}
 }
 
-func (d *Shuttle) runRpc(conn *websocket.Conn) error {
+func (d *Shuttle) runRpc(conn *websocket.Conn) (err error) {
 	conn.MaxPayloadBytes = 128 << 20
 	log.Infof("connecting to primary estuary node")
-	if err := conn.Close(); err != nil {
-		return err
-	}
+	defer func() {
+		if errC := conn.Close(); errC != nil {
+			err = errC
+		}
+	}()
 
 	readDone := make(chan struct{})
 

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -82,6 +82,7 @@ const (
 	ColDir  = "dir"
 )
 
+//#nosec G104 - it's not common to treat SetLogLevel error return
 func before(cctx *cli.Context) error {
 	level := util.LogLevel
 
@@ -1132,6 +1133,7 @@ func (s *Shuttle) handleLogLevel(c echo.Context) error {
 		return err
 	}
 
+	//#nosec G104 - it's not common to treat SetLogLevel error return
 	logging.SetLogLevel(body.System, body.Level)
 
 	return c.JSON(http.StatusOK, map[string]interface{}{})

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -401,7 +401,10 @@ func main() {
 		// https://github.com/filecoin-project/lotus/blob/731da455d46cb88ee5de9a70920a2d29dec9365c/cli/util/api.go#L37
 		flset := flag.NewFlagSet("lotus", flag.ExitOnError)
 		flset.String("api-url", "", "node api url")
-		flset.Set("api-url", cfg.Node.ApiURL)
+		err = flset.Set("api-url", cfg.Node.ApiURL)
+		if err != nil {
+			return err
+		}
 
 		ncctx := cli.NewContext(cli.NewApp(), flset, nil)
 		api, closer, err := lcli.GetGatewayAPI(ncctx)
@@ -806,7 +809,9 @@ func (d *Shuttle) RunRpcConnection() error {
 func (d *Shuttle) runRpc(conn *websocket.Conn) error {
 	conn.MaxPayloadBytes = 128 << 20
 	log.Infof("connecting to primary estuary node")
-	defer conn.Close()
+	if err := conn.Close(); err != nil {
+		return err
+	}
 
 	readDone := make(chan struct{})
 
@@ -843,11 +848,16 @@ func (d *Shuttle) runRpc(conn *websocket.Conn) error {
 		case <-readDone:
 			return fmt.Errorf("read routine exited, assuming socket is closed")
 		case msg := <-d.outgoing:
-			conn.SetWriteDeadline(time.Now().Add(time.Second * 30))
+			if err := conn.SetWriteDeadline(time.Now().Add(time.Second * 30)); err != nil {
+				log.Errorf("failed to set the connection's network write deadline: %s", err)
+
+			}
 			if err := websocket.JSON.Send(conn, msg); err != nil {
 				log.Errorf("failed to send message: %s", err)
 			}
-			conn.SetWriteDeadline(time.Time{})
+			if err := conn.SetWriteDeadline(time.Time{}); err != nil {
+				log.Errorf("failed to set the connection's network write deadline: %s", err)
+			}
 		}
 	}
 }
@@ -1974,7 +1984,10 @@ func (s *Shuttle) handleReadContent(c echo.Context, u *User) error {
 		})
 	}
 
-	io.Copy(c.Response(), r)
+	_, err = io.Copy(c.Response(), r)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ func encode(cfg interface{}, w io.Writer) error {
 	return err
 }
 
-func load(cfg interface{}, filename string) error {
+func load(cfg interface{}, filename string) (err error) {
 	f, err := os.Open(filepath.Clean(filename))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -32,16 +32,22 @@ func load(cfg interface{}, filename string) error {
 		}
 		return err
 	}
-	defer f.Close()
+
+	defer func() {
+		if errC := f.Close(); errC != nil {
+			err = errC
+		}
+	}()
+
 	if err := json.NewDecoder(f).Decode(cfg); err != nil {
 		return fmt.Errorf("failure to decode config: %s", err)
 	}
-	return nil
+	return err
 }
 
 // save writes the config from `cfg` into `filename`.
 func save(cfg interface{}, filename string) error {
-	err := os.MkdirAll(filepath.Dir(filename), 0755)
+	err := os.MkdirAll(filepath.Dir(filename), 0750)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ func encode(cfg interface{}, w io.Writer) error {
 }
 
 func load(cfg interface{}, filename string) error {
-	f, err := os.Open(filename)
+	f, err := os.Open(filepath.Clean(filename))
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = ErrNotInitialized

--- a/dbmgr/dbmgr.go
+++ b/dbmgr/dbmgr.go
@@ -96,7 +96,6 @@ func (mgr *DBMgr) Shuttles() *ShuttlesQuery {
 	return NewShuttlesQuery(mgr.DB)
 }
 
-//#nosec G104
 func NewDBMgr(dbval string) (*DBMgr, error) {
 	parts := strings.SplitN(dbval, "=", 2)
 	if len(parts) == 1 {

--- a/dbmgr/dbmgr.go
+++ b/dbmgr/dbmgr.go
@@ -96,6 +96,7 @@ func (mgr *DBMgr) Shuttles() *ShuttlesQuery {
 	return NewShuttlesQuery(mgr.DB)
 }
 
+//#nosec G104
 func NewDBMgr(dbval string) (*DBMgr, error) {
 	parts := strings.SplitN(dbval, "=", 2)
 	if len(parts) == 1 {

--- a/dbmgr/dbmgr.go
+++ b/dbmgr/dbmgr.go
@@ -129,27 +129,9 @@ func NewDBMgr(dbval string) (*DBMgr, error) {
 	sqldb.SetMaxOpenConns(99)
 	sqldb.SetConnMaxIdleTime(time.Hour)
 
-	db.AutoMigrate(&Content{})
-	db.AutoMigrate(&Object{})
-	db.AutoMigrate(&ObjRef{})
-	db.AutoMigrate(&Collection{})
-	db.AutoMigrate(&CollectionRef{})
-
-	db.AutoMigrate(&Deal{})
-	db.AutoMigrate(&DFERecord{})
-	db.AutoMigrate(&PieceCommRecord{})
-	db.AutoMigrate(&ProposalRecord{})
-	db.AutoMigrate(&RetrievalFailureRecord{})
-	db.AutoMigrate(&RetrievalSuccessRecord{})
-
-	db.AutoMigrate(&MinerStorageAsk{})
-	db.AutoMigrate(&StorageMiner{})
-
-	db.AutoMigrate(&User{})
-	db.AutoMigrate(&AuthToken{})
-	db.AutoMigrate(&InviteCode{})
-
-	db.AutoMigrate(&Shuttle{})
+	if err := migrateSchemas(db); err != nil {
+		return nil, err
+	}
 
 	var count int64
 	if err := db.Model(&StorageMiner{}).Count(&count).Error; err != nil {
@@ -218,6 +200,30 @@ func NewDBMgr(dbval string) (*DBMgr, error) {
 	}
 
 	return &DBMgr{db}, nil
+}
+
+func migrateSchemas(db *gorm.DB) error {
+	if err := db.AutoMigrate(
+		&Content{},
+		&Object{},
+		&ObjRef{},
+		&Collection{},
+		&CollectionRef{},
+		&Deal{},
+		&DFERecord{},
+		&PieceCommRecord{},
+		&ProposalRecord{},
+		&RetrievalFailureRecord{},
+		&RetrievalSuccessRecord{},
+		&MinerStorageAsk{},
+		&StorageMiner{},
+		&User{},
+		&AuthToken{},
+		&InviteCode{},
+		&Shuttle{}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // USERS

--- a/handlers.go
+++ b/handlers.go
@@ -4586,6 +4586,7 @@ func (s *Server) handleLogLevel(c echo.Context) error {
 		return err
 	}
 
+	//#nosec G104 - it's not common to treat SetLogLevel error return
 	logging.SetLogLevel(body.System, body.Level)
 
 	return c.JSON(http.StatusOK, map[string]interface{}{})

--- a/handlers.go
+++ b/handlers.go
@@ -967,6 +967,7 @@ func (s *Server) redirectContentAdding(c echo.Context, u *User) error {
 		log.Warnf("failed to get preferred upload endpoints: %s", err)
 		return err
 	} else if len(uep) > 0 {
+		//#nosec G404 - crypto/rand it's not necessary for this use case
 		// propagate any query params
 		req, err := http.NewRequest("POST", fmt.Sprintf("%s/content/add", uep[rand.Intn(len(uep))]), c.Request().Body)
 		if err != nil {
@@ -2760,7 +2761,10 @@ func (s *Server) handleReadLocalContent(c echo.Context) error {
 		})
 	}
 
-	io.Copy(c.Response(), r)
+	_, err = io.Copy(c.Response(), r)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3456,12 +3460,18 @@ func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
 		if err != nil {
 			return err
 		}
-		lastDirNode.AddRawLink(c.Name, &ipld.Link{
+		err = lastDirNode.AddRawLink(c.Name, &ipld.Link{
 			Size: uint64(c.Size),
 			Cid:  c.Cid.CID,
 		})
+		if err != nil {
+			return err
+		}
 	}
-	dserv.Add(context.Background(), collectionNode) // add new CID to local blockstore
+
+	if err := dserv.Add(context.Background(), collectionNode); err != nil {
+		return err
+	} // add new CID to local blockstore
 
 	// update DB with new collection CID
 	col.CID = collectionNode.Cid().String()

--- a/handlers.go
+++ b/handlers.go
@@ -967,7 +967,6 @@ func (s *Server) redirectContentAdding(c echo.Context, u *User) error {
 		log.Warnf("failed to get preferred upload endpoints: %s", err)
 		return err
 	} else if len(uep) > 0 {
-		//#nosec G404 - crypto/rand it's not necessary for this use case
 		// propagate any query params
 		req, err := http.NewRequest("POST", fmt.Sprintf("%s/content/add", uep[rand.Intn(len(uep))]), c.Request().Body)
 		if err != nil {
@@ -2854,9 +2853,9 @@ func (s *Server) AuthRequired(level int) echo.MiddlewareFunc {
 }
 
 type registerBody struct {
-	Username     string `json:"username"`
-	Password	 string `json:"passwordHash"`
-	InviteCode   string `json:"inviteCode"`
+	Username   string `json:"username"`
+	Password   string `json:"passwordHash"`
+	InviteCode string `json:"inviteCode"`
 }
 
 func (s *Server) handleRegisterUser(c echo.Context) error {
@@ -2964,8 +2963,6 @@ func (s *Server) handleLoginUser(c echo.Context) error {
 		return err
 	}
 
-	
-	
 	if user.PassHash != util.GetPasswordHash(body.Password, user.Salt) {
 		return &util.HttpError{
 			Code:   http.StatusForbidden,
@@ -2995,7 +2992,7 @@ func (s *Server) handleUserChangePassword(c echo.Context, u *User) error {
 	}
 
 	salt := uuid.New().String()
-	
+
 	updatedUserColumns := &User{
 		Salt:     salt,
 		PassHash: util.GetPasswordHash(params.NewPassword, salt),

--- a/handlers.go
+++ b/handlers.go
@@ -967,6 +967,7 @@ func (s *Server) redirectContentAdding(c echo.Context, u *User) error {
 		log.Warnf("failed to get preferred upload endpoints: %s", err)
 		return err
 	} else if len(uep) > 0 {
+		//#nosec G404 - crypto/rand it's not necessary for this use case
 		// propagate any query params
 		req, err := http.NewRequest("POST", fmt.Sprintf("%s/content/add", uep[rand.Intn(len(uep))]), c.Request().Body)
 		if err != nil {

--- a/handlers.go
+++ b/handlers.go
@@ -3460,7 +3460,7 @@ func (s *Server) handleCommitCollection(c echo.Context, u *User) error {
 		if err != nil {
 			return err
 		}
-		err := lastDirNode.AddRawLink(c.Filename, &ipld.Link{
+		err = lastDirNode.AddRawLink(c.Filename, &ipld.Link{
 			Size: uint64(c.Size),
 			Cid:  c.Cid.CID,
 		})

--- a/main.go
+++ b/main.go
@@ -565,7 +565,10 @@ func main() {
 		// https://github.com/filecoin-project/lotus/blob/731da455d46cb88ee5de9a70920a2d29dec9365c/cli/util/api.go#L37
 		flset := flag.NewFlagSet("lotus", flag.ExitOnError)
 		flset.String("api-url", "", "node api url")
-		flset.Set("api-url", cfg.Node.ApiURL)
+		err = flset.Set("api-url", cfg.Node.ApiURL)
+		if err != nil {
+			return err
+		}
 
 		ncctx := cli.NewContext(cli.NewApp(), flset, nil)
 		api, closer, err := lcli.GetGatewayAPI(ncctx)

--- a/main.go
+++ b/main.go
@@ -713,29 +713,9 @@ func setupDatabase(dbConnStr string) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	db.AutoMigrate(&Content{})
-	db.AutoMigrate(&Object{})
-	db.AutoMigrate(&ObjRef{})
-	db.AutoMigrate(&Collection{})
-	db.AutoMigrate(&CollectionRef{})
-
-	db.AutoMigrate(&contentDeal{})
-	db.AutoMigrate(&dfeRecord{})
-	db.AutoMigrate(&PieceCommRecord{})
-	db.AutoMigrate(&proposalRecord{})
-	db.AutoMigrate(&util.RetrievalFailureRecord{})
-	db.AutoMigrate(&retrievalSuccessRecord{})
-
-	db.AutoMigrate(&minerStorageAsk{})
-	db.AutoMigrate(&storageMiner{})
-
-	db.AutoMigrate(&User{})
-	db.AutoMigrate(&AuthToken{})
-	db.AutoMigrate(&InviteCode{})
-
-	db.AutoMigrate(&Shuttle{})
-
-	db.AutoMigrate(&Autoretrieve{})
+	if err = migrateSchemas(db); err != nil {
+		return nil, err
+	}
 
 	// 'manually' add unique composite index on collection fields because gorms syntax for it is tricky
 	if err := db.Exec("create unique index if not exists collection_refs_paths on collection_refs (path,collection)").Error; err != nil {
@@ -755,6 +735,31 @@ func setupDatabase(dbConnStr string) (*gorm.DB, error) {
 
 	}
 	return db, nil
+}
+
+func migrateSchemas(db *gorm.DB) error {
+	if err := db.AutoMigrate(
+		&Content{},
+		&Object{},
+		&ObjRef{},
+		&Collection{},
+		&CollectionRef{},
+		&contentDeal{},
+		&dfeRecord{},
+		&PieceCommRecord{},
+		&proposalRecord{},
+		&util.RetrievalFailureRecord{},
+		&retrievalSuccessRecord{},
+		&minerStorageAsk{},
+		&storageMiner{},
+		&User{},
+		&AuthToken{},
+		&InviteCode{},
+		&Shuttle{},
+		&Autoretrieve{}); err != nil {
+		return err
+	}
+	return nil
 }
 
 type Server struct {

--- a/metrics/exporter.go
+++ b/metrics/exporter.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	//#nosec G108 - exposing the profiling endpoint is expected
 	_ "net/http/pprof"
 
 	"contrib.go.opencensus.io/exporter/prometheus"

--- a/node/node.go
+++ b/node/node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	peering "github.com/application-research/estuary/node/modules/peering"
@@ -549,7 +550,7 @@ func loadBlockstore(bscfg string, wal string, flush, walTruncate, nocache bool) 
 }
 
 func loadOrInitPeerKey(kf string) (crypto.PrivKey, error) {
-	data, err := ioutil.ReadFile(kf)
+	data, err := ioutil.ReadFile(filepath.Clean(kf))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err

--- a/replication.go
+++ b/replication.go
@@ -687,10 +687,13 @@ func (cm *ContentManager) createAggregate(ctx context.Context, conts []Content) 
 	log.Info("aggregating contents in staging zone into new content")
 	dir := unixfs.EmptyDirNode()
 	for _, c := range conts {
-		dir.AddRawLink(fmt.Sprintf("%d-%s", c.ID, c.Name), &ipld.Link{
+		err := dir.AddRawLink(fmt.Sprintf("%d-%s", c.ID, c.Name), &ipld.Link{
 			Size: uint64(c.Size),
 			Cid:  c.Cid.CID,
 		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return dir, nil
@@ -1922,6 +1925,7 @@ func (cm *ContentManager) getDealID(ctx context.Context, pubcid cid.Cid, d *cont
 
 	dealix := -1
 	for i, pd := range params.Deals {
+		pd := pd
 		nd, err := cborutil.AsIpld(&pd)
 		if err != nil {
 			return 0, xerrors.Errorf("failed to compute deal proposal ipld node: %w", err)

--- a/replication.go
+++ b/replication.go
@@ -1525,13 +1525,15 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 				return DEAL_CHECK_UNKNOWN, err
 			}
 
-			cm.recordDealFailure(&DealFailureError{
+			if err := cm.recordDealFailure(&DealFailureError{
 				Miner:   maddr,
 				Phase:   "check-chain-deal",
 				Message: fmt.Sprintf("deal %d was slashed at epoch %d", d.DealID, deal.State.SlashEpoch),
 				Content: d.Content,
 				UserID:  d.UserID,
-			})
+			}); err != nil {
+				return DEAL_CHECK_UNKNOWN, err
+			}
 			return DEAL_CHECK_UNKNOWN, nil
 		}
 
@@ -1587,13 +1589,15 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 		}
 		if expired {
 			// deal expired, miner didnt start it in time
-			cm.recordDealFailure(&DealFailureError{
+			if err := cm.recordDealFailure(&DealFailureError{
 				Miner:   maddr,
 				Phase:   "check-status",
 				Message: "was unable to check deal status with miner and now deal has expired",
 				Content: d.Content,
 				UserID:  d.UserID,
-			})
+			}); err != nil {
+				return DEAL_CHECK_UNKNOWN, err
+			}
 			return DEAL_CHECK_UNKNOWN, nil
 		}
 
@@ -1651,13 +1655,15 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 			log.Infof("failed to find message on chain: %s", *provds.PublishCid)
 			if provds.Proposal.StartEpoch < head.Height() {
 				// deal expired, miner didn`t start it in time
-				cm.recordDealFailure(&DealFailureError{
+				if err := cm.recordDealFailure(&DealFailureError{
 					Miner:   maddr,
 					Phase:   "check-status",
 					Message: "deal did not make it on chain in time (but has publish deal cid set)",
 					Content: d.Content,
 					UserID:  d.UserID,
-				})
+				}); err != nil {
+					return DEAL_CHECK_UNKNOWN, err
+				}
 				return DEAL_CHECK_UNKNOWN, nil
 			}
 			return DEAL_CHECK_PROGRESS, nil
@@ -1673,13 +1679,15 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 	if provds.Proposal == nil {
 		log.Errorw("response from miner has nil Proposal", "miner", maddr, "propcid", d.PropCid.CID, "dealUUID", d.DealUUID)
 		if time.Since(d.CreatedAt) > time.Hour*24*14 {
-			cm.recordDealFailure(&DealFailureError{
+			if err := cm.recordDealFailure(&DealFailureError{
 				Miner:   maddr,
 				Phase:   "check-status",
 				Message: "miner returned nil response proposal and deal expired",
 				Content: d.Content,
 				UserID:  d.UserID,
-			})
+			}); err != nil {
+				return DEAL_CHECK_UNKNOWN, err
+			}
 			return DEAL_CHECK_UNKNOWN, nil
 		}
 		return DEAL_CHECK_UNKNOWN, fmt.Errorf("bad response from miner %s for deal %s deal status check: %s",
@@ -1688,13 +1696,15 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 
 	if provds.Proposal.StartEpoch < head.Height() {
 		// deal expired, miner didnt start it in time
-		cm.recordDealFailure(&DealFailureError{
+		if err := cm.recordDealFailure(&DealFailureError{
 			Miner:   maddr,
 			Phase:   "check-status",
 			Message: "deal did not make it on chain in time",
 			Content: d.Content,
 			UserID:  d.UserID,
-		})
+		}); err != nil {
+			return DEAL_CHECK_UNKNOWN, err
+		}
 		return DEAL_CHECK_UNKNOWN, nil
 	}
 	// miner still has time...
@@ -1743,13 +1753,15 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 
 	switch status.Status {
 	case datatransfer.Failed:
-		cm.recordDealFailure(&DealFailureError{
+		if err := cm.recordDealFailure(&DealFailureError{
 			Miner:   maddr,
 			Phase:   "data-transfer",
 			Message: fmt.Sprintf("transfer failed: %s", status.Message),
 			Content: content.ID,
 			UserID:  d.UserID,
-		})
+		}); err != nil {
+			return DEAL_CHECK_UNKNOWN, err
+		}
 
 		// TODO: returning unknown==error here feels excessive
 		// but since 'Failed' is a terminal state, we kinda just have to make a new deal altogether
@@ -1757,13 +1769,15 @@ func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, e
 			return DEAL_CHECK_UNKNOWN, nil
 		}
 	case datatransfer.Cancelled:
-		cm.recordDealFailure(&DealFailureError{
+		if err := cm.recordDealFailure(&DealFailureError{
 			Miner:   maddr,
 			Phase:   "data-transfer",
 			Message: fmt.Sprintf("transfer cancelled: %s", status.Message),
 			Content: content.ID,
 			UserID:  d.UserID,
-		})
+		}); err != nil {
+			return DEAL_CHECK_UNKNOWN, err
+		}
 		return DEAL_CHECK_UNKNOWN, nil
 	case datatransfer.Failing:
 		// I guess we just wait until its failed all the way?
@@ -1964,13 +1978,15 @@ func (cm *ContentManager) repairDeal(d *contentDeal) error {
 			log.Errorf("failed to get miner address from deal (%s): %w", d.Miner, err)
 		}
 
-		cm.recordDealFailure(&DealFailureError{
+		if err := cm.recordDealFailure(&DealFailureError{
 			Miner:   maddr,
 			Phase:   "fault",
 			Message: fmt.Sprintf("miner faulted on deal: %d", d.DealID),
 			Content: d.Content,
 			UserID:  d.UserID,
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	log.Infow("repair deal", "propcid", d.PropCid.CID, "miner", d.Miner, "content", d.Content)
@@ -2046,13 +2062,15 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content Conte
 		if err != nil {
 			var clientErr *filclient.Error
 			if !(xerrors.As(err, &clientErr) && clientErr.Code == filclient.ErrLotusError) {
-				cm.recordDealFailure(&DealFailureError{
+				if err := cm.recordDealFailure(&DealFailureError{
 					Miner:   m,
 					Phase:   "query-ask",
 					Message: err.Error(),
 					Content: content.ID,
 					UserID:  content.UserID,
-				})
+				}); err != nil {
+					return err
+				}
 			}
 			log.Warnf("failed to get ask for miner %s: %s\n", m, err)
 			continue
@@ -2065,13 +2083,15 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content Conte
 
 		if cm.priceIsTooHigh(price, verified) {
 			log.Infow("miners price is too high", "miner", m, "price", price)
-			cm.recordDealFailure(&DealFailureError{
+			if err := cm.recordDealFailure(&DealFailureError{
 				Miner:   m,
 				Phase:   "miner-search",
 				Message: fmt.Sprintf("miners price is too high: %s (verified = %v)", types.FIL(price), verified),
 				Content: content.ID,
 				UserID:  content.UserID,
-			})
+			}); err != nil {
+				return err
+			}
 			continue
 		}
 
@@ -2115,13 +2135,15 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content Conte
 
 		proto, err := cm.FilClient.DealProtocolForMiner(ctx, ms[i])
 		if err != nil {
-			cm.recordDealFailure(&DealFailureError{
+			if err := cm.recordDealFailure(&DealFailureError{
 				Miner:   ms[i],
 				Phase:   "send-proposal",
 				Message: err.Error(),
 				Content: content.ID,
 				UserID:  content.UserID,
-			})
+			}); err != nil {
+				return xerrors.Errorf("failed to record deal failure: %w", err)
+			}
 			continue
 		}
 
@@ -2175,13 +2197,15 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content Conte
 			if propPhase {
 				phase = "propose"
 			}
-			cm.recordDealFailure(&DealFailureError{
+			if err := cm.recordDealFailure(&DealFailureError{
 				Miner:   ms[i],
 				Phase:   phase,
 				Message: err.Error(),
 				Content: content.ID,
 				UserID:  content.UserID,
-			})
+			}); err != nil {
+				return fmt.Errorf("failed to record deal failure %w", err)
+			}
 			continue
 		}
 
@@ -2311,13 +2335,15 @@ func (cm *ContentManager) makeDealWithMiner(ctx context.Context, content Content
 	if err != nil {
 		var clientErr *filclient.Error
 		if !(xerrors.As(err, &clientErr) && clientErr.Code == filclient.ErrLotusError) {
-			cm.recordDealFailure(&DealFailureError{
+			if err := cm.recordDealFailure(&DealFailureError{
 				Miner:   miner,
 				Phase:   "query-ask",
 				Message: err.Error(),
 				Content: content.ID,
 				UserID:  content.UserID,
-			})
+			}); err != nil {
+				return 0, xerrors.Errorf("failed to record deal failure: %w", err)
+			}
 		}
 		return 0, xerrors.Errorf("failed to get ask for miner %s: %w", miner, err)
 	}
@@ -2342,13 +2368,15 @@ func (cm *ContentManager) makeDealWithMiner(ctx context.Context, content Content
 
 	proto, err := cm.FilClient.DealProtocolForMiner(ctx, miner)
 	if err != nil {
-		cm.recordDealFailure(&DealFailureError{
+		if err := cm.recordDealFailure(&DealFailureError{
 			Miner:   miner,
 			Phase:   "send-proposal",
 			Message: err.Error(),
 			Content: content.ID,
 			UserID:  content.UserID,
-		})
+		}); err != nil {
+			return 0, xerrors.Errorf("failed to record deal failure: %w", err)
+		}
 		return 0, err
 	}
 
@@ -2402,13 +2430,15 @@ func (cm *ContentManager) makeDealWithMiner(ctx context.Context, content Content
 		if propPhase {
 			phase = "propose"
 		}
-		cm.recordDealFailure(&DealFailureError{
+		if err := cm.recordDealFailure(&DealFailureError{
 			Miner:   miner,
 			Phase:   phase,
 			Message: err.Error(),
 			Content: content.ID,
 			UserID:  content.UserID,
-		})
+		}); err != nil {
+			return 0, fmt.Errorf("failed to record deal failure: %w", err)
+		}
 		return 0, err
 	}
 
@@ -2910,13 +2940,15 @@ func (cm *ContentManager) runRetrieval(ctx context.Context, contentToFetch uint)
 			span.RecordError(err)
 
 			log.Errorw("failed to query retrieval", "miner", maddr, "content", content.Cid.CID, "err", err)
-			cm.recordRetrievalFailure(&util.RetrievalFailureRecord{
+			if err := cm.recordRetrievalFailure(&util.RetrievalFailureRecord{
 				Miner:   maddr.String(),
 				Phase:   "query",
 				Message: err.Error(),
 				Content: content.ID,
 				Cid:     content.Cid,
-			})
+			}); err != nil {
+				return xerrors.Errorf("failed to record deal failure: %w", err)
+			}
 			continue
 		}
 		log.Infow("got retrieval ask", "content", content, "miner", maddr, "ask", ask)
@@ -2924,13 +2956,15 @@ func (cm *ContentManager) runRetrieval(ctx context.Context, contentToFetch uint)
 		if err := cm.tryRetrieve(ctx, maddr, content.Cid.CID, ask); err != nil {
 			span.RecordError(err)
 			log.Errorw("failed to retrieve content", "miner", maddr, "content", content.Cid.CID, "err", err)
-			cm.recordRetrievalFailure(&util.RetrievalFailureRecord{
+			if err := cm.recordRetrievalFailure(&util.RetrievalFailureRecord{
 				Miner:   maddr.String(),
 				Phase:   "retrieval",
 				Message: err.Error(),
 				Content: content.ID,
 				Cid:     content.Cid,
-			})
+			}); err != nil {
+				return xerrors.Errorf("failed to record deal failure: %w", err)
+			}
 			continue
 		}
 

--- a/retrieval.go
+++ b/retrieval.go
@@ -41,13 +41,15 @@ func (s *Server) retrievalAsksForContent(ctx context.Context, contid uint) (map[
 
 		resp, err := s.FilClient.RetrievalQuery(ctx, maddr, content.Cid.CID)
 		if err != nil {
-			s.CM.recordRetrievalFailure(&util.RetrievalFailureRecord{
+			if err := s.CM.recordRetrievalFailure(&util.RetrievalFailureRecord{
 				Miner:   maddr.String(),
 				Phase:   "query",
 				Message: err.Error(),
 				Content: content.ID,
 				Cid:     content.Cid,
-			})
+			}); err != nil {
+				return nil, err
+			}
 			log.Errorf("failed to query miner %s: %s", maddr, err)
 			continue
 		}
@@ -85,13 +87,15 @@ func (s *Server) retrieveContent(ctx context.Context, contid uint) error {
 	for m, ask := range asks {
 		if err := s.CM.tryRetrieve(ctx, m, content.Cid.CID, ask); err != nil {
 			log.Errorw("failed to retrieve content", "miner", m, "content", content.Cid.CID, "err", err)
-			s.CM.recordRetrievalFailure(&util.RetrievalFailureRecord{
+			if err := s.CM.recordRetrievalFailure(&util.RetrievalFailureRecord{
 				Miner:   m.String(),
 				Phase:   "retrieval",
 				Message: err.Error(),
 				Content: contid,
 				Cid:     content.Cid,
-			})
+			}); err != nil {
+				return err
+			}
 			continue
 		}
 

--- a/stagingbs/stagingbs.go
+++ b/stagingbs/stagingbs.go
@@ -19,7 +19,7 @@ type StagingBSMgr struct {
 }
 
 func NewStagingBSMgr(dir string) (*StagingBSMgr, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +65,10 @@ func (sbmgr *StagingBSMgr) CleanUp(bsid BSID) error {
 	bs, ok := sbmgr.open[bsid]
 	sbmgr.olk.Unlock()
 	if ok {
-		bs.Close()
+		err := bs.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	return os.RemoveAll(string(bsid))

--- a/util/http.go
+++ b/util/http.go
@@ -144,28 +144,37 @@ func ErrorHandler(err error, ctx echo.Context) {
 	var httpRespErr *HttpError
 	if xerrors.As(err, &httpRespErr) {
 		log.Errorf("handler error: %s", err)
-		ctx.JSON(httpRespErr.Code, HttpErrorResponse{Error: *httpRespErr})
+		if err := ctx.JSON(httpRespErr.Code, HttpErrorResponse{Error: *httpRespErr}); err != nil {
+			log.Errorf("handler error: %s", err)
+			return
+		}
 		return
 	}
 
 	var echoErr *echo.HTTPError
 	if xerrors.As(err, &echoErr) {
-		ctx.JSON(echoErr.Code, HttpErrorResponse{
+		if err := ctx.JSON(echoErr.Code, HttpErrorResponse{
 			Error: HttpError{
 				Code:    echoErr.Code,
 				Reason:  http.StatusText(echoErr.Code),
 				Details: echoErr.Message.(string),
 			},
-		})
+		}); err != nil {
+			log.Errorf("handler error: %s", err)
+			return
+		}
 		return
 	}
 
 	log.Errorf("handler error: %s", err)
-	ctx.JSON(http.StatusInternalServerError, HttpErrorResponse{
+	if err := ctx.JSON(http.StatusInternalServerError, HttpErrorResponse{
 		Error: HttpError{
 			Code:    http.StatusInternalServerError,
 			Reason:  http.StatusText(http.StatusInternalServerError),
 			Details: err.Error(),
 		},
-	})
+	}); err != nil {
+		log.Errorf("handler error: %s", err)
+		return
+	}
 }

--- a/util/http.go
+++ b/util/http.go
@@ -15,6 +15,7 @@ import (
 
 var log = logging.Logger("util")
 
+//#nosec G101 -- This is a false positive
 const (
 	ERR_INVALID_TOKEN              = "ERR_INVALID_TOKEN"
 	ERR_TOKEN_EXPIRED              = "ERR_TOKEN_EXPIRED"


### PR DESCRIPTION
Hello, this PR solves all the [issues](https://github.com/application-research/estuary/runs/7095139639?check_suite_focus=true) related to gosec security scan.

The issues are:
- G404 (CWE-338): Use of weak random number generator.
- G108 (CWE-200): Profiling endpoint is automatically exposed on /debug/pprof. 
- G101 (CWE-798): Potential hardcoded credentials.
- G304 (CWE-22): Potential file inclusion via variable.
- G601 (CWE-118): Implicit memory aliasing in for loop.
- G301 (CWE-276): Expect directory permissions to be 0750 or less.
- G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File".
- G104 (CWE-703): Errors unhandled.


Observations:
- G404 is a false positive because the rand number is between [0, len(uep)], there's no need to generate a 'secure' random number.

```
//#nosec G404 - crypto/rand it's not necessary for this use case
// propagate any query params
req, err := http.NewRequest("POST", fmt.Sprintf("%s/content/add", uep[rand.Intn(len(uep))]), c.Request().Body)
```

- G108 is okay because the endpoint is intended to be exposed.
```
//#nosec G108 - exposing the profiling endpoint is expected
	_ "net/http/pprof"
```

-  G101 is a false positive because gosec searches for a string literal with "AUTH" in it. Example:
```
//#nosec G101 -- This is a false positive
const (
	ERR_INVALID_TOKEN              = "ERR_INVALID_TOKEN"
	ERR_TOKEN_EXPIRED              = "ERR_TOKEN_EXPIRED"
```

- G304 I did: `f, err := os.Open(filepath.Clean(filename))`

- G601 I did this to fix it:
```
for i, pd := range params.Deals {
		pd := pd // <-- here
		nd, err := cborutil.AsIpld(&pd)
```

- G301 changed the permission 755 to 750 (let me know if this is a problem):
```
 	if err := os.MkdirAll(dir, 0750); err != nil {
```

- G307 is tricky because when we use defer on functions that return an error, it's ignored. So in a couple of places, I did this: 
```
defer func() {
		if errC := f.Close(); errC != nil {
			err = errC
		}
	}()
```
err is a named return value.
 
- the G104 warning shows in a lot of places, most are solvable by treating the error ( ` err = doSomething(); err != nil {} { return err }`). I put #nosec for this when setLogLevel shows up because its not common to treat log errors (let me know if this is ok). In some places, i used  `xerrors.Errorf` and `fmt.Errorf` as return because the enclosing lines did the same.
```
//#nosec G104 - it's not common to treat SetLogLevel error return
	logging.SetLogLevel(body.System, body.Level)
```


Because I'm adding the GitHub action for `gosec` on push to master/PR, I think it's better to put this scan before doing the push to the remote but I do not know where. Makefile? Which recipe (build)?


All feedback is welcome, thanks!