### PR TITLE
Absolute paths when rendering gateway dir hrefs

### DIFF
--- a/util/gateway/gateway.go
+++ b/util/gateway/gateway.go
@@ -182,10 +182,9 @@ func (gw *GatewayHandler) serveUnixfsDir(ctx context.Context, n mdagipld.Node, w
 	fmt.Fprintf(w, "<html><body><ul>")
 
 	requestURI, err := url.ParseRequestURI(req.RequestURI)
-	originalURLPath := requestURI.Path
 
 	if err := dir.ForEachLink(ctx, func(lnk *mdagipld.Link) error {
-		href := gopath.Join(originalURLPath, lnk.Name)
+		href := gopath.Join(requestURI.Path, lnk.Name)
 		fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>", href, lnk.Name)
 		return nil
 	}); err != nil {

--- a/util/gateway/gateway.go
+++ b/util/gateway/gateway.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	gopath "path"
 	"strings"
 	"time"
 
@@ -179,8 +181,12 @@ func (gw *GatewayHandler) serveUnixfsDir(ctx context.Context, n mdagipld.Node, w
 
 	fmt.Fprintf(w, "<html><body><ul>")
 
+	requestURI, err := url.ParseRequestURI(req.RequestURI)
+	originalURLPath := requestURI.Path
+
 	if err := dir.ForEachLink(ctx, func(lnk *mdagipld.Link) error {
-		fmt.Fprintf(w, "<li><a href=\"./%s\">%s</a></li>", lnk.Name, lnk.Name)
+		href := gopath.Join(originalURLPath, lnk.Name)
+		fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>", href, lnk.Name)
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
When rendering a dir via the estuary gateway, renders hrefs as `/gw/ipfs/<cid>/<child-name>` instead of `./<child-name>`.

This fixes browsing cids like the following: 
- https://api.estuary.tech/gw/ipfs/bafybeihadprcvcygjv7znlpdmrekbu6moyykceg4gb2jhq2obpjf4p6mbm (no trailing slash case)
- https://api.estuary.tech/gw/ipfs/bafybeihadprcvcygjv7znlpdmrekbu6moyykceg4gb2jhq2obpjf4p6mbm/outputs/ (nested paths case)


This also mirrors the behavior of the kubo gateway implementation (see https://strn.pl/ipfs/bafybeihadprcvcygjv7znlpdmrekbu6moyykceg4gb2jhq2obpjf4p6mbm as a reference), hrefs are rendered as `/ipfs/<cid>/<child-name>`.