### PR TITLE
Added pprof debug endpoints to shuttles

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 
 	//#nosec G108 - exposing the profiling endpoint is expected
-	_ "net/http/pprof"
+	httpprof "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1046,6 +1046,7 @@ func (s *Shuttle) ServeAPI() error {
 		}
 		return err
 	})
+	e.GET("/debug/pprof/:prof", serveProfile)
 
 	e.Use(middleware.CORS())
 
@@ -1086,6 +1087,11 @@ func (s *Shuttle) ServeAPI() error {
 	admin.GET("/system/config", s.handleGetSystemConfig)
 
 	return e.Start(s.shuttleConfig.ApiListen)
+}
+
+func serveProfile(c echo.Context) error {
+	httpprof.Handler(c.Param("prof")).ServeHTTP(c.Response().Writer, c.Request())
+	return nil
 }
 
 func (s *Shuttle) isContentAddingDisabled(u *User) bool {


### PR DESCRIPTION
Added the pprof endpoints to the shuttles endpoints. This should help us debug some issues we have been seeing with the stability of the shuttles.

```{{endpoint}}/debug/pprof/:prof```

Go built in profiles:
- goroutine — stack traces of all current goroutines
- heap — a sampling of memory allocations of live objects
- allocs — a sampling of all past memory allocations
- threadcreate — stack traces that led to the creation of new OS threads
- block — stack traces that led to blocking on synchronization primitives
- mutex — stack traces of holders of contended mutexes