### PR TITLE
Don't panic if wallet balance exists but has nil datacap

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -1510,6 +1510,10 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content util.Conten
 			return errors.New("verifed deals requires datacap, please see https://verify.glif.io or use the --verified-deal=false for non-verified deals")
 		}
 
+		if bl.VerifiedClientBalance == nil {
+			return errors.Wrap(err, "client balance has nil dataCap")
+		}
+
 		if bl.VerifiedClientBalance.LessThan(big.NewIntUnsigned(uint64(abi.UnpaddedPieceSize(content.Size).Padded()))) {
 			// how do we notify admin to top up datacap?
 			return errors.Wrapf(err, "will not make deal, client address dataCap:%d GiB is lower than content size:%d GiB", big.Div(*bl.VerifiedClientBalance, big.NewIntUnsigned(uint64(1073741824))), abi.UnpaddedPieceSize(content.Size).Padded()/1073741824)

--- a/replication.go
+++ b/replication.go
@@ -1506,12 +1506,8 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content util.Conten
 			return errors.Wrap(err, "could not retrieve dataCap from client balance")
 		}
 
-		if bl == nil {
+		if bl == nil || bl.VerifiedClientBalance == nil {
 			return errors.New("verifed deals requires datacap, please see https://verify.glif.io or use the --verified-deal=false for non-verified deals")
-		}
-
-		if bl.VerifiedClientBalance == nil {
-			return errors.Wrap(err, "client balance has nil dataCap")
 		}
 
 		if bl.VerifiedClientBalance.LessThan(big.NewIntUnsigned(uint64(abi.UnpaddedPieceSize(content.Size).Padded()))) {


### PR DESCRIPTION
Ran into a panic when testing with a wallet that had FIL but no datacap. This change catches that panic and provides a helpful error message.

Before:
![image](https://user-images.githubusercontent.com/2850013/200420577-6d2e123c-6627-4501-92e9-25890c96064f.png)

After:
![image](https://user-images.githubusercontent.com/2850013/200420483-1a734aa8-5ade-4295-a990-174eb69b61dd.png)
