### PR TITLE
fix pinning status for shuttle contents

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1151,12 +1151,8 @@ func (s *Shuttle) handleLogLevel(c echo.Context) error {
 func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 	ctx := c.Request().Context()
 
-	if u.StorageDisabled || s.disableLocalAdding {
-		return &util.HttpError{
-			Code:    http.StatusBadRequest,
-			Reason:  util.ERR_CONTENT_ADDING_DISABLED,
-			Details: "uploading content to this node is not allowed at the moment",
-		}
+	if err := util.ErrorIfContentAddingDisabled(u.StorageDisabled || s.disableLocalAdding); err != nil {
+		return err
 	}
 
 	form, err := c.MultipartForm()
@@ -1222,7 +1218,6 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 		Content: contid,
 		Cid:     util.DbCID{CID: nd.Cid()},
 		UserID:  u.ID,
-
 		Active:  false,
 		Pinning: true,
 	}
@@ -1359,7 +1354,6 @@ func (s *Shuttle) handleAddCar(c echo.Context, u *User) error {
 		Content: contid,
 		Cid:     util.DbCID{CID: root},
 		UserID:  u.ID,
-
 		Active:  false,
 		Pinning: true,
 	}
@@ -1462,7 +1456,6 @@ func (s *Shuttle) shuttleCreateContent(ctx context.Context, uid uint, root cid.C
 			Filename: filename,
 			Location: s.shuttleHandle,
 		},
-
 		Collections:  cols,
 		DagSplitRoot: dagsplitroot,
 		User:         uid,
@@ -2260,7 +2253,6 @@ func (s *Shuttle) handleImportDeal(c echo.Context, u *User) error {
 			}
 			continue
 		}
-
 		break
 	}
 

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1078,6 +1078,10 @@ func (s *Shuttle) ServeAPI() error {
 	return e.Start(s.shuttleConfig.ApiListen)
 }
 
+func (s *Shuttle) isContentAddingDisabled(u *User) bool {
+	return s.disableLocalAdding || u.StorageDisabled
+}
+
 func (s *Shuttle) tracingMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 
@@ -1149,7 +1153,7 @@ func (s *Shuttle) handleLogLevel(c echo.Context) error {
 func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 	ctx := c.Request().Context()
 
-	if err := util.ErrorIfContentAddingDisabled(u.StorageDisabled || s.disableLocalAdding); err != nil {
+	if err := util.ErrorIfContentAddingDisabled(s.isContentAddingDisabled(u)); err != nil {
 		return err
 	}
 
@@ -1279,7 +1283,7 @@ func (s *Shuttle) Provide(ctx context.Context, c cid.Cid) error {
 func (s *Shuttle) handleAddCar(c echo.Context, u *User) error {
 	ctx := c.Request().Context()
 
-	if err := util.ErrorIfContentAddingDisabled(u.StorageDisabled || s.disableLocalAdding); err != nil {
+	if err := util.ErrorIfContentAddingDisabled(s.isContentAddingDisabled(u)); err != nil {
 		return err
 	}
 

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -572,7 +572,6 @@ func (s *Shuttle) handleRpcSplitContent(ctx context.Context, req *drpc.SplitCont
 				return err
 			}
 		}
-
 		s.sendSplitContentComplete(ctx, pin.Content)
 		return nil
 	}
@@ -591,7 +590,6 @@ func (s *Shuttle) handleRpcSplitContent(ctx context.Context, req *drpc.SplitCont
 		if err != nil {
 			return err
 		}
-
 		boxCids = append(boxCids, cc)
 	}
 
@@ -603,7 +601,7 @@ func (s *Shuttle) handleRpcSplitContent(ctx context.Context, req *drpc.SplitCont
 			return err
 		}
 
-		pin := &Pin{
+		cpin := &Pin{
 			Cid:       util.DbCID{CID: c},
 			Content:   contid,
 			Active:    false,
@@ -613,11 +611,11 @@ func (s *Shuttle) handleRpcSplitContent(ctx context.Context, req *drpc.SplitCont
 			SplitFrom: pin.Content,
 		}
 
-		if err := s.DB.Create(pin).Error; err != nil {
+		if err := s.DB.Create(cpin).Error; err != nil {
 			return xerrors.Errorf("failed to track new content in database: %w", err)
 		}
 
-		if err := s.addDatabaseTrackingToContent(ctx, pin.Content, dserv, s.Node.Blockstore, c, func(int64) {}); err != nil {
+		if err := s.addDatabaseTrackingToContent(ctx, cpin.Content, dserv, s.Node.Blockstore, c, func(int64) {}); err != nil {
 			return err
 		}
 	}
@@ -627,12 +625,12 @@ func (s *Shuttle) handleRpcSplitContent(ctx context.Context, req *drpc.SplitCont
 	}).Error; err != nil {
 		return err
 	}
+
 	if err := s.DB.Where("pin = ?", pin.ID).Delete(&ObjRef{}).Error; err != nil {
 		return err
 	}
 
 	s.sendSplitContentComplete(ctx, pin.Content)
-
 	return nil
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -4658,7 +4658,7 @@ func (s *Server) handleCreateContent(c echo.Context, u *User) error {
 		Cid:         util.DbCID{CID: rootCID},
 		Filename:    req.Filename,
 		Active:      false,
-		Pinning:     false,
+		Pinning:     true,
 		UserID:      u.ID,
 		Replication: s.CM.Replication,
 		Location:    req.Location,
@@ -4679,7 +4679,6 @@ func (s *Server) handleCreateContent(c echo.Context, u *User) error {
 		}
 
 		path := &sp
-
 		if err := s.DB.Create(&CollectionRef{
 			Collection: col.ID,
 			Content:    content.ID,
@@ -5031,7 +5030,7 @@ func (s *Server) handleShuttleCreateContent(c echo.Context) error {
 		Cid:         util.DbCID{CID: root},
 		Filename:    req.Filename,
 		Active:      false,
-		Pinning:     false,
+		Pinning:     true,
 		UserID:      req.User,
 		Replication: s.CM.Replication,
 		Location:    req.Location,

--- a/pinning.go
+++ b/pinning.go
@@ -375,7 +375,6 @@ func (cm *ContentManager) selectLocationForContent(ctx context.Context, obj cid.
 	})
 
 	if len(shuttles) == 0 {
-		//log.Info("no shuttles available for content to be delegated to")
 		if cm.localContentAddingDisabled {
 			return "", fmt.Errorf("no shuttles available and local content adding disabled")
 		}
@@ -923,11 +922,11 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 	if cont.Active {
 		// content already active, no need to add objects, just update location
 		if err := cm.DB.Model(Content{}).Where("id = ?", cont.ID).UpdateColumns(map[string]interface{}{
+			"pinning":  false,
 			"location": handle,
 		}).Error; err != nil {
 			return err
 		}
-
 		// TODO: should we recheck the staging zones?
 		return nil
 	}
@@ -956,6 +955,5 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 	}
 
 	cm.ToCheck <- cont.ID
-
 	return nil
 }


### PR DESCRIPTION
Currently, when shuttles add content and fail to signal estuary about pin completion (maybe due to downtime), estuary will not check if this content is pinned. This leaves the content in a stale state on Estuary, but on the shuttle, it will be pinned and active.

This PR correctly sets the pin status on Estuary side when the content is created, and if any downtime occurs, when Estuary is back up, it will retry the pinning and be updated accordingly.

see here for more context https://filecoinproject.slack.com/archives/C033QS35MFA/p1659047543608269