### PR TITLE
fix(auth): change passwordHash to base64 -> ensures compatibility with postgres

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2867,7 +2867,7 @@ func (s *Server) handleRegisterUser(c echo.Context) error {
 		Username: username,
 		UUID:     uuid.New().String(),
 		Salt:     salt,
-		PassHash: util.GetPasswordHash(reg.Password, salt),
+		PassHash: util.GetPasswordHashBase64(reg.Password, salt),
 		Perm:     util.PermLevelUser,
 	}
 
@@ -2927,7 +2927,7 @@ func (s *Server) handleLoginUser(c echo.Context) error {
 	}
 
 	//	validate password
-	if ((user.Salt != "") && user.PassHash != util.GetPasswordHash(body.Password, user.Salt)) ||
+	if ((user.Salt != "") && (user.PassHash != util.GetPasswordHash(body.Password, user.Salt)) || (user.PassHash != util.GetPasswordHashBase64(body.Password, user.Salt))) ||
 		((user.Salt == "") && (user.PassHash != body.Password)) {
 		return &util.HttpError{
 			Code:   http.StatusForbidden,
@@ -2960,7 +2960,7 @@ func (s *Server) handleUserChangePassword(c echo.Context, u *User) error {
 
 	updatedUserColumns := &User{
 		Salt:     salt,
-		PassHash: util.GetPasswordHash(params.NewPassword, salt),
+		PassHash: util.GetPasswordHashBase64(params.NewPassword, salt),
 	}
 
 	if err := s.DB.Model(User{}).Where("id = ?", u.ID).Updates(updatedUserColumns).Error; err != nil {

--- a/main.go
+++ b/main.go
@@ -463,7 +463,7 @@ func main() {
 					UUID:     uuid.New().String(),
 					Username: username,
 					Salt:     salt,
-					PassHash: util.GetPasswordHash(password, salt),
+					PassHash: util.GetPasswordHashBase64(password, salt),
 					Perm:     100,
 				}
 				if err := db.Create(newUser).Error; err != nil {

--- a/util/auth.go
+++ b/util/auth.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"crypto/sha256"
+	b64 "encoding/base64"
 	"fmt"
 	"net/http"
 )
@@ -28,4 +29,9 @@ func IsContentOwner(uID, entityID uint) error {
 func GetPasswordHash(password, salt string) string {
 	passHashBytes := sha256.Sum256([]byte(password + "." + salt))
 	return string(passHashBytes[:])
+}
+
+func GetPasswordHashBase64(password, salt string) string {
+	passHashBytes := sha256.Sum256([]byte(password + "." + salt))
+	return b64.StdEncoding.EncodeToString(passHashBytes[:])
 }


### PR DESCRIPTION
### The error:

When trying to use the project with a postgres database, running setup with:

`./estuary setup --username=<uname> --password=<pword> --database=postgres=postgresql://[user[:password]@][host][:port][/dbname]
`

I get:

`FATAL	estuary	estuary/main.go:665	could not run estuary app: admin user creation failed: ERROR: invalid byte sequence for encoding "UTF8": 0xee 0x0d 0x26 (SQLSTATE 22021)	{"app_version": "v0.1.8-22-ga7420a2"}`

### Explanation:

When converting the password hash byte sequence to a string (to be saved in the db as a string) here: https://github.com/application-research/estuary/blob/master/util/auth.go#L30
The output contains characters that if tried to be encoded in UTF-8, would look like:

`��PK�uU����իagc����T0x`

The SQLite database will save it no problem, but postgres will complain with the error above making user registration and first user admin setup not possible. 

Already tried changing encoding of the postgres db to other formats without luck. Changing it to base64 made it work. 

### Fix (in this PR):

Save the hash byte sequence encoded in a base64 string. This way postgres will have no problem saving the hash as a UTF-8 string.

### Potential errors:
* **Backwards compatibility of passwords**
    * _Explanation_: If already existing users try to log in with their credentials they will not be able to do so since their saved hashed passwords are not in base64
    * _Mitigation_: Offer now two verifications: either it matches via `GetPasswordHashBase` (previous method) or `GetPasswordHashBase64` (proposed method). Included in this PR.