### PR TITLE
fix: only send pin completion message after blocks are completely copied

### DIFF
--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -128,6 +128,7 @@ type StorageDeal struct {
 }
 
 type RetrieveContent struct {
+	UserID  uint
 	Content uint
 	Cid     cid.Cid
 	Deals   []StorageDeal


### PR DESCRIPTION
When files are uploaded to a shuttle, it sends a pin completion RPC message to the primary even before the staging blocks are copied to the main blockstore. 

The Primary immediately starts deal processing and request for commp from the shuttle, given the copy is not completed, the results in commp error.

This PR addresses this by making sure the RPC message is only sent after the copy is done