### PR TITLE
fix: sort the invite retrieval in ascending order

### DIFF
--- a/dbmgr/dbmgr.go
+++ b/dbmgr/dbmgr.go
@@ -808,6 +808,7 @@ func (q *InviteCodesQuery) GetClaimedInvites() ([]ClaimedInvite, error) {
 		Select("code, username, (?) as claimed_by", q.DB.Table("users").Select("username").Where("id = invite_codes.claimed_by")).
 		//Where("claimed_by IS NULL").
 		Joins("left join users on users.id = invite_codes.created_by").
+		Order("invite_codes.created_at ASC").
 		Scan(&invites).Error; err != nil {
 		return nil, err
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -1820,6 +1820,7 @@ func (s *Server) handleAdminGetInvites(c echo.Context) error {
 		Select("code, username, (?) as claimed_by", s.DB.Table("users").Select("username").Where("id = invite_codes.claimed_by")).
 		//Where("claimed_by IS NULL").
 		Joins("left join users on users.id = invite_codes.created_by").
+		Order("invite_codes.created_at ASC").
 		Scan(&invites).Error; err != nil {
 		return err
 	}


### PR DESCRIPTION
# Changes

Simple change to sort the invite codes in ascending order

![2022-09-19_05-53-05 (1)](https://user-images.githubusercontent.com/4479171/190992852-cfee406a-d23e-43c6-986a-042d14c346ed.gif)

