### PR TITLE
fix: application crashing on unverified client datacap

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -1402,7 +1402,7 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content util.Conten
 		// only verified deals need datacap checks
 		if verified {
 			bl, err := cm.FilClient.Balance(ctx)
-			if err != nil {
+			if err != nil || bl.VerifiedClientBalance == nil {
 				return errors.Wrap(err, "could not retrieve dataCap from client balance")
 			}
 


### PR DESCRIPTION
I ran into this error where the estuary application was continuously crashing after restarting. It was because the wallet address was exhausted of datacap.  Earlier I had 32GB datacap, but after making a few deals, this got exhausted and Balance.VerifiedClientBalance comes as nil instead of 0. This leads to the crashing of the estuary app because of nil pointer dereference. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1f18571]

goroutine 4993 [running]:
main.(*ContentManager).ensureStorage(_, {_, _}, {0x2, {0x25d858f2, 0xeda8eacf1, 0x0}, {0x25d858f2, 0xeda8eacf1, 0x0}, ...}, ...)
        /home/ubuntu/filecoin-learn/src/estuary/replication.go:1408 +0xfb1
main.(*ContentManager).ContentWatcher(0xc004c48820)
        /home/ubuntu/filecoin-learn/src/estuary/replication.go:358 +0x46d
created by main.main.func3
        /home/ubuntu/filecoin-learn/src/estuary/main.go:633 +0x120a
```

