### PR TITLE
docs(readme): Add clarification of first user credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To run locally in a 'dev' environment, first run:
 ```
 
 Save the auth token that this outputs, you will need it for interacting with
-and controlling the node.
+and controlling the node. This username and password won't work to log in using the front end (estuary-www), but the auth token will.
 
 NOTE: if you want to use a different database than a sqlite instance stored in your local directory, you will need to configure that with the `--database` flag, like so: `./estuary setup --username=<uname> --password=<pword> --database=XXXXX`
 
@@ -89,15 +89,18 @@ npm run dev
 
 And then head to [localhost:4444/staging](http://localhost:4444/staging) to see the status of your deal.
 
-
 ## Contributing
+
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributing and development instructions.
 
 ## Troubleshooting
+
 Make sure to install all dependencies as indicated above. Here are a few issues that one can encounter while building estuary
 
 ### Guide for: `route ip+net: netlinkrib: too many open files`
+
 #### Error
+
 If you get the following error:
 
 ```sh
@@ -107,31 +110,39 @@ If you get the following error:
 It is because you do not have enough open file handles available.
 
 #### Solution
+
 Update this with the following command:
 
 ```sh
 ulimit -n 10000
 ```
+
 ### Guide for: Missing `hwloc` on M1 Macs
+
 The Portable Hardware Locality (hwloc) software package provides a portable abstraction of the hierarchical structure of current architectures, including NUMA memory nodes, sockets, shared caches, cores, and simultaneous multi-threading (across OS, versions, architectures, etc.).
 
 `lhwloc` is used by libp2p-core. Estuary uses libp2p for the majority of its features including network communication, pinning, replication and resource manager.
 
 #### Error
+
 ```
 `ld: library not found for -lhwloc`
 ```
 
 #### Solution
+
 For M1 Macs, here's the following steps needed
+
 - Step 1: `brew install go bzr jq pkg-config rustup hwloc` - Uninstall rust as it would clash with rustup in case you have installed.
 - Step 2: export LIBRARY_PATH=/opt/homebrew/lib
 - Step 3: Follow the steps as per the docs.
 
 ### Guide for: `cannot find -lfilcrypto collect2`
+
 Related issue [here](https://github.com/application-research/estuary/issues/71)
 
 #### Error
+
 When trying to build estuary in an ARM machine, it returns an error
 
 ```
@@ -139,6 +150,7 @@ When trying to build estuary in an ARM machine, it returns an error
 ```
 
 #### Solution
+
 Related solution [here](https://github.com/filecoin-project/lotus/issues/1779#issuecomment-629932097)
 
 ```


### PR DESCRIPTION
### The problem

Users via the front-end when providing credentials are using a predefined salt defined here: https://github.com/application-research/estuary-www/blob/master/common/constants.ts#L28  for their password. The resulting hash is then safely sent to authenticate. This goes for signing-up/logging-in.

Now when creating the first user via:

`./estuary setup --username=<uname> --password=<pword> --database=XXXXX`

The provided password is saved by salting it with a randomly generated `uuid` not the salt provided above. Therefore when trying to authenticate using this same credentials, the resulting hash will not match and the first user is not able to authenticate. The user can use a workaround by using the token and logging in with it. However it might be confusing to see the provided credentials are not working for first time users in estuary-www.


### The Fix

It could be possible to salt the first user's password in the backend with the same salt, not sure if maintaining a copy of the same salt (in estuary-www and estuary) desired, since at some point it might diverge.

However, providing some documentation provided in this PR will at least avoid confusion. 