### PR TITLE
bugfix for mac silicon - makes sure homebrew path is in library path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,9 @@ FFI_PATH:=extern/filecoin-ffi/
 FFI_DEPS:=.install-filcrypto
 FFI_DEPS:=$(addprefix $(FFI_PATH),$(FFI_DEPS))
 
-#For mac silicon
-export LIBRARY_PATH := /opt/homebrew/lib:$(LIBRARY_PATH)
+ifeq ($(OS),Darwin)
+	export LIBRARY_PATH := /opt/homebrew/lib:$(LIBRARY_PATH)
+endif
 
 $(FFI_DEPS): build/.filecoin-install ;
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ FFI_PATH:=extern/filecoin-ffi/
 FFI_DEPS:=.install-filcrypto
 FFI_DEPS:=$(addprefix $(FFI_PATH),$(FFI_DEPS))
 
+#For mac silicon
+export LIBRARY_PATH := /opt/homebrew/lib:$(LIBRARY_PATH)
+
 $(FFI_DEPS): build/.filecoin-install ;
 
 build/.filecoin-install: $(FFI_PATH)


### PR DESCRIPTION
seems homebrew's library path not being added to LIBRARY_PATH is a recurring issue and this should fix it