### PR TITLE
fix: nosync false

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -369,7 +369,7 @@ func constructBlockstore(bscfg string) (EstuaryBlockstore, string, error) {
 	if !strings.HasPrefix(bscfg, ":") {
 		lmdbs, err := lmdb.Open(&lmdb.Options{
 			Path:   bscfg,
-			NoSync: true,
+			NoSync: false,
 		})
 		if err != nil {
 			return nil, "", err
@@ -386,7 +386,7 @@ func constructBlockstore(bscfg string) (EstuaryBlockstore, string, error) {
 	case "lmdb":
 		lmdbs, err := lmdb.Open(&lmdb.Options{
 			Path:   path,
-			NoSync: true,
+			NoSync: false,
 		})
 		if err != nil {
 			return nil, path, err

--- a/stagingbs/stagingbs.go
+++ b/stagingbs/stagingbs.go
@@ -39,7 +39,7 @@ func (sbmgr *StagingBSMgr) AllocNew() (BSID, blockstore.Blockstore, error) {
 
 	bstore, err := lmdb.Open(&lmdb.Options{
 		Path:   dir,
-		NoSync: true,
+		NoSync: false,
 	})
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
# Changes
- We have several occurances of corrupted lmdb and this is potentially caused by having a nosync configuration set to true. According to LMDB spec:

```
MDB_NOSYNC Don't flush system buffers to disk when committing a transaction. This optimization means a system crash can corrupt the database or lose the last transactions if buffers are not yet flushed to disk. The risk is governed by how often the system flushes dirty buffers to disk and how often mdb_env_sync() is called. However, if the filesystem preserves write order and the MDB_WRITEMAP flag is not used, transactions exhibit ACI (atomicity, consistency, isolation) properties and only lose D (durability). I.e. database integrity is maintained, but a system crash may undo the final transactions. Note that (MDB_NOSYNC | MDB_WRITEMAP) leaves the system with no hint for when to write transactions to disk, unless mdb_env_sync() is called. (MDB_MAPASYNC | MDB_WRITEMAP) may be preferable. This flag may be changed at any time using mdb_env_set_flags().
```

Setting this to false will have some performance impact but the tradeoff is reliability.