### PR TITLE
Do not select shuttle if shuttle content adding is disabled

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -310,7 +310,7 @@ func main() {
 			Value: cfg.Dev,
 		},
 		&cli.StringSliceFlag{
-			Name:  "announce-addr",
+			Name: "announce-addr",
 			Usage: "specify multiaddrs that this node can be connected to	",
 			Value: cli.NewStringSlice(cfg.Node.AnnounceAddrs...),
 		},
@@ -882,6 +882,7 @@ func (d *Shuttle) getHelloMessage() (*drpc.Hello, error) {
 			ID:    d.Node.Host.ID(),
 			Addrs: d.Node.Host.Addrs(),
 		},
+		ContentAddingDisabled: d.disableLocalAdding,
 	}, nil
 }
 

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -16,9 +16,10 @@ type Hello struct {
 
 	DiskSpaceFree int64
 
-	Address  address.Address
-	AddrInfo peer.AddrInfo
-	Private  bool
+	Address               address.Address
+	AddrInfo              peer.AddrInfo
+	Private               bool
+	ContentAddingDisabled bool
 }
 
 type Command struct {

--- a/handlers.go
+++ b/handlers.go
@@ -3101,6 +3101,11 @@ func (s *Server) getPreferredUploadEndpoints(u *User) ([]string, error) {
 	defer s.CM.shuttlesLk.Unlock()
 	var shuttles []Shuttle
 	for hnd, sh := range s.CM.shuttles {
+		if sh.ContentAddingDisabled {
+			log.Debugf("shuttle %+v content adding is disabled", sh)
+			continue
+		}
+
 		if sh.hostname == "" {
 			log.Debugf("shuttle %+v has empty hostname", sh)
 			continue

--- a/shuttle.go
+++ b/shuttle.go
@@ -40,7 +40,8 @@ type ShuttleConnection struct {
 	addrInfo peer.AddrInfo
 	address  address.Address
 
-	private bool
+	private               bool
+	ContentAddingDisabled bool
 
 	spaceLow       bool
 	blockstoreSize uint64
@@ -87,17 +88,18 @@ func (cm *ContentManager) registerShuttleConnection(handle string, hello *drpc.H
 	ctx, cancel := context.WithCancel(context.Background())
 
 	sc := &ShuttleConnection{
-		handle:   handle,
-		address:  hello.Address,
-		addrInfo: hello.AddrInfo,
-		hostname: hello.Host,
-		cmds:     make(chan *drpc.Command, 32),
-		ctx:      ctx,
-		private:  hello.Private,
+		handle:                handle,
+		address:               hello.Address,
+		addrInfo:              hello.AddrInfo,
+		hostname:              hello.Host,
+		cmds:                  make(chan *drpc.Command, 32),
+		ctx:                   ctx,
+		private:               hello.Private,
+		ContentAddingDisabled: hello.ContentAddingDisabled,
 	}
 
-	// when a shuttle connects, if global content adding is enabled, refresh shuttle pin queue
-	if !cm.globalContentAddingDisabled {
+	// when a shuttle connects, if global content adding and shuttle content adding is enabled, refresh shuttle pin queue
+	if !cm.globalContentAddingDisabled && !hello.ContentAddingDisabled {
 		go func() {
 			if err := cm.refreshPinQueue(ctx, handle); err != nil {
 				log.Errorf("failed to refresh shuttle: %s pin queue: %s", handle, err)


### PR DESCRIPTION
Currently, when a shuttle is run with the `disable-content--adding` flag, Estuary does not respect it and keeps listing that shuttle on the `viewer` endpoint; this leads to such shuttle still taking on more files even though it is out of disk space, causing it to crash. 

This PR will make Estuary aware of this flag from the shuttle and stop listing the shuttle on the viewer endpoint.