### PR TITLE
Add /admin/fil-address endpoint for when account has no balance yet

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -245,6 +245,7 @@ func (s *Server) ServeAPI() error {
 
 	admin := e.Group("/admin")
 	admin.Use(s.AuthRequired(util.PermLevelAdmin))
+	admin.GET("/fil-address", s.handleAdminFilAddress)
 	admin.GET("/balance", s.handleAdminBalance)
 	admin.POST("/add-escrow/:amt", s.handleAdminAddEscrow)
 	admin.GET("/dealstats", s.handleDealStats)
@@ -1932,6 +1933,10 @@ func (s *Server) handleAdminCreateInvite(c echo.Context, u *util.User) error {
 	return c.JSON(http.StatusOK, map[string]string{
 		"code": invite.Code,
 	})
+}
+
+func (s *Server) handleAdminFilAddress(c echo.Context) error {
+	return c.JSON(http.StatusOK, s.FilClient.ClientAddr)
 }
 
 func (s *Server) handleAdminBalance(c echo.Context) error {


### PR DESCRIPTION
**Problem**: When setting up a new estuary node, you can’t find your FIL address through the estuary-www UI because the /admin/balance endpoint fails until the address has some balance. This can cause confusion if you miss the FIL address in the CLI output, making it trickier to get your account funded and start using your estuary node.

**Proposed Solution**: Add a dedicated /admin/fil-address endpoint so we can always display the FIL address in the estuary-www Balance page.

**Note**: Will follow-up with an estuary-www PR to consume this endpoint. (Edit: See https://github.com/application-research/estuary-www/pull/81)

This is what /admin/balance throws in this initial state:
`{"error":{"code":500,"reason":"Internal Server Error","details":"resolution lookup failed (<address>): resolve address <address>: actor not found"}}`