### PR TITLE
Add build and deploy workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,112 @@
+name: Build
+
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_ORG:
+        description: 'Dockerhub org to get image from'
+        required: true
+
+jobs:
+  build_linux_amd64:
+    # Map the job outputs to step outputs
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        version: ['linux/amd64']
+        include:
+        # add the GO naming convention for OS ($GOOS) and architecture ($GOARCH)
+        # instead of using Linux' naming convention (version items).
+          - version: linux/amd64
+            OS: linux
+            ARCH: amd64
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Build binary for ${{ matrix.version }}
+      env:
+        DOCKERHUB_ORG: ${{ secrets.DOCKERHUB_ORG }}
+      run: |
+        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} $DOCKERHUB_ORG/estuary-base:latest /bin/sh -c "make"
+    - name: Prepare build artifact for stashing
+      run: |
+        mkdir binaries
+        mv ./estuary ./estuary-shuttle ./benchest ./bsget ./binaries
+    - name: Upload binaries to be used by next workflow
+      uses: actions/upload-artifact@v1
+      with:
+        name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
+        path: ./binaries
+
+  build_linux_arm64:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        version: ['linux/arm64']
+        include:
+        # add the GO naming convention for OS ($GOOS) and architecture ($GOARCH)
+        # instead of using Linux' naming convention (version items).
+          - version: linux/arm64
+            OS: linux
+            ARCH: arm64
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Install QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: linux/arm64
+
+    - name: Build binary for ${{ matrix.version }}
+      env:
+        DOCKERHUB_ORG: ${{ secrets.DOCKERHUB_ORG }}
+      run: |
+        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} $DOCKERHUB_ORG/estuary-base:linux-arm64 /bin/sh -c "cp /build/* extern/filecoin-ffi/ && touch extern/filecoin-ffi/.install-filcrypto && make"
+    - name: Prepare build artifact for stashing
+      run: |
+        mkdir binaries
+        mv ./estuary ./estuary-shuttle ./benchest ./bsget ./binaries
+    - name: Upload binaries to be used by next workflow
+      uses: actions/upload-artifact@v1
+      with:
+        name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
+        path: ./binaries
+
+  build_macos_amd64:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        version: ['darwin-amd64']
+        include:
+          - version: darwin-amd64
+            OS: darwin
+            ARCH: amd64
+    steps:
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v1
+      id: go
+      with:
+        go-version: 1.17
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install dependencies
+      run: |
+        brew install bzr jq pkg-config rustup hwloc
+        cargo install cargo-lipo
+    - name: Build binary for macOS
+      run: |
+        export PATH=/System/Volumes/Data/Users/runner/go/bin:$PATH
+        make
+    - name: Prepare build artifact for stashing
+      run: |
+        mkdir binaries
+        mv ./estuary ./estuary-shuttle ./benchest ./bsget ./binaries
+    - name: Upload binaries to be used by next workflow
+      uses: actions/upload-artifact@v1
+      with:
+        name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
+        path: ./binaries

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,19 @@
+name: Deploy dev branch to staging box
+
+on:
+  push:
+    branches: [ dev ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy dev through ssh
+        uses: fifsky/ssh-action@master
+        with:
+          command: |
+            cd ~/estuary-docker
+            docker-compose stop
+            docker-compose up -d
+          host: staging.estuary.tech
+          key: ${{ secrets.STAGING_SSH_KEY }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,10 +6,11 @@ on:
     tags:
       - '*'
 
+
 jobs:
   docker:
     runs-on: ubuntu-latest
-    steps:     
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,114 +10,16 @@ permissions:
   contents: write
 
 jobs:
-  build_linux_amd64:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        version: ['linux/amd64']
-        include:
-        # add the GO naming convention for OS ($GOOS) and architecture ($GOARCH)
-        # instead of using Linux' naming convention (version items).
-          - version: linux/amd64
-            OS: linux
-            ARCH: amd64
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Build binary for ${{ matrix.version }}
-      run: |
-        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} ${{ secrets.DOCKERHUB_ORG }}/estuary-base:latest /bin/sh -c "make"
-    - name: Prepare build artifact for stashing
-      run: |
-        mkdir release
+  build_binaries:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit # pass secrets to build workflows
 
-        mv ./estuary ./estuary-shuttle ./benchest ./bsget ./release
-    # The build artifact can be identified by the trailing sha of the git commit
-    - name: Stash the build artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
-        path: ./release
-  
-  build_linux_arm64:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        version: ['linux/arm64']
-        include:
-        # add the GO naming convention for OS ($GOOS) and architecture ($GOARCH)
-        # instead of using Linux' naming convention (version items).
-          - version: linux/arm64
-            OS: linux
-            ARCH: arm64
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    
-    - name: Install QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: linux/arm64
-
-    - name: Build binary for ${{ matrix.version }}
-      run: |
-        docker run --rm -v "$PWD":/usr/est/build -w /usr/est/build --platform=${{ matrix.version }} ${{ secrets.DOCKERHUB_ORG }}/estuary-base:linux-arm64 /bin/sh -c "cp /build/* extern/filecoin-ffi/ && touch extern/filecoin-ffi/.install-filcrypto && make"
-    
-    - name: Prepare build artifact for stashing
-      run: |
-        mkdir release
-        mv ./estuary ./estuary-shuttle ./benchest ./bsget ./release
-    # The build artifact can be identified by the trailing sha of the git commit
-    - name: Stash the build artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
-        path: ./release
-  
-  build_macos_amd64:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        version: ['darwin-amd64']
-        include:
-          - version: darwin-amd64
-            OS: darwin
-            ARCH: amd64
-    steps:
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v1
-      id: go
-      with:
-        go-version: 1.17
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Install dependencies
-      run: |
-        brew install bzr jq pkg-config rustup hwloc
-        cargo install cargo-lipo
-    - name: Build binary for macOS
-      run: |
-        export PATH=/System/Volumes/Data/Users/runner/go/bin:$PATH
-        make
-    - name: Prepare build artifact for stashing
-      run: |
-        mkdir release
-        mv ./estuary ./estuary-shuttle ./benchest ./bsget ./release
-    # The build artifact can be identified by the trailing sha of the git commit
-    - name: Stash the build artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: estuary-${{ matrix.OS }}-${{ matrix.ARCH }}-${{ github.sha }}
-        path: ./release
 
   # A Github release is created whenever the git reference contains a tag, starting with 'v*' (e.g. v0.4.2)
   # And the previous build jobs have been successful
   create_release:
     runs-on: ubuntu-20.04
-    needs: [build_linux_amd64, build_linux_arm64, build_macos_amd64]
+    needs: build_binaries
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
     - name: Create Release

--- a/.github/workflows/secops.yml
+++ b/.github/workflows/secops.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - dev
   pull_request:
     branches:
       - master
+      - dev
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Build
-      run: make generate-swagger 
+      run: make generate-swagger
 
     - name: Check for new files
       run: echo "NEW_FILES=$(git diff | cat | wc -m)" >> $GITHUB_ENV


### PR DESCRIPTION
- Add reusable build workflows
- Add a workflow to deploy the dev branch on the staging box

TODO after this is merged:
1. add STAGING_USERNAME var to estuary repo

2. add the following to the deployments document (for staging)
    - clone application-research/estuary-docker on staging box (`/root`)
    - change these on `/root/estuary-docker/docker-compose.yml`:
        - `ESTUARY_API_LISTEN=0.0.0.0:80` (put estuary-www on port 80)
        - `ESTUARY_HOSTNAME=http://staging.estuary.tech` (everywhere)
        - `ESTUARY_API=http://estuary-main:3004` to
          `http://staging.estuary.tech:3004`
        - comment out the estuary-shuttle part
    - find the new auth token on `/usr/src/estuary/data/estuary.db` (`select * from auth_tokens`)
    - TODO: use postgres instead of estuary.db (see https://github.com/application-research/estuary-docker/issues/4)