### PR TITLE
Use ID blockstore

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -438,6 +438,7 @@ func loadBlockstore(bscfg string, wal string, flush, walTruncate, nocache bool) 
 	if err != nil {
 		return nil, "", err
 	}
+	bstore = newIdBlockstore(bstore)
 
 	if wal != "" {
 		opts := badgerbs.DefaultOptions(wal)
@@ -561,4 +562,17 @@ func (dmw *deleteManyWrap) DeleteMany(ctx context.Context, cids []cid.Cid) error
 	}
 
 	return nil
+}
+
+// idBlockstoreWrap wrapper help put and retrieve identity/inline CIDs
+type idBlockstoreWrap struct {
+	blockstore.Blockstore
+}
+
+func newIdBlockstore(bStore blockstore.Blockstore) EstuaryBlockstore {
+	return idBlockstoreWrap{blockstore.NewIdStore(bStore)}
+}
+
+func (ibl idBlockstoreWrap) DeleteMany(ctx context.Context, cids []cid.Cid) error {
+	return ibl.DeleteMany(ctx, cids)
 }


### PR DESCRIPTION
This PR brings a change that allows the blockstore properly handle Identity CIDs. see https://filecoinproject.slack.com/archives/C016APFREQK/p1660261206656769 for more context. This change will fix this bug https://github.com/application-research/estuary/issues/330 

before

<img width="855" alt="Screenshot 2022-10-18 at 04 14 20" src="https://user-images.githubusercontent.com/13554411/196329467-e5c794fe-6470-4f4b-821f-590c0b96f389.png">

after

<img width="932" alt="Screenshot 2022-10-18 at 04 22 37" src="https://user-images.githubusercontent.com/13554411/196329506-b35fef96-58bc-4875-8633-491d30fea0c4.png">


closes https://github.com/application-research/estuary/issues/330 