### PR TITLE
correctly check deal status and correctly restart transfers

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -2126,8 +2126,8 @@ func (s *Shuttle) handleRestartAllTransfers(e echo.Context) error {
 
 	var restarted int
 	for id, st := range transfers {
-		isTerm, _ := util.TransferTerminated(filclient.ChannelStateConv(st))
-		if !isTerm {
+		canRestart := util.CanRestartTransfer(filclient.ChannelStateConv(st))
+		if canRestart {
 			idcp := id
 			if err := s.Filc.RestartTransfer(ctx, &idcp); err != nil {
 				log.Warnf("failed to restart transfer: %s", err)

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -645,8 +645,8 @@ func (s *Shuttle) handleRpcRestartTransfer(ctx context.Context, req *drpc.Restar
 		return err
 	}
 
-	canRestart := util.CanRestartTransfer(st)
-	if !canRestart {
+	cannotRestart := !util.CanRestartTransfer(st)
+	if cannotRestart {
 		trsFailed, msg := util.TransferFailed(st)
 		if trsFailed {
 			s.sendTransferStatusUpdate(ctx, &drpc.TransferStatus{

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -645,15 +645,19 @@ func (s *Shuttle) handleRpcRestartTransfer(ctx context.Context, req *drpc.Restar
 		return err
 	}
 
-	isTerm, msg := util.TransferTerminated(st)
-	if isTerm {
-		s.sendTransferStatusUpdate(ctx, &drpc.TransferStatus{
-			Chanid:  req.ChanID.String(),
-			State:   st,
-			Failed:  true,
-			Message: fmt.Sprintf("status: %d(%s), message: %s", st.Status, msg, st.Message),
-		})
-		return fmt.Errorf("cannot restart transfer with status: %d", st.Status)
+	canRestart := util.CanRestartTransfer(st)
+	if !canRestart {
+		trsFailed, msg := util.TransferFailed(st)
+		if trsFailed {
+			s.sendTransferStatusUpdate(ctx, &drpc.TransferStatus{
+				Chanid:  req.ChanID.String(),
+				State:   st,
+				Failed:  true,
+				Message: fmt.Sprintf("status: %d(%s), message: %s", st.Status, msg, st.Message),
+			})
+			return fmt.Errorf("cannot restart transfer with status: %d", st.Status)
+		}
+		return nil
 	}
 	return s.Filc.RestartTransfer(ctx, &req.ChanID)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -1309,7 +1309,7 @@ func (s *Server) handleContentStatus(c echo.Context, u *User) error {
 				Deal: d,
 			}
 
-			chanst, err := s.CM.GetTransferStatus(ctx, &d, &content)
+			chanst, err := s.CM.GetTransferStatus(ctx, &d, content.Cid.CID, content.Location)
 			if err != nil {
 				log.Errorf("failed to get transfer status: %s", err)
 			}
@@ -1413,7 +1413,7 @@ func (s *Server) dealStatusByID(ctx context.Context, dealid uint) (*dealStatus, 
 		return nil, err
 	}
 
-	chanst, err := s.CM.GetTransferStatus(ctx, &deal, &content)
+	chanst, err := s.CM.GetTransferStatus(ctx, &deal, content.Cid.CID, content.Location)
 	if err != nil {
 		log.Errorf("failed to get transfer status: %s", err)
 	}
@@ -1708,7 +1708,7 @@ func (s *Server) handleTransferRestart(c echo.Context) error {
 		return err
 	}
 
-	if err := s.CM.RestartTransfer(ctx, cont.Location, chanid, deal.ID); err != nil {
+	if err := s.CM.RestartTransfer(ctx, cont.Location, chanid, deal); err != nil {
 		return err
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -826,8 +826,8 @@ func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chani
 			return err
 		}
 
-		canRestart := util.CanRestartTransfer(st)
-		if !canRestart {
+		cannotRestart := !util.CanRestartTransfer(st)
+		if cannotRestart {
 			trsFailed, msg := util.TransferFailed(st)
 			if trsFailed {
 				if err := cm.DB.Model(contentDeal{}).Where("id = ?", d.ID).UpdateColumns(map[string]interface{}{

--- a/main.go
+++ b/main.go
@@ -797,6 +797,8 @@ func (s *Server) RestartAllTransfersForLocation(ctx context.Context, loc string)
 	return nil
 }
 
+// RestartTransfer tries to resume incomplete data transfers between client and storage providers.
+// It supports only legacy deals (PushTransfer)
 func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chanid datatransfer.ChannelID, d contentDeal) error {
 	maddr, err := d.MinerAddr()
 	if err != nil {
@@ -805,9 +807,11 @@ func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chani
 
 	var dealUUID *uuid.UUID
 	if d.DealUUID != "" {
-		if parsed, parseErr := uuid.Parse(d.DealUUID); parseErr == nil {
-			dealUUID = &parsed
+		parsed, err := uuid.Parse(d.DealUUID)
+		if err != nil {
+			return fmt.Errorf("parsing deal uuid %s: %w", d.DealUUID, err)
 		}
+		dealUUID = &parsed
 	}
 
 	_, isPushTransfer, err := cm.getDealStatus(ctx, &d, maddr, dealUUID)

--- a/main.go
+++ b/main.go
@@ -805,8 +805,7 @@ func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chani
 
 	var dealUUID *uuid.UUID
 	if d.DealUUID != "" {
-		parsed, parseErr := uuid.Parse(d.DealUUID)
-		if parseErr == nil {
+		if parsed, parseErr := uuid.Parse(d.DealUUID); parseErr == nil {
 			dealUUID = &parsed
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -380,7 +380,7 @@ func main() {
 			Name:  "staging-bucket",
 			Usage: "enable staging bucket",
 			Value: cfg.StagingBucket.Enabled,
-    },
+		},
 		&cli.StringSliceFlag{
 			Name:  "deal-protocol-version",
 			Usage: "sets the deal protocol version. defaults to v110 (go-fil-markets) and v120 (boost)",
@@ -789,7 +789,7 @@ func (s *Server) RestartAllTransfersForLocation(ctx context.Context, loc string)
 			continue
 		}
 
-		if err := s.CM.RestartTransfer(ctx, loc, chid, d.ID); err != nil {
+		if err := s.CM.RestartTransfer(ctx, loc, chid, d); err != nil {
 			log.Errorf("failed to restart transfer: %s", err)
 			continue
 		}
@@ -797,23 +797,49 @@ func (s *Server) RestartAllTransfersForLocation(ctx context.Context, loc string)
 	return nil
 }
 
-func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chanid datatransfer.ChannelID, dealID uint) error {
-	if loc == "local" {
+func (cm *ContentManager) RestartTransfer(ctx context.Context, loc string, chanid datatransfer.ChannelID, d contentDeal) error {
+	maddr, err := d.MinerAddr()
+	if err != nil {
+		return err
+	}
+
+	var dealUUID *uuid.UUID
+	if d.DealUUID != "" {
+		parsed, parseErr := uuid.Parse(d.DealUUID)
+		if parseErr == nil {
+			dealUUID = &parsed
+		}
+	}
+
+	_, isPushTransfer, err := cm.getDealStatus(ctx, &d, maddr, dealUUID)
+	if err != nil {
+		return err
+	}
+
+	if !isPushTransfer {
+		return nil
+	}
+
+	if loc == constants.ContentLocationLocal {
 		st, err := cm.FilClient.TransferStatus(ctx, &chanid)
 		if err != nil {
 			return err
 		}
 
-		isTerm, msg := util.TransferTerminated(st)
-		if isTerm {
-			if err := cm.DB.Model(contentDeal{}).Where("id = ?", dealID).UpdateColumns(map[string]interface{}{
-				"failed":    true,
-				"failed_at": time.Now(),
-			}).Error; err != nil {
-				return err
+		canRestart := util.CanRestartTransfer(st)
+		if !canRestart {
+			trsFailed, msg := util.TransferFailed(st)
+			if trsFailed {
+				if err := cm.DB.Model(contentDeal{}).Where("id = ?", d.ID).UpdateColumns(map[string]interface{}{
+					"failed":    true,
+					"failed_at": time.Now(),
+				}).Error; err != nil {
+					return err
+				}
+				errMsg := fmt.Sprintf("status: %d(%s), message: %s", st.Status, msg, st.Message)
+				return fmt.Errorf("deal in database is in progress, but data transfer is terminated: %s", errMsg)
 			}
-			errMsg := fmt.Sprintf("status: %d(%s), message: %s", st.Status, msg, st.Message)
-			return fmt.Errorf("deal in database is in progress, but data transfer is terminated: %s", errMsg)
+			return nil
 		}
 		return cm.FilClient.RestartTransfer(ctx, &chanid)
 	}

--- a/replication.go
+++ b/replication.go
@@ -1488,7 +1488,7 @@ const (
 func (cm *ContentManager) getDealStatus(ctx context.Context, d *contentDeal, maddr address.Address, dealUUID *uuid.UUID) (*storagemarket.ProviderDealState, bool, error) {
 	isPushTransfer := false
 	providerDealState, err := cm.FilClient.DealStatus(ctx, maddr, d.PropCid.CID, dealUUID)
-	if err != nil && provds == nil {
+	if err != nil && providerDealState == nil {
 		isPushTransfer = true
 		providerDealState, err = cm.FilClient.DealStatus(ctx, maddr, d.PropCid.CID, nil)
 	}

--- a/replication.go
+++ b/replication.go
@@ -1487,12 +1487,12 @@ const (
 // first check deal protocol version 2, then check version 1
 func (cm *ContentManager) getDealStatus(ctx context.Context, d *contentDeal, maddr address.Address, dealUUID *uuid.UUID) (*storagemarket.ProviderDealState, bool, error) {
 	isPushTransfer := false
-	provds, err := cm.FilClient.DealStatus(ctx, maddr, d.PropCid.CID, dealUUID)
+	providerDealState, err := cm.FilClient.DealStatus(ctx, maddr, d.PropCid.CID, dealUUID)
 	if err != nil && provds == nil {
 		isPushTransfer = true
-		provds, err = cm.FilClient.DealStatus(ctx, maddr, d.PropCid.CID, nil)
+		providerDealState, err = cm.FilClient.DealStatus(ctx, maddr, d.PropCid.CID, nil)
 	}
-	return provds, isPushTransfer, err
+	return providerDealState, isPushTransfer, err
 }
 
 func (cm *ContentManager) checkDeal(ctx context.Context, d *contentDeal) (int, error) {

--- a/util/misc.go
+++ b/util/misc.go
@@ -11,15 +11,14 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-func TransferTerminated(st *filclient.ChannelState) (bool, string) {
-	msg, _ := datatransfer.Statuses[st.Status]
+func CanRestartTransfer(st *filclient.ChannelState) bool {
 	switch st.Status {
 	case datatransfer.Cancelled,
 		datatransfer.Failed,
 		datatransfer.Completed:
-		return true, msg
+		return false
 	default:
-		return false, msg
+		return true
 	}
 }
 


### PR DESCRIPTION
This PR brings 2 improvements;

- After the boost integration, deal checking logic assumes all deals are boost deals and does not correctly check legacy deals. This PR brings the necessary changes to correctly check the deal status for both boost and legacy deals. 

- Currently, when a request to restart a data transfer is made and that transfer is already complete, the content deal is marked as failed because the transfer will not be restartable since it's already complete. This PR brings the necessary changes to make sure a transfer that is already complete will not be marked as failed.

NB: working on unit test for this