### PR TITLE
fix pin mgr status and send peers info to shuttles for pinning

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1532,25 +1532,8 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 	dsess := dserv.Session(ctx)
 
 	if err := d.addDatabaseTrackingToContent(ctx, op.ContId, dsess, d.Node.Blockstore, op.Obj, cb); err != nil {
-		// pinning failed, we wont try again. mark pin as dead
-		/* maybe its fine if we retry later?
-		if err := d.DB.Model(Pin{}).Where("content = ?", op.ContId).UpdateColumns(map[string]interface{}{
-			"pinning": false,
-		}).Error; err != nil {
-			log.Errorf("failed to update failed pin status: %s", err)
-		}
-		*/
-
 		return errors.Wrapf(err, "failed to addDatabaseTrackingToContent - contID(%d), cid(%s)", op.ContId, op.Obj.String())
 	}
-
-	/*
-		if op.Replace > 0 {
-			if err := s.CM.RemoveContent(ctx, op.Replace, true); err != nil {
-				log.Infof("failed to remove content in replacement: %d", op.Replace)
-			}
-		}
-	*/
 
 	if err := d.Provide(ctx, op.Obj); err != nil {
 		return errors.Wrapf(err, "failed to provide - contID(%d), cid(%s)", op.ContId, op.Obj.String())
@@ -1725,7 +1708,6 @@ func (s *Shuttle) refreshPinQueue() error {
 	for _, c := range toPin {
 		s.addPinToQueue(c, nil, 0)
 	}
-
 	return nil
 }
 

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/ipfs/go-merkledag"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/xerrors"
@@ -79,10 +80,10 @@ func (d *Shuttle) sendRpcMessage(ctx context.Context, msg *drpc.Message) error {
 func (d *Shuttle) handleRpcAddPin(ctx context.Context, apo *drpc.AddPin) error {
 	d.addPinLk.Lock()
 	defer d.addPinLk.Unlock()
-	return d.addPin(ctx, apo.DBID, apo.Cid, apo.UserId, false)
+	return d.addPin(ctx, apo.DBID, apo.Cid, apo.UserId, apo.Peers, false)
 }
 
-func (d *Shuttle) addPin(ctx context.Context, contid uint, data cid.Cid, user uint, skipLimiter bool) error {
+func (d *Shuttle) addPin(ctx context.Context, contid uint, data cid.Cid, user uint, peers []*peer.AddrInfo, skipLimiter bool) error {
 	ctx, span := d.Tracer.Start(ctx, "addPin", trace.WithAttributes(
 		attribute.Int64("contID", int64(contid)),
 		attribute.Int64("userID", int64(user)),
@@ -160,6 +161,7 @@ func (d *Shuttle) addPin(ctx context.Context, contid uint, data cid.Cid, user ui
 		UserId:      user,
 		Status:      types.PinningStatusQueued,
 		SkipLimiter: skipLimiter,
+		Peers:       peers,
 	}
 
 	d.PinMgr.Add(op)
@@ -278,6 +280,7 @@ func (d *Shuttle) handleRpcTakeContent(ctx context.Context, cmd *drpc.TakeConten
 		if err != nil {
 			return err
 		}
+
 		if count > 0 {
 			if count > 1 {
 				log.Errorf("have multiple pins for same content: %d", c.ID)
@@ -285,11 +288,10 @@ func (d *Shuttle) handleRpcTakeContent(ctx context.Context, cmd *drpc.TakeConten
 			continue
 		}
 
-		if err := d.addPin(ctx, c.ID, c.Cid, c.UserID, true); err != nil {
+		if err := d.addPin(ctx, c.ID, c.Cid, c.UserID, c.Peers, true); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -354,6 +354,8 @@ func (d *Shuttle) handleRpcAggregateContent(ctx context.Context, cmd *drpc.Aggre
 		return err
 	}
 
+	// since aggregates only needs put the containing box in the blockstore,
+	// mark it as action and change pinning status
 	if err := d.DB.Model(Pin{}).Where("id = ?", pin.ID).UpdateColumns(map[string]interface{}{
 		"active":  true,
 		"pinning": false,

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -67,7 +67,6 @@ const CMD_TakeContent = "TakeContent"
 
 type TakeContent struct {
 	Contents []ContentFetch
-	Sources  []peer.AddrInfo
 }
 
 const CMD_AggregateContent = "AggregateContent"

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -150,6 +150,7 @@ type ContentFetch struct {
 	ID     uint
 	Cid    cid.Cid
 	UserID uint
+	Peers  []*peer.AddrInfo
 }
 
 type Message struct {

--- a/handlers.go
+++ b/handlers.go
@@ -4504,7 +4504,7 @@ func (s *Server) handleShuttleConnection(c echo.Context) error {
 		for {
 			var msg drpc.Message
 			if err := websocket.JSON.Receive(ws, &msg); err != nil {
-				log.Errorf("failed to read message from shuttle: %s", err)
+				log.Errorf("failed to read message from shuttle: %s, %s", shuttle.Handle, err)
 				return
 			}
 
@@ -5213,6 +5213,12 @@ func (s *Server) handleShuttleRepinAll(c echo.Context) error {
 			return err
 		}
 
+		var origins []*peer.AddrInfo
+		// when refreshing pinning queue, use content origins if available
+		if cont.Origins != "" {
+			_ = json.Unmarshal([]byte(cont.Origins), &origins) // no need to handle or log err, its just a nice to have
+		}
+
 		if err := s.CM.sendShuttleCommand(c.Request().Context(), handle, &drpc.Command{
 			Op: drpc.CMD_AddPin,
 			Params: drpc.CmdParams{
@@ -5220,6 +5226,7 @@ func (s *Server) handleShuttleRepinAll(c echo.Context) error {
 					DBID:   cont.ID,
 					UserId: cont.UserID,
 					Cid:    cont.Cid.CID,
+					Peers:  origins,
 				},
 			},
 		}); err != nil {

--- a/pinner/pinmgr.go
+++ b/pinner/pinmgr.go
@@ -185,9 +185,6 @@ func (pm *PinManager) doPinning(op *PinningOperation) error {
 	defer cancel()
 
 	op.SetStatus(types.PinningStatusPinning)
-	if err := pm.StatusChangeFunc(op.ContId, op.Location, types.PinningStatusPinning); err != nil {
-		return err
-	}
 
 	if err := pm.RunPinFunc(ctx, op, func(size int64) {
 		op.lk.Lock()
@@ -202,7 +199,7 @@ func (pm *PinManager) doPinning(op *PinningOperation) error {
 		return errors.Wrap(err, "shuttle RunPinFunc failed")
 	}
 	op.complete()
-	return pm.StatusChangeFunc(op.ContId, op.Location, types.PinningStatusPinned)
+	return nil
 }
 
 func (pm *PinManager) popNextPinOp() *PinningOperation {

--- a/pinner/pinmgr.go
+++ b/pinner/pinmgr.go
@@ -2,8 +2,6 @@ package pinner
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"sync"
 	"time"
 
@@ -119,47 +117,6 @@ func (po *PinningOperation) SetStatus(st types.PinningStatus) {
 
 	po.Status = st
 	po.LastUpdate = time.Now()
-}
-
-func (po *PinningOperation) PinStatus() *types.IpfsPinStatusResponse {
-	po.lk.Lock()
-	defer po.lk.Unlock()
-
-	meta := make(map[string]interface{}, 0)
-	if po.Meta != "" {
-		if err := json.Unmarshal([]byte(po.Meta), &meta); err != nil {
-			log.Warnf("content %d has invalid meta: %s", po.ContId, err)
-		}
-	}
-
-	originStrs := make([]string, 0)
-	for _, o := range po.Peers {
-		ai, err := peer.AddrInfoToP2pAddrs(o)
-		if err == nil {
-			for _, a := range ai {
-				originStrs = append(originStrs, a.String())
-			}
-		}
-	}
-
-	return &types.IpfsPinStatusResponse{
-		RequestID: fmt.Sprint(po.ContId),
-		Status:    po.Status,
-		Created:   po.Started,
-		Pin: types.IpfsPin{
-			CID:     po.Obj.String(),
-			Name:    po.Name,
-			Origins: originStrs,
-			Meta:    meta,
-		},
-		Info: make(map[string]interface{}, 0),
-		/* Ref: https://github.com/ipfs/go-pinning-service-http-client/issues/12
-		Info: map[string]interface{}{
-			"obj_fetched":  po.NumFetched,
-			"size_fetched": po.SizeFetched,
-		},
-		*/
-	}
 }
 
 func (pm *PinManager) PinQueueSize() int {

--- a/pinning.go
+++ b/pinning.go
@@ -844,7 +844,7 @@ func (s *Server) handleDeletePin(e echo.Context, u *util.User) error {
 }
 
 // even though there are 4 pin statuses, queued, pinning, pinned and failed
-// the UpdatePinStatus only changes DB stte for failed
+// the UpdatePinStatus only changes DB state for failed status
 // when the content was added, status = pinning
 // when the pin process is complete, status = pinned
 func (cm *ContentManager) UpdatePinStatus(location string, contID uint, status types.PinningStatus) error {

--- a/replication.go
+++ b/replication.go
@@ -118,9 +118,6 @@ type ContentManager struct {
 
 	hostname string
 
-	pinJobs map[uint]*pinner.PinningOperation
-	pinLk   sync.Mutex
-
 	pinMgr *pinner.PinManager
 
 	shuttlesLk sync.Mutex
@@ -312,7 +309,6 @@ func NewContentManager(db *gorm.DB, api api.Gateway, fc *filclient.FilClient, tb
 		ToCheck:                      make(chan uint, 100000),
 		retrievalsInProgress:         make(map[uint]*util.RetrievalProgress),
 		buckets:                      make(map[uint][]*contentStagingZone),
-		pinJobs:                      make(map[uint]*pinner.PinningOperation),
 		pinMgr:                       pinmgr,
 		remoteTransferStatus:         cache,
 		shuttles:                     make(map[string]*ShuttleConnection),
@@ -3221,7 +3217,6 @@ func (cm *ContentManager) sendConsolidateContentCmd(ctx context.Context, loc str
 			log.Warnf("no addr info for node: %s", handle)
 			continue
 		}
-
 		tc.Sources = append(tc.Sources, *ai)
 	}
 

--- a/replication.go
+++ b/replication.go
@@ -252,7 +252,7 @@ func (cm *ContentManager) tryAddContent(cb *contentStagingZone, c util.Content) 
 	cb.lk.Lock()
 	defer cb.lk.Unlock()
 
-	// if this bucket is being consolidated, do not add anymoe content
+	// if this bucket is being consolidated, do not add anymore content
 	if cb.IsConsolidating {
 		return false, nil
 	}
@@ -547,7 +547,7 @@ func (cm *ContentManager) currentLocationForContent(c uint) (string, error) {
 func (cm *ContentManager) stagedContentByLocation(ctx context.Context, b *contentStagingZone) (map[string][]util.Content, error) {
 	out := make(map[string][]util.Content)
 	for _, c := range b.Contents {
-		// need to verify current location from db, incase this stage content was a part of a consolidated content
+		// need to get current location from db, incase this stage content was a part of a consolidated content - its location would have changed.
 		// so we can group it into its current location
 		loc, err := cm.currentLocationForContent(c.ID)
 		if err != nil {
@@ -610,7 +610,7 @@ func (cm *ContentManager) aggregateContent(ctx context.Context, b *contentStagin
 
 	if len(cbl) > 1 {
 		// Need to migrate content all to the same shuttle
-		// Only attempt consolidation on a zone if it has not be done before, prevents dups request
+		// Only attempt consolidation on a zone if it has not be done before, prevents re-consolidation request
 		if !b.IsConsolidating {
 			b.IsConsolidating = true
 			go func() {

--- a/shuttle.go
+++ b/shuttle.go
@@ -154,6 +154,7 @@ func (cm *ContentManager) processShuttleMessage(handle string, msg *drpc.Message
 	defer span.End()
 
 	log.Debugf("handling shuttle message: %s", msg.Op)
+
 	switch msg.Op {
 	case drpc.OP_UpdatePinStatus:
 		ups := msg.Params.UpdatePinStatus


### PR DESCRIPTION
This PR;

1. Fixes the issue of wrong pin status raised in https://github.com/application-research/estuary/issues/408 and https://filecoinproject.slack.com/archives/C016APFREQK/p1665650121296659 by keeping only one pin status state (the one in DB, no need having 2 states in pinMgr and Db)
2. Improves shuttle pinning success rate by propagating origins from pin request to shuttle for peers' discoverability
3. Fixes shuttle pinning status for consolidated contents
4. Properly trigger deal-making for shuttle aggregated contents
5. Fixes consolidation bugs
 
These have been tested

closes https://github.com/application-research/estuary/issues/408