### PR TITLE
chore: added shuttle read-timeout config

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -589,7 +589,12 @@ func main() {
 					log.Error(err)
 				}
 			})
-			if err := http.ListenAndServe("127.0.0.1:3105", nil); err != nil {
+			server := &http.Server{
+				Addr:              "127.0.0.1:3105",
+				ReadHeaderTimeout: 5 * time.Second,
+			}
+
+			if err := server.ListenAndServe(); err != nil {
 				log.Errorf("failed to start http server for pprof endpoints: %s", err)
 			}
 		}()


### PR DESCRIPTION
# Changes

This PR introduces a read head timeout on the shuttle. This closes inactive connections and prevents any DDOS attacks.

