### PR TITLE
Dont use hardcoded credentials on estuary setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ cd estuary
 make clean all
 ```
 
-Then run `./estuary setup` to initialize the database as well as the access token. **Make sure to save this token as it'll be used to do almost all API calls**.
+Then run `./estuary setup --username=<uname> --password=<pword>` to initialize the database as well as the access token. **Make sure to save this token as it'll be used to do almost all API calls**.
 ```bash
-$ ./estuary setup
+$ ./estuary setup --username=<uname> --password=<pword>
 Auth Token: ESTb43c2f9c-9832-498a-8300-35d9c4b8c16eARY
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Requirements:
 To run locally in a 'dev' environment, first run:
 
 ```sh
-./estuary setup
+./estuary setup --username=<uname> --password=<pword>
 ```
 
 Save the auth token that this outputs, you will need it for interacting with
 and controlling the node.
 
-NOTE: if you want to use a different database than a sqlite instance stored in your local directory, you will need to configure that with the `--database` flag, passed before the setup command: `./estuary --database=XXXXX setup`
+NOTE: if you want to use a different database than a sqlite instance stored in your local directory, you will need to configure that with the `--database` flag, like so: `./estuary setup --username=<uname> --password=<pword> --database=XXXXX`
 
 Once you have the setup complete, choose an appropriate directory for estuary to keep its data, and use it as your datadir flag when running estuary.
 You will also need to tell estuary where it can access a lotus gateway api, we recommend using:

--- a/handlers.go
+++ b/handlers.go
@@ -2886,9 +2886,10 @@ func (s *Server) handleRegisterUser(c echo.Context) error {
 		if !xerrors.Is(err, gorm.ErrRecordNotFound) {
 			return err
 		}
+		exist = nil
 	}
 
-	if exist != nil && strings.ToLower(exist.Username) == username {
+	if exist != nil {
 		return &util.HttpError{
 			Code:   http.StatusBadRequest,
 			Reason: util.ERR_USERNAME_TAKEN,
@@ -4156,7 +4157,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 
 		// now, update size and cid
 		if err := s.DB.Model(Content{}).Where("id = ?", cont.ID).UpdateColumns(map[string]interface{}{
-			"cid":  util.DbCID{nd.Cid()},
+			"cid":  util.DbCID{CID: nd.Cid()},
 			"size": size,
 		}).Error; err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/application-research/estuary/node/modules/peering"
@@ -458,6 +460,27 @@ func main() {
 		{
 			Name:  "setup",
 			Usage: "Creates an initial auth token under new user \"admin\"",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "username",
+					Usage: "specify setup username",
+				},
+				&cli.StringFlag{
+					Name:  "password",
+					Usage: "specify setup password",
+				},
+				&cli.StringFlag{
+					Name:  "config",
+					Usage: "specify configuration file location",
+					Value: filepath.Join(hDir, ".estuary"),
+				},
+				&cli.StringFlag{
+					Name:    "database",
+					Usage:   "specify connection string for estuary database",
+					Value:   cfg.DatabaseConnString,
+					EnvVars: []string{"ESTUARY_DATABASE"},
+				},
+			},
 			Action: func(cctx *cli.Context) error {
 				if err := cfg.Load(cctx.String("config")); err != nil && err != config.ErrNotInitialized { // still want to report parsing errors
 					return err
@@ -465,6 +488,16 @@ func main() {
 
 				if err := overrideSetOptions(app.Flags, cctx, cfg); err != nil {
 					return nil
+				}
+
+				username := cctx.String("username")
+				if username == "" {
+					return errors.New("setup username cannot be empty")
+				}
+
+				password := cctx.String("password")
+				if password == "" {
+					return errors.New("setup password cannot be empty")
 				}
 
 				db, err := setupDatabase(cfg.DatabaseConnString)
@@ -476,18 +509,25 @@ func main() {
 					Logger: logger.Discard,
 				})
 
-				username := "admin"
-				password := ""
-				salt:= ""
+				username = strings.ToLower(username)
 
-				if err := quietdb.First(&User{}, "username = ?", username).Error; err == nil {
-					return fmt.Errorf("an admin user already exists")
+				var exist *User
+				if err := quietdb.First(&exist, "username = ?", username).Error; err != nil {
+					if !xerrors.Is(err, gorm.ErrRecordNotFound) {
+						return err
+					}
+					exist = nil
 				}
 
+				if exist != nil {
+					return fmt.Errorf("a user already exist for that username:%s", username)
+				}
+
+				salt := uuid.New().String()
 				newUser := &User{
 					UUID:     uuid.New().String(),
 					Username: username,
-					Salt:	  salt,
+					Salt:     salt,
 					PassHash: util.GetPasswordHash(password, salt),
 					Perm:     100,
 				}
@@ -505,7 +545,6 @@ func main() {
 				}
 
 				fmt.Printf("Auth Token: %v\n", authToken.Token)
-
 				return nil
 			},
 		}, {


### PR DESCRIPTION
This PR closes https://github.com/application-research/estuary/issues/332

table before test
<img width="1087" alt="Screenshot 2022-07-27 at 12 41 41" src="https://user-images.githubusercontent.com/13554411/181241367-c195739e-854b-4b5b-91a9-b1fb5d064e20.png">

- test with an omitted `username`

<img width="1015" alt="Screenshot 2022-07-27 at 12 41 16" src="https://user-images.githubusercontent.com/13554411/181241717-c65fee1a-18f5-4288-ac7f-5af0fb539889.png">

- test with an omitted `password`

<img width="1016" alt="Screenshot 2022-07-27 at 13 01 06" src="https://user-images.githubusercontent.com/13554411/181241933-13ff2924-aa69-4e1e-86dd-fc1cd39b5b2d.png">

- test when the `username` is already taken

<img width="1022" alt="Screenshot 2022-07-27 at 12 40 38" src="https://user-images.githubusercontent.com/13554411/181242153-d58f9f6e-4702-4afd-8ee1-896f6a0a2862.png">

- test when a new `username` and `password` is used

<img width="1023" alt="Screenshot 2022-07-27 at 12 56 46" src="https://user-images.githubusercontent.com/13554411/181242304-af143463-eb42-4ea0-8789-190eec72b0e2.png">

table after test
<img width="1033" alt="Screenshot 2022-07-27 at 13 05 00" src="https://user-images.githubusercontent.com/13554411/181242589-f505eb7c-0ebf-4e35-b142-229ea35097b5.png">

