### PR TITLE
List full contents for UI response, Only return content with deals for UI deals response, and Fix dropped RPC messages 

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -181,6 +181,10 @@ func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Shuttle
 			cfg.Dev = cctx.Bool("dev")
 		case "no-reload-pin-queue":
 			cfg.NoReloadPinQueue = cctx.Bool("no-reload-pin-queue")
+		case "rpc-incoming-queue-size":
+			cfg.RPCMessage.IncomingQueueSize = cctx.Int("rpc-incoming-queue-size")
+		case "rpc-outgoing-queue-size":
+			cfg.RPCMessage.OutgoingQueueSize = cctx.Int("rpc-outgoing-queue-size")
 		default:
 		}
 	}
@@ -348,6 +352,16 @@ func main() {
 			Usage: "sets the bitswap target message size",
 			Value: cfg.Node.Bitswap.TargetMessageSize,
 		},
+		&cli.IntFlag{
+			Name:  "rpc-incoming-queue-size",
+			Usage: "sets incoming rpc message queue size",
+			Value: cfg.RPCMessage.IncomingQueueSize,
+		},
+		&cli.IntFlag{
+			Name:  "rpc-outgoing-queue-size",
+			Usage: "sets outgoing rpc message queue size",
+			Value: cfg.RPCMessage.OutgoingQueueSize,
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -492,7 +506,7 @@ func main() {
 			inflightCids:     make(map[cid.Cid]uint),
 			splitsInProgress: make(map[uint]bool),
 
-			outgoing:  make(chan *drpc.Message),
+			outgoing:  make(chan *drpc.Message, cfg.RPCMessage.OutgoingQueueSize),
 			authCache: cache,
 
 			hostname:           cfg.Hostname,

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -31,8 +31,8 @@ type Estuary struct {
 	Logging                Logging       `json:"logging"`
 	FilClient              FilClient     `json:"fil_client"`
 	StagingBucket          StagingBucket `json:"staging_bucket"`
-	ShuttleMessageHandlers int           `json:"shuttle_message_Handlers"`
 	Replication            int           `json:"replication"`
+	RPCMessage             RPCMessage    `json:"rpc_message"`
 }
 
 func (cfg *Estuary) Load(filename string) error {
@@ -167,6 +167,10 @@ func NewEstuary(appVersion string) *Estuary {
 				HighWater: 3000,
 			},
 		},
-		ShuttleMessageHandlers: 30,
+		RPCMessage: RPCMessage{
+			IncomingQueueSize: 100000,
+			OutgoingQueueSize: 100000,
+			QueueHandlers:     30,
+		},
 	}
 }

--- a/config/rpc_message.go
+++ b/config/rpc_message.go
@@ -1,0 +1,7 @@
+package config
+
+type RPCMessage struct {
+	IncomingQueueSize int `json:"incoming_queue_size"`
+	OutgoingQueueSize int `json:"outgoing_queue_size"`
+	QueueHandlers     int `json:"queue_handlers"`
+}

--- a/config/shuttle.go
+++ b/config/shuttle.go
@@ -31,6 +31,7 @@ type Shuttle struct {
 	Logging            Logging       `json:"logging"`
 	EstuaryRemote      EstuaryRemote `json:"estuary_remote"`
 	FilClient          FilClient     `json:"fil_client"`
+	RPCMessage         RPCMessage    `json:"rpc_message"`
 }
 
 func (cfg *Shuttle) Load(filename string) error {
@@ -160,6 +161,10 @@ func NewShuttle(appVersion string) *Shuttle {
 				CacheSize: 2000,
 				TTL:       30,
 			},
+		},
+		RPCMessage: RPCMessage{
+			OutgoingQueueSize: 100000,
+			IncomingQueueSize: 100000,
 		},
 	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -409,7 +409,7 @@ func (s *Server) handleStats(c echo.Context, u *util.User) error {
 	}
 
 	var contents []util.Content
-	if err := s.DB.Limit(limit).Offset(offset).Order("created_at desc").Find(&contents, "user_id = ? and active", u.ID).Error; err != nil {
+	if err := s.DB.Limit(limit).Offset(offset).Order("created_at desc").Find(&contents, "user_id = ?", u.ID).Error; err != nil {
 		return err
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -1106,7 +1106,7 @@ func (cm *ContentManager) addDatabaseTrackingToContent(ctx context.Context, cont
 	if err != nil {
 		return err
 	}
-	return cm.addObjectsToDatabase(ctx, cont, dserv, root, objects, constants.ContentLocationLocal)
+	return cm.addObjectsToDatabase(ctx, cont, objects, constants.ContentLocationLocal)
 }
 
 func (cm *ContentManager) addDatabaseTracking(ctx context.Context, u *util.User, dserv ipld.NodeGetter, root cid.Cid, filename string, replication int) (*util.Content, error) {

--- a/handlers.go
+++ b/handlers.go
@@ -1864,7 +1864,7 @@ func (s *Server) handleGetProposal(c echo.Context) error {
 			return &util.HttpError{
 				Code:    http.StatusNotFound,
 				Reason:  util.ERR_RECORD_NOT_FOUND,
-				Details: fmt.Sprintf("proposal: %d was not found", propCid),
+				Details: fmt.Sprintf("proposal: %s was not found", propCid),
 			}
 		}
 		return err

--- a/handlers.go
+++ b/handlers.go
@@ -4655,7 +4655,7 @@ func (s *Server) handleShuttleConnection(c echo.Context) error {
 			return
 		}
 
-		cmds, unreg, err := s.CM.registerShuttleConnection(shuttle.Handle, &hello)
+		outgoingRpcQueue, unreg, err := s.CM.registerShuttleConnection(shuttle.Handle, &hello)
 		if err != nil {
 			log.Errorf("failed to register shuttle: %s", err)
 			return
@@ -4665,9 +4665,9 @@ func (s *Server) handleShuttleConnection(c echo.Context) error {
 		go func() {
 			for {
 				select {
-				case cmd := <-cmds:
+				case rpcMessage := <-outgoingRpcQueue:
 					// Write
-					err := websocket.JSON.Send(ws, cmd)
+					err := websocket.JSON.Send(ws, rpcMessage)
 					if err != nil {
 						log.Errorf("failed to write command to shuttle: %s", err)
 						return

--- a/main.go
+++ b/main.go
@@ -172,8 +172,12 @@ func overrideSetOptions(flags []cli.Flag, cctx *cli.Context, cfg *config.Estuary
 			cfg.Node.Bitswap.MaxOutstandingBytesPerPeer = cctx.Int64("bitswap-max-work-per-peer")
 		case "bitswap-target-message-size":
 			cfg.Node.Bitswap.TargetMessageSize = cctx.Int("bitswap-target-message-size")
-		case "shuttle-message-handlers":
-			cfg.ShuttleMessageHandlers = cctx.Int("shuttle-message-handlers")
+		case "rpc-incoming-queue-size":
+			cfg.RPCMessage.IncomingQueueSize = cctx.Int("rpc-incoming-queue-size")
+		case "rpc-outgoing-queue-size":
+			cfg.RPCMessage.OutgoingQueueSize = cctx.Int("rpc-outgoing-queue-size")
+		case "rpc-queue-handlers":
+			cfg.RPCMessage.QueueHandlers = cctx.Int("rpc-queue-handlers")
 		case "staging-bucket":
 			cfg.StagingBucket.Enabled = cctx.Bool("staging-bucket")
 		case "indexer-url":
@@ -380,9 +384,19 @@ func main() {
 			Value: cfg.Node.Bitswap.TargetMessageSize,
 		},
 		&cli.IntFlag{
-			Name:  "shuttle-message-handlers",
-			Usage: "sets shuttle message handler count",
-			Value: cfg.ShuttleMessageHandlers,
+			Name:  "rpc-incoming-queue-size",
+			Usage: "sets incoming rpc message queue size",
+			Value: cfg.RPCMessage.IncomingQueueSize,
+		},
+		&cli.IntFlag{
+			Name:  "rpc-outgoing-queue-size",
+			Usage: "sets outgoing rpc message queue size",
+			Value: cfg.RPCMessage.OutgoingQueueSize,
+		},
+		&cli.IntFlag{
+			Name:  "rpc-queue-handlers",
+			Usage: "sets rpc message handler count",
+			Value: cfg.RPCMessage.QueueHandlers,
 		},
 		&cli.BoolFlag{
 			Name:  "staging-bucket",
@@ -649,8 +663,8 @@ func main() {
 			init.trackingBstore.SetCidReqFunc(cm.RefreshContentForCid)
 		}
 
-		go cm.Run(cctx.Context)                                               // deal making and deal reconciliation
-		go cm.handleShuttleMessages(cctx.Context, cfg.ShuttleMessageHandlers) // register workers/handlers to process shuttle rpc messages from a channel(queue)
+		go cm.Run(cctx.Context)                                                 // deal making and deal reconciliation
+		go cm.handleShuttleMessages(cctx.Context, cfg.RPCMessage.QueueHandlers) // register workers/handlers to process shuttle rpc messages from a channel(queue)
 
 		// Start autoretrieve if not disabled
 		if !cfg.DisableAutoRetrieve {

--- a/pinning.go
+++ b/pinning.go
@@ -912,7 +912,7 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 		})
 	}
 
-	if err := cm.addObjectsToDatabase(ctx, pincomp.DBID, nil, cid.Cid{}, objects, handle); err != nil {
+	if err := cm.addObjectsToDatabase(ctx, pincomp.DBID, objects, handle); err != nil {
 		return xerrors.Errorf("failed to add objects to database: %w", err)
 	}
 

--- a/replication.go
+++ b/replication.go
@@ -330,7 +330,7 @@ func NewContentManager(db *gorm.DB, api api.Gateway, fc *filclient.FilClient, tb
 		Replication:                  cfg.Replication,
 		tracer:                       otel.Tracer("replicator"),
 		DisableFilecoinStorage:       cfg.DisableFilecoinStorage,
-		IncomingRPCMessages:          make(chan *drpc.Message, 200000),
+		IncomingRPCMessages:          make(chan *drpc.Message, cfg.RPCMessage.IncomingQueueSize),
 		EnabledDealProtocolsVersions: cfg.Deal.EnabledDealProtocolsVersions,
 	}
 

--- a/replication.go
+++ b/replication.go
@@ -330,14 +330,13 @@ func NewContentManager(db *gorm.DB, api api.Gateway, fc *filclient.FilClient, tb
 		Replication:                  cfg.Replication,
 		tracer:                       otel.Tracer("replicator"),
 		DisableFilecoinStorage:       cfg.DisableFilecoinStorage,
-		IncomingRPCMessages:          make(chan *drpc.Message),
+		IncomingRPCMessages:          make(chan *drpc.Message, 200000),
 		EnabledDealProtocolsVersions: cfg.Deal.EnabledDealProtocolsVersions,
 	}
-	qm := newQueueManager(func(c uint) {
+
+	cm.queueMgr = newQueueManager(func(c uint) {
 		cm.toCheck(c)
 	})
-
-	cm.queueMgr = qm
 	return cm, nil
 }
 

--- a/replication.go
+++ b/replication.go
@@ -2996,7 +2996,7 @@ func (s *Server) handleFixupDeals(c echo.Context) error {
 // addObjectsToDatabase creates entries on the estuary database for CIDs related to an already pinned CID (`root`)
 // These entries are saved on the `objects` table, while metadata about the `root` CID is mostly kept on the `contents` table
 // The link between the `objects` and `contents` tables is the `obj_refs` table
-func (cm *ContentManager) addObjectsToDatabase(ctx context.Context, content uint, dserv ipld.NodeGetter, root cid.Cid, objects []*util.Object, loc string) error {
+func (cm *ContentManager) addObjectsToDatabase(ctx context.Context, contID uint, objects []*util.Object, loc string) error {
 	_, span := cm.tracer.Start(ctx, "addObjectsToDatabase")
 	defer span.End()
 
@@ -3008,7 +3008,7 @@ func (cm *ContentManager) addObjectsToDatabase(ctx context.Context, content uint
 	var totalSize int64
 	for _, o := range objects {
 		refs = append(refs, util.ObjRef{
-			Content: content,
+			Content: contID,
 			Object:  o.ID,
 		})
 		totalSize += int64(o.Size)
@@ -3019,7 +3019,7 @@ func (cm *ContentManager) addObjectsToDatabase(ctx context.Context, content uint
 		attribute.Int("numObjects", len(objects)),
 	)
 
-	if err := cm.DB.Model(util.Content{}).Where("id = ?", content).UpdateColumns(map[string]interface{}{
+	if err := cm.DB.Model(util.Content{}).Where("id = ?", contID).UpdateColumns(map[string]interface{}{
 		"active":   true,
 		"size":     totalSize,
 		"pinning":  false,
@@ -3031,7 +3031,6 @@ func (cm *ContentManager) addObjectsToDatabase(ctx context.Context, content uint
 	if err := cm.DB.CreateInBatches(refs, 500).Error; err != nil {
 		return xerrors.Errorf("failed to create refs: %w", err)
 	}
-
 	return nil
 }
 

--- a/shuttle.go
+++ b/shuttle.go
@@ -92,7 +92,7 @@ func (cm *ContentManager) registerShuttleConnection(handle string, hello *drpc.H
 		address:               hello.Address,
 		addrInfo:              hello.AddrInfo,
 		hostname:              hello.Host,
-		cmds:                  make(chan *drpc.Command, 100000),
+		cmds:                  make(chan *drpc.Command, cm.cfg.RPCMessage.OutgoingQueueSize),
 		ctx:                   ctx,
 		private:               hello.Private,
 		ContentAddingDisabled: hello.ContentAddingDisabled,

--- a/shuttle.go
+++ b/shuttle.go
@@ -92,7 +92,7 @@ func (cm *ContentManager) registerShuttleConnection(handle string, hello *drpc.H
 		address:               hello.Address,
 		addrInfo:              hello.AddrInfo,
 		hostname:              hello.Host,
-		cmds:                  make(chan *drpc.Command, 32),
+		cmds:                  make(chan *drpc.Command, 100000),
 		ctx:                   ctx,
 		private:               hello.Private,
 		ContentAddingDisabled: hello.ContentAddingDisabled,


### PR DESCRIPTION
This PR brings some improvements and bug fixes;

- The API response for the contents UI, will now return all contents (this will address the UX issue raised in https://github.com/application-research/estuary/issues/462 and https://filecoinproject.slack.com/archives/C016APFREQK/p1665824335920899?thread_ts=1665650121.296659&cid=C016APFREQK

**before**
<img width="983" alt="Screenshot 2022-10-16 at 07 13 18" src="https://user-images.githubusercontent.com/13554411/196021789-88b5ef05-477d-4b0a-a1a5-147b98506d45.png">

**after**
<img width="760" alt="Screenshot 2022-10-16 at 07 10 51" src="https://user-images.githubusercontent.com/13554411/196021804-08fb3f6a-d885-492c-9442-447ec180084c.png">


- The UI deals page will now only show the deals for contents that actually have deals being made - see https://filecoinproject.slack.com/archives/C016APFREQK/p1665674619728969. It intermittently picks up newly added contents, even small ones just before they are added to the staging zone due to race conditions. This fix, will do away with race checks and really directly on the deal on the database.

**before** (only content 18 has deal attempt, but it shows contents 18 and 21 - 21 should not be there)
<img width="1263" alt="Screenshot 2022-10-16 at 07 54 54" src="https://user-images.githubusercontent.com/13554411/196022730-c3b4cde6-b1c9-4287-be2c-271a83399abc.png">
<img width="1270" alt="Screenshot 2022-10-16 at 07 55 11" src="https://user-images.githubusercontent.com/13554411/196022732-9cf703d9-968c-4c0e-83a5-ce702590f8ff.png">

**after** (only 18 now shows)
<img width="1244" alt="Screenshot 2022-10-16 at 07 56 03" src="https://user-images.githubusercontent.com/13554411/196022758-8076ec69-24c8-40ee-b83d-077a720829ba.png">


- Improve the shuttle API response, noticed some HTTP error codes were not properly reported

**before**
<img width="1134" alt="Screenshot 2022-10-16 at 05 27 51" src="https://user-images.githubusercontent.com/13554411/196021874-94f9b726-ba64-449e-822a-ed9f3aefb596.png">

**after**
<img width="1066" alt="Screenshot 2022-10-16 at 05 34 08" src="https://user-images.githubusercontent.com/13554411/196021884-0c36fa66-d175-4f41-adb7-6dd213074e76.png">

- Fixed the first part of dropped RPC messages, by using a buffered queue for primary (this will fix such bugs reported https://filecoinproject.slack.com/archives/C016APFREQK/p1665771946484999?thread_ts=1665623630.317789&cid=C016APFREQK and https://github.com/application-research/estuary/issues/462.
 The second PR will be created to handle resending pin RPC messages for situations where the shuttle was down or crashed before receiving/processing RPC request

closes https://github.com/application-research/estuary/issues/462