### PR TITLE
clarify difference between --no-storage-cron and --disable-deal-making

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,8 +144,8 @@ func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Estuary
 			cfg.LowMem = cctx.Bool("lowmem")
 		case "no-storage-cron":
 			cfg.DisableFilecoinStorage = cctx.Bool("no-storage-cron")
-		case "disable-deal-making":
-			cfg.Deal.IsDisabled = cctx.Bool("disable-deal-making")
+		case "disable-new-deals":
+			cfg.Deal.IsDisabled = cctx.Bool("disable-new-deals")
 		case "verified-deal":
 			cfg.Deal.IsVerified = cctx.Bool("verified-deal")
 		case "fail-deals-on-transfer-failure":
@@ -297,8 +297,8 @@ func main() {
 			Value: cfg.Deal.FailOnTransferFailure,
 		},
 		&cli.BoolFlag{
-			Name:  "disable-deal-making",
-			Usage: "do not create any new deals (existing deals will still be processed)",
+			Name:  "disable-new-deals",
+			Usage: "prevents the worker from making any new deals, but existing deals will still be updated/checked",
 			Value: cfg.Deal.IsDisabled,
 		},
 		&cli.BoolFlag{

--- a/main.go
+++ b/main.go
@@ -142,8 +142,8 @@ func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Estuary
 			cfg.Replication = cctx.Int("replication")
 		case "lowmem":
 			cfg.LowMem = cctx.Bool("lowmem")
-		case "disable-fil-node":
-			cfg.DisableFilecoinStorage = cctx.Bool("disable-fil-node")
+		case "disable-deals-storage":
+			cfg.DisableFilecoinStorage = cctx.Bool("disable-deals-storage")
 		case "disable-new-deals":
 			cfg.Deal.IsDisabled = cctx.Bool("disable-new-deals")
 		case "verified-deal":
@@ -265,7 +265,7 @@ func main() {
 			Hidden: true,
 		},
 		&cli.BoolFlag{
-			Name:  "disable-fil-node",
+			Name:  "disable-deals-storage",
 			Usage: "stops estuary from making new deals and updating existing deals, essentially runs as an ipfs node instead",
 			Value: cfg.DisableFilecoinStorage,
 		},

--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:  "no-storage-cron",
-			Usage: "run estuary without processing files into deals",
+			Usage: "stops estuary from making new deals and updating existing deals, essentially runs as an ipfs node",
 			Value: cfg.DisableFilecoinStorage,
 		},
 		&cli.BoolFlag{

--- a/main.go
+++ b/main.go
@@ -142,8 +142,8 @@ func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Estuary
 			cfg.Replication = cctx.Int("replication")
 		case "lowmem":
 			cfg.LowMem = cctx.Bool("lowmem")
-		case "no-storage-cron":
-			cfg.DisableFilecoinStorage = cctx.Bool("no-storage-cron")
+		case "disable-fil-node":
+			cfg.DisableFilecoinStorage = cctx.Bool("disable-fil-node")
 		case "disable-new-deals":
 			cfg.Deal.IsDisabled = cctx.Bool("disable-new-deals")
 		case "verified-deal":
@@ -265,8 +265,8 @@ func main() {
 			Hidden: true,
 		},
 		&cli.BoolFlag{
-			Name:  "no-storage-cron",
-			Usage: "stops estuary from making new deals and updating existing deals, essentially runs as an ipfs node",
+			Name:  "disable-fil-node",
+			Usage: "stops estuary from making new deals and updating existing deals, essentially runs as an ipfs node instead",
 			Value: cfg.DisableFilecoinStorage,
 		},
 		&cli.BoolFlag{

--- a/scripts/estuary-service/estuary.service
+++ b/scripts/estuary-service/estuary.service
@@ -5,7 +5,7 @@ After=network-online.target postgres.service
 [Service]
 EnvironmentFile=/etc/estuary/log.env
 EnvironmentFile=/etc/estuary/config.env
-ExecStart=/usr/local/bin/estuary --repo=${LOTUS_REPO} --database=${ESTUARY_DB_CONN} --datadir=${ESTUARY_DATA} --apilisten=${ESTUARY_API} --lightstep-token=${ESTUARY_LIGHTSTEP_TOKEN} --logging=false --fail-deals-on-transfer-failure --disable-deal-making=false --disable-content-adding=false --disable-local-content-adding=true
+ExecStart=/usr/local/bin/estuary --repo=${LOTUS_REPO} --database=${ESTUARY_DB_CONN} --datadir=${ESTUARY_DATA} --apilisten=${ESTUARY_API} --lightstep-token=${ESTUARY_LIGHTSTEP_TOKEN} --logging=false --fail-deals-on-transfer-failure --disable-new-deals=false --disable-content-adding=false --disable-local-content-adding=true
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
- Changed the name of the `--disable-deal-making` flag to `--disable-new-deals` for clarity, edited the help message 
- Changed the description of the `--no-storage-cron`, left the name of the flag as is because it seems clear as is if you know what cron means, if not it can be changed 