### PR TITLE
create a v1 prefix for the api

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1947,9 +1947,9 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.0.0",
+	Version:          "1.0.0",
 	Host:             "api.estuary.tech",
-	BasePath:         "/",
+	BasePath:         "/v1/",
 	Schemes:          []string{},
 	Title:            "Estuary API",
 	Description:      "This is the API for the Estuary application.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12,10 +12,10 @@
       "name": "Apache 2.0 Apache-2.0 OR MIT",
       "url": "https://github.com/application-research/estuary/blob/master/LICENSE.md"
     },
-    "version": "0.0.0"
+    "version": "1.0.0"
   },
   "host": "api.estuary.tech",
-  "basePath": "/",
+  "basePath": "/v1/",
   "paths": {
     "/admin/autoretrieve/init": {
       "post": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /
+basePath: /v1/
 definitions:
   collections.Collection:
     properties:
@@ -130,7 +130,7 @@ info:
     url: https://github.com/application-research/estuary/blob/master/LICENSE.md
   termsOfService: http://estuary.tech
   title: Estuary API
-  version: 0.0.0
+  version: 1.0.0
 paths:
   /admin/autoretrieve/init:
     post:

--- a/handlers.go
+++ b/handlers.go
@@ -80,7 +80,7 @@ import (
 )
 
 // @title Estuary API
-// @version 0.0.0
+// @version 1.0.0
 // @description This is the API for the Estuary application.
 // @termsOfService http://estuary.tech
 
@@ -91,23 +91,24 @@ import (
 // @license.url https://github.com/application-research/estuary/blob/master/LICENSE.md
 
 // @host api.estuary.tech
-// @BasePath  /
+// @BasePath  /v1/
 // @securityDefinitions.Bearer
 // @securityDefinitions.Bearer.type apiKey
 // @securityDefinitions.Bearer.in header
 // @securityDefinitions.Bearer.name Authorization
 func (s *Server) ServeAPI() error {
-	e := echo.New()
-	e.Binder = new(util.Binder)
+	myecho := echo.New()
+	myecho.Binder = new(util.Binder)
 
 	if s.cfg.Logging.ApiEndpointLogging {
-		e.Use(middleware.Logger())
+		myecho.Use(middleware.Logger())
 	}
 
-	e.Use(s.tracingMiddleware)
-	e.Use(util.AppVersionMiddleware(s.cfg.AppVersion))
-	e.HTTPErrorHandler = util.ErrorHandler
+	myecho.Use(s.tracingMiddleware)
+	myecho.Use(util.AppVersionMiddleware(s.cfg.AppVersion))
+	myecho.HTTPErrorHandler = util.ErrorHandler
 
+	e := myecho.Group("/v1")
 	e.GET("/debug/pprof/:prof", serveProfile)
 	e.GET("/debug/cpuprofile", serveCpuProfile)
 
@@ -317,7 +318,23 @@ func (s *Server) ServeAPI() error {
 	if !s.cfg.DisableSwaggerEndpoint {
 		e.GET("/swagger/*", echoSwagger.WrapHandler)
 	}
-	return e.Start(s.cfg.ApiListen)
+
+	addRoutesWithNoPrefix(myecho)
+
+	return myecho.Start(s.cfg.ApiListen)
+}
+
+func addRoutesWithNoPrefix(myecho *echo.Echo) {
+	for _, value := range myecho.Routes() {
+		var newpath string
+		if strings.HasPrefix(value.Path, "/v1/") {
+			newpath = value.Path[4:] // cut out /v1/
+			c := myecho.NewContext(nil, nil)
+			myecho.Router().Find(value.Method, value.Path, c)
+			h := c.Handler()
+			myecho.Add(value.Method, newpath, h)
+		}
+	}
 }
 
 func serveCpuProfile(c echo.Context) error {

--- a/handlers.go
+++ b/handlers.go
@@ -97,18 +97,18 @@ import (
 // @securityDefinitions.Bearer.in header
 // @securityDefinitions.Bearer.name Authorization
 func (s *Server) ServeAPI() error {
-	myecho := echo.New()
-	myecho.Binder = new(util.Binder)
+	echoEngine := echo.New()
+	echoEngine.Binder = new(util.Binder)
 
 	if s.cfg.Logging.ApiEndpointLogging {
-		myecho.Use(middleware.Logger())
+		echoEngine.Use(middleware.Logger())
 	}
 
-	myecho.Use(s.tracingMiddleware)
-	myecho.Use(util.AppVersionMiddleware(s.cfg.AppVersion))
-	myecho.HTTPErrorHandler = util.ErrorHandler
+	echoEngine.Use(s.tracingMiddleware)
+	echoEngine.Use(util.AppVersionMiddleware(s.cfg.AppVersion))
+	echoEngine.HTTPErrorHandler = util.ErrorHandler
 
-	e := myecho.Group("/v1")
+	e := echoEngine.Group("/v1")
 	e.GET("/debug/pprof/:prof", serveProfile)
 	e.GET("/debug/cpuprofile", serveCpuProfile)
 
@@ -319,20 +319,20 @@ func (s *Server) ServeAPI() error {
 		e.GET("/swagger/*", echoSwagger.WrapHandler)
 	}
 
-	addRoutesWithNoPrefix(myecho)
+	addRoutesWithNoPrefix(echoEngine)
 
-	return myecho.Start(s.cfg.ApiListen)
+	return echoEngine.Start(s.cfg.ApiListen)
 }
 
-func addRoutesWithNoPrefix(myecho *echo.Echo) {
-	for _, value := range myecho.Routes() {
+func addRoutesWithNoPrefix(echoEngine *echo.Echo) {
+	for _, value := range echoEngine.Routes() {
 		var newpath string
 		if strings.HasPrefix(value.Path, "/v1/") {
 			newpath = value.Path[4:] // cut out /v1/
-			c := myecho.NewContext(nil, nil)
-			myecho.Router().Find(value.Method, value.Path, c)
+			c := echoEngine.NewContext(nil, nil)
+			echoEngine.Router().Find(value.Method, value.Path, c)
 			h := c.Handler()
-			myecho.Add(value.Method, newpath, h)
+			echoEngine.Add(value.Method, newpath, h)
 		}
 	}
 }


### PR DESCRIPTION
create a v1 prefix for the api i, also install all of the v1 api endpoints to the router without the v1 prefix in a way that can easily be deprecated in the future

testing it looks correct--

```
% curl -X POST http://localhost:3004/user/api-keys -H "Authorization: Bearer ESTxx0ARY" -H "Accept: application/json" 

{"token":"ESTxxARY","expiry":"2022-11-22T22:25:03.73497Z"} 

% curl -X POST http://localhost:3004/v1/user/api-keys -H "Authorization: Bearer ESTxxRY" -H "Accept: application/json" 

{"token":"ESTxxRY","expiry":"2022-11-22T22:25:12.289277Z"}
```