### PR TITLE
docs: Update annotations for Pinning API endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2079,17 +2079,11 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/types.IpfsListPinStatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/util.HttpError"
                         }
@@ -2123,16 +2117,10 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
+                            "$ref": "#/definitions/types.IpfsPinStatusResponse"
                         }
                     },
                     "500": {
@@ -2167,11 +2155,11 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/types.IpfsPinStatusResponse"
                         }
                     },
-                    "400": {
-                        "description": "Bad Request",
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/util.HttpError"
                         }
@@ -2236,14 +2224,14 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "202": {
+                        "description": "Accepted",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/types.IpfsPinStatusResponse"
                         }
                     },
-                    "400": {
-                        "description": "Bad Request",
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/util.HttpError"
                         }
@@ -2275,17 +2263,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
+                    "202": {
+                        "description": ""
                     },
                     "500": {
                         "description": "Internal Server Error",
@@ -3044,6 +3023,20 @@ const docTemplate = `{
                 }
             }
         },
+        "types.IpfsListPinStatusResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.IpfsPinStatusResponse"
+                    }
+                }
+            }
+        },
         "types.IpfsPin": {
             "type": "object",
             "properties": {
@@ -3062,6 +3055,33 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "types.IpfsPinStatusResponse": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "string"
+                },
+                "delegates": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "info": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "pin": {
+                    "$ref": "#/definitions/types.IpfsPin"
+                },
+                "requestid": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2072,17 +2072,11 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/types.IpfsListPinStatusResponse"
             }
           },
           "400": {
             "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
-          },
-          "404": {
-            "description": "Not Found",
             "schema": {
               "$ref": "#/definitions/util.HttpError"
             }
@@ -2116,16 +2110,10 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "schema": {
-              "type": "string"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
+              "$ref": "#/definitions/types.IpfsPinStatusResponse"
             }
           },
           "500": {
@@ -2160,11 +2148,11 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/types.IpfsPinStatusResponse"
             }
           },
-          "400": {
-            "description": "Bad Request",
+          "404": {
+            "description": "Not Found",
             "schema": {
               "$ref": "#/definitions/util.HttpError"
             }
@@ -2229,14 +2217,14 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
+          "202": {
+            "description": "Accepted",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/types.IpfsPinStatusResponse"
             }
           },
-          "400": {
-            "description": "Bad Request",
+          "404": {
+            "description": "Not Found",
             "schema": {
               "$ref": "#/definitions/util.HttpError"
             }
@@ -2268,17 +2256,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
+          "202": {
+            "description": ""
           },
           "500": {
             "description": "Internal Server Error",
@@ -3037,6 +3016,20 @@
         }
       }
     },
+    "types.IpfsListPinStatusResponse": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer"
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/types.IpfsPinStatusResponse"
+          }
+        }
+      }
+    },
     "types.IpfsPin": {
       "type": "object",
       "properties": {
@@ -3055,6 +3048,33 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "types.IpfsPinStatusResponse": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string"
+        },
+        "delegates": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "info": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "pin": {
+          "$ref": "#/definitions/types.IpfsPin"
+        },
+        "requestid": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
         }
       }
     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -73,6 +73,15 @@ definitions:
       name:
         type: string
     type: object
+  types.IpfsListPinStatusResponse:
+    properties:
+      count:
+        type: integer
+      results:
+        items:
+          $ref: '#/definitions/types.IpfsPinStatusResponse'
+        type: array
+    type: object
   types.IpfsPin:
     properties:
       cid:
@@ -86,6 +95,24 @@ definitions:
         items:
           type: string
         type: array
+    type: object
+  types.IpfsPinStatusResponse:
+    properties:
+      created:
+        type: string
+      delegates:
+        items:
+          type: string
+        type: array
+      info:
+        additionalProperties: true
+        type: object
+      pin:
+        $ref: '#/definitions/types.IpfsPin'
+      requestid:
+        type: string
+      status:
+        type: string
     type: object
   util.ContentAddIpfsBody:
     properties:
@@ -1511,13 +1538,9 @@ paths:
         "200":
           description: OK
           schema:
-            type: string
+            $ref: '#/definitions/types.IpfsListPinStatusResponse'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/util.HttpError'
-        "404":
-          description: Not Found
           schema:
             $ref: '#/definitions/util.HttpError'
         "500":
@@ -1539,14 +1562,10 @@ paths:
       produces:
         - application/json
       responses:
-        "200":
-          description: OK
+        "202":
+          description: Accepted
           schema:
-            type: string
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/util.HttpError'
+            $ref: '#/definitions/types.IpfsPinStatusResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -1566,14 +1585,8 @@ paths:
       produces:
         - application/json
       responses:
-        "200":
-          description: OK
-          schema:
-            type: string
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/util.HttpError'
+        "202":
+          description: ""
         "500":
           description: Internal Server Error
           schema:
@@ -1595,9 +1608,9 @@ paths:
         "200":
           description: OK
           schema:
-            type: string
-        "400":
-          description: Bad Request
+            $ref: '#/definitions/types.IpfsPinStatusResponse'
+        "404":
+          description: Not Found
           schema:
             $ref: '#/definitions/util.HttpError'
         "500":
@@ -1639,12 +1652,12 @@ paths:
       produces:
         - application/json
       responses:
-        "200":
-          description: OK
+        "202":
+          description: Accepted
           schema:
-            type: string
-        "400":
-          description: Bad Request
+            $ref: '#/definitions/types.IpfsPinStatusResponse'
+        "404":
+          description: Not Found
           schema:
             $ref: '#/definitions/util.HttpError'
         "500":

--- a/pinning.go
+++ b/pinning.go
@@ -423,10 +423,9 @@ func (cm *ContentManager) primaryStagingLocation(ctx context.Context, uid uint) 
 // @Description  This endpoint lists all pin status objects
 // @Tags         pinning
 // @Produce      json
-// @Success      200    {object}  string
-// @Failure      400    {object}  util.HttpError
-// @Failure      404  {object}  util.HttpError
-// @Failure      500    {object}  util.HttpError
+// @Success      200  {object}  types.IpfsListPinStatusResponse
+// @Failure      400  {object}  util.HttpError
+// @Failure      500  {object}  util.HttpError
 // @Router       /pinning/pins [get]
 func (s *Server) handleListPins(e echo.Context, u *util.User) error {
 	_, span := s.tracer.Start(e.Request().Context(), "handleListPins")
@@ -632,10 +631,9 @@ func filterForStatusQuery(q *gorm.DB, statuses map[types.PinningStatus]bool) (*g
 // @Description  This endpoint adds a pin to the IPFS daemon.
 // @Tags         pinning
 // @Produce      json
-// @Success      200    {object}  string
-// @Failure      400    {object}  util.HttpError
+// @Success      202	{object}  types.IpfsPinStatusResponse
 // @Failure      500    {object}  util.HttpError
-// @in           200,400,default  string  Token "token"
+// @in           202,default  string  Token "token"
 // @Param        pin          body      types.IpfsPin  true   "Pin Body {cid:cid, name:name}"
 // @Router       /pinning/pins [post]
 func (s *Server) handleAddPin(e echo.Context, u *util.User) error {
@@ -704,8 +702,8 @@ func (s *Server) handleAddPin(e echo.Context, u *util.User) error {
 // @Description  This endpoint returns a pin status object.
 // @Tags         pinning
 // @Produce      json
-// @Success      200    {object}  string
-// @Failure      400    {object}  util.HttpError
+// @Success      200	{object}  types.IpfsPinStatusResponse
+// @Failure      404	{object}  util.HttpError
 // @Failure      500    {object}  util.HttpError
 // @Param        pinid  path      string  true  "cid"
 // @Router       /pinning/pins/{pinid} [get]
@@ -743,8 +741,8 @@ func (s *Server) handleGetPin(e echo.Context, u *util.User) error {
 // @Description  This endpoint replaces a pinned object.
 // @Tags         pinning
 // @Produce      json
-// @Success      200  {object}  string
-// @Failure      400  {object}  util.HttpError
+// @Success      202	{object}	types.IpfsPinStatusResponse
+// @Failure      404	{object}	util.HttpError
 // @Failure      500  {object}  util.HttpError
 // @Param        pinid		path      string  true  "Pin ID"
 // @Param        cid		body      string  true  "CID of new pin"
@@ -811,8 +809,7 @@ func (s *Server) handleReplacePin(e echo.Context, u *util.User) error {
 // @Description  This endpoint deletes a pinned object.
 // @Tags         pinning
 // @Produce      json
-// @Success      200  {object}  string
-// @Failure      400  {object}  util.HttpError
+// @Success		 202
 // @Failure      500  {object}  util.HttpError
 // @Param        pinid  path      string  true  "Pin ID"
 // @Router       /pinning/pins/{pinid} [delete]


### PR DESCRIPTION
This is necessary because otherwise the `estuary-clients` package won't generate the correct Go types to unmarshal responses into, hence the client doesn't work.