### PR TITLE
create a v1 prefix for the api

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1779,9 +1779,9 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.0.0",
+	Version:          "1.0.0",
 	Host:             "api.estuary.tech",
-	BasePath:         "/",
+	BasePath:         "/v1/",
 	Schemes:          []string{},
 	Title:            "Estuary API",
 	Description:      "This is the API for the Estuary application.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12,10 +12,10 @@
       "name": "Apache 2.0 Apache-2.0 OR MIT",
       "url": "https://github.com/application-research/estuary/blob/master/LICENSE.md"
     },
-    "version": "0.0.0"
+    "version": "1.0.0"
   },
   "host": "api.estuary.tech",
-  "basePath": "/",
+  "basePath": "/v1/",
   "paths": {
     "/admin/autoretrieve/init": {
       "post": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /
+basePath: /v1/
 definitions:
   main.Collection:
     properties:
@@ -108,7 +108,7 @@ info:
     url: https://github.com/application-research/estuary/blob/master/LICENSE.md
   termsOfService: http://estuary.tech
   title: Estuary API
-  version: 0.0.0
+  version: 1.0.0
 paths:
   /admin/autoretrieve/init:
     post:


### PR DESCRIPTION
 also install all of the v1 api endpoints to the router without the v1 prefix in a way that can easily be deprecated in the future

testing it looks correct-- 

`% curl -X POST http://localhost:3004/user/api-keys -H "Authorization: Bearer ESTxx0ARY" -H "Accept: application/json"
{"token":"ESTxxARY","expiry":"2022-11-22T22:25:03.73497Z"}
 % curl -X POST http://localhost:3004/v1/user/api-keys -H "Authorization: Bearer ESTxxRY" -H "Accept: application/json"
{"token":"ESTxxRY","expiry":"2022-11-22T22:25:12.289277Z"}`