### PR TITLE
Update documentation to reflect incompatibility with go 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Requirements:
 
-- go (1.15 or higher)
+- go (1.15 >= and <= 1.18)
 - [jq](https://stedolan.github.io/jq/)
 - [hwloc](https://www.open-mpi.org/projects/hwloc/)
 - opencl


### PR DESCRIPTION
#403 
Attempted to update quic-go to resolve this issue but it led to more errors from the [go-libp2p-quic-transport](https://github.com/libp2p/go-libp2p-quic-transport) package and then go-libp2p-core.

Modifying documentation for now to reflect the incompatibility.