### PR TITLE
Update replace pin swagger annotations

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2200,6 +2200,39 @@ const docTemplate = `{
                         "name": "pinid",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "CID of new pin",
+                        "name": "cid",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Name (filename) of new pin",
+                        "name": "name",
+                        "in": "body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Origins of new pin",
+                        "name": "origins",
+                        "in": "body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Meta information of new pin",
+                        "name": "meta",
+                        "in": "body",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2193,6 +2193,39 @@
             "name": "pinid",
             "in": "path",
             "required": true
+          },
+          {
+            "description": "CID of new pin",
+            "name": "cid",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name (filename) of new pin",
+            "name": "name",
+            "in": "body",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Origins of new pin",
+            "name": "origins",
+            "in": "body",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Meta information of new pin",
+            "name": "meta",
+            "in": "body",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1615,6 +1615,27 @@ paths:
           name: pinid
           required: true
           type: string
+        - description: CID of new pin
+          in: body
+          name: cid
+          required: true
+          schema:
+            type: string
+        - description: Name (filename) of new pin
+          in: body
+          name: name
+          schema:
+            type: string
+        - description: Origins of new pin
+          in: body
+          name: origins
+          schema:
+            type: string
+        - description: Meta information of new pin
+          in: body
+          name: meta
+          schema:
+            type: string
       produces:
         - application/json
       responses:

--- a/pinning.go
+++ b/pinning.go
@@ -746,7 +746,11 @@ func (s *Server) handleGetPin(e echo.Context, u *util.User) error {
 // @Success      200  {object}  string
 // @Failure      400  {object}  util.HttpError
 // @Failure      500  {object}  util.HttpError
-// @Param        pinid  path      string  true  "Pin ID"
+// @Param        pinid		path      string  true  "Pin ID"
+// @Param        cid		body      string  true  "CID of new pin"
+// @Param        name		body      string  false  "Name (filename) of new pin"
+// @Param        origins	body      string  false  "Origins of new pin"
+// @Param        meta		body      string  false  "Meta information of new pin"
 // @Router       /pinning/pins/{pinid} [post]
 func (s *Server) handleReplacePin(e echo.Context, u *util.User) error {
 


### PR DESCRIPTION
We forgot to mention some parameters on the swagger annotations for replacing a pin

Reminder: the `docs: update swagger docs` commit is a post commit hook, not me