### PR TITLE
Fix redirect on content adding

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -3105,7 +3105,7 @@ func (s *Server) handleGetViewer(c echo.Context, u *User) error {
 			DealDuration:          dealDuration,
 			MaxStagingWait:        maxStagingZoneLifetime,
 			FileStagingThreshold:  int64(individualDealThreshold),
-			ContentAddingDisabled: s.CM.contentAddingDisabled || u.StorageDisabled,
+			ContentAddingDisabled: s.CM.globalContentAddingDisabled || u.StorageDisabled,
 			DealMakingDisabled:    s.CM.dealMakingDisabled(),
 			UploadEndpoints:       uep,
 			Flags:                 u.Flags,
@@ -5359,5 +5359,5 @@ func (s *Server) getShuttleConfig(hostname string, authToken string) (interface{
 }
 
 func (s *Server) isContentAddingDisabled(u *User) bool {
-	return s.CM.contentAddingDisabled || u.StorageDisabled
+	return s.CM.globalContentAddingDisabled || u.StorageDisabled
 }

--- a/handlers.go
+++ b/handlers.go
@@ -968,7 +968,7 @@ func (s *Server) redirectContentAdding(c echo.Context, u *User) error {
 		return err
 	} else if len(uep) > 0 {
 		// propagate any query params
-		req, err := http.NewRequest("POST", fmt.Sprintf("%s/content/add", uep[rand.Intn(len(uep))]), c.Request().Body)
+		req, err := http.NewRequest("POST", uep[rand.Intn(len(uep))], c.Request().Body)
 		if err != nil {
 			return err
 		}

--- a/handlers.go
+++ b/handlers.go
@@ -3137,6 +3137,7 @@ func (s *Server) getPreferredUploadEndpoints(u *User) ([]string, error) {
 	var shuttles []Shuttle
 	for hnd, sh := range s.CM.shuttles {
 		if sh.hostname == "" {
+			log.Debugf("shuttle %+v has empty hostname", sh)
 			continue
 		}
 
@@ -3147,6 +3148,7 @@ func (s *Server) getPreferredUploadEndpoints(u *User) ([]string, error) {
 		}
 
 		if !shuttle.Open {
+			log.Debugf("shuttle %+v is not open, skipping", shuttle)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -478,7 +478,7 @@ func main() {
 
 				username := "admin"
 				password := ""
-				salt:= ""
+				salt := ""
 
 				if err := quietdb.First(&User{}, "username = ?", username).Error; err == nil {
 					return fmt.Errorf("an admin user already exists")
@@ -487,7 +487,7 @@ func main() {
 				newUser := &User{
 					UUID:     uuid.New().String(),
 					Username: username,
-					Salt:	  salt,
+					Salt:     salt,
 					PassHash: util.GetPasswordHash(password, salt),
 					Perm:     100,
 				}
@@ -657,7 +657,7 @@ func main() {
 		go cm.handleShuttleMessages(cctx.Context, cfg.ShuttleMessageHandlers) // register workers/handlers to process shuttle rpc messages from a channel(queue)
 
 		// refresh pin queue for local contents
-		if !cm.contentAddingDisabled {
+		if !cm.globalContentAddingDisabled {
 			go func() {
 				if err := cm.refreshPinQueue(cctx.Context, util.ContentLocationLocal); err != nil {
 					log.Errorf("failed to refresh pin queue: %s", err)

--- a/replication.go
+++ b/replication.go
@@ -98,8 +98,8 @@ type ContentManager struct {
 	dealDisabledLk       sync.Mutex
 	isDealMakingDisabled bool
 
-	contentAddingDisabled      bool
-	localContentAddingDisabled bool
+	globalContentAddingDisabled bool
+	localContentAddingDisabled  bool
 
 	Replication int
 
@@ -313,34 +313,34 @@ func NewContentManager(db *gorm.DB, api api.Gateway, fc *filclient.FilClient, tb
 	}
 
 	cm := &ContentManager{
-		Provider:                   prov,
-		DB:                         db,
-		Api:                        api,
-		FilClient:                  fc,
-		Blockstore:                 tbs.Under().(node.EstuaryBlockstore),
-		Host:                       nd.Host,
-		Node:                       nd,
-		NotifyBlockstore:           nbs,
-		Tracker:                    tbs,
-		ToCheck:                    make(chan uint, 100000),
-		retrievalsInProgress:       make(map[uint]*util.RetrievalProgress),
-		buckets:                    make(map[uint][]*contentStagingZone),
-		pinJobs:                    make(map[uint]*pinner.PinningOperation),
-		pinMgr:                     pinmgr,
-		remoteTransferStatus:       cache,
-		shuttles:                   make(map[string]*ShuttleConnection),
-		contentSizeLimit:           util.DefaultContentSizeLimit,
-		hostname:                   cfg.Hostname,
-		inflightCids:               make(map[cid.Cid]uint),
-		FailDealOnTransferFailure:  cfg.Deal.FailOnTransferFailure,
-		isDealMakingDisabled:       cfg.Deal.Disable,
-		contentAddingDisabled:      cfg.Content.DisableGlobalAdding,
-		localContentAddingDisabled: cfg.Content.DisableLocalAdding,
-		VerifiedDeal:               cfg.Deal.Verified,
-		Replication:                cfg.Replication,
-		tracer:                     otel.Tracer("replicator"),
-		DisableFilecoinStorage:     cfg.DisableFilecoinStorage,
-		IncomingRPCMessages:        make(chan *drpc.Message),
+		Provider:                    prov,
+		DB:                          db,
+		Api:                         api,
+		FilClient:                   fc,
+		Blockstore:                  tbs.Under().(node.EstuaryBlockstore),
+		Host:                        nd.Host,
+		Node:                        nd,
+		NotifyBlockstore:            nbs,
+		Tracker:                     tbs,
+		ToCheck:                     make(chan uint, 100000),
+		retrievalsInProgress:        make(map[uint]*util.RetrievalProgress),
+		buckets:                     make(map[uint][]*contentStagingZone),
+		pinJobs:                     make(map[uint]*pinner.PinningOperation),
+		pinMgr:                      pinmgr,
+		remoteTransferStatus:        cache,
+		shuttles:                    make(map[string]*ShuttleConnection),
+		contentSizeLimit:            util.DefaultContentSizeLimit,
+		hostname:                    cfg.Hostname,
+		inflightCids:                make(map[cid.Cid]uint),
+		FailDealOnTransferFailure:   cfg.Deal.FailOnTransferFailure,
+		isDealMakingDisabled:        cfg.Deal.Disable,
+		globalContentAddingDisabled: cfg.Content.DisableGlobalAdding,
+		localContentAddingDisabled:  cfg.Content.DisableLocalAdding,
+		VerifiedDeal:                cfg.Deal.Verified,
+		Replication:                 cfg.Replication,
+		tracer:                      otel.Tracer("replicator"),
+		DisableFilecoinStorage:      cfg.DisableFilecoinStorage,
+		IncomingRPCMessages:         make(chan *drpc.Message),
 	}
 	qm := newQueueManager(func(c uint) {
 		cm.ToCheck <- c

--- a/shuttle.go
+++ b/shuttle.go
@@ -102,7 +102,7 @@ func (cm *ContentManager) registerShuttleConnection(handle string, hello *drpc.H
 	}
 
 	// when a shuttle connects, refresh its pin queue
-	if !cm.contentAddingDisabled {
+	if !cm.globalContentAddingDisabled {
 		go func() {
 			if err := cm.refreshPinQueue(ctx, handle); err != nil {
 				log.Errorf("failed to refresh shuttle: %s pin queue: %s", handle, err)

--- a/util/misc.go
+++ b/util/misc.go
@@ -55,7 +55,7 @@ func CidIsUnwalkable(c cid.Cid) bool {
 
 func ErrorIfContentAddingDisabled(isContentAddingDisabled bool) error {
 	if isContentAddingDisabled {
-		return HttpError{
+		return &HttpError{
 			Code:    http.StatusBadRequest,
 			Reason:  ERR_CONTENT_ADDING_DISABLED,
 			Details: "uploading content to this node is not allowed at the moment",

--- a/util/misc.go
+++ b/util/misc.go
@@ -1,12 +1,13 @@
 package util
 
 import (
+	"net/http"
+
 	"github.com/application-research/filclient"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multihash"
-	"net/http"
 )
 
 func TransferTerminated(st *filclient.ChannelState) bool {


### PR DESCRIPTION
#315 introduced had an issue that made impossible for the functionality to work. Basically, the function was returning a slightly different endpoint string and we ended up redirecting to an inexistent place (hence the 404s instead of 400s when we tried to upload to  `api.estuary.tech/content/add`).


### Verification
Before (with `--disable-local-content-adding=true`):
![image](https://user-images.githubusercontent.com/8129788/181792919-acaaf8f2-e677-4b20-8df8-1638f961c524.png)

After (with `--disable-local-content-adding=true`):
![Screenshot from 2022-07-29 12-25-21](https://user-images.githubusercontent.com/8129788/181792988-f4dcdfd2-a27b-4d77-a7ab-af09f7273a0f.png)

The behavior with `--disable-content-adding=true` (not `local`) is the same, we always reject:
![image](https://user-images.githubusercontent.com/8129788/181793343-af49135e-864e-4f31-b793-f8ebf5a12992.png)
