### PR TITLE
Fix collections add content

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -630,7 +630,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "coluuid",
+                        "description": "Collection UUID",
                         "name": "coluuid",
                         "in": "path",
                         "required": true

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -623,7 +623,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "coluuid",
+            "description": "Collection UUID",
             "name": "coluuid",
             "in": "path",
             "required": true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -566,7 +566,7 @@ paths:
         - application/json
       description: This endpoint adds already-pinned contents (that have ContentIDs) to a collection.
       parameters:
-        - description: coluuid
+        - description: Collection UUID
           in: path
           name: coluuid
           required: true

--- a/handlers.go
+++ b/handlers.go
@@ -3626,7 +3626,7 @@ func (s *Server) handleListCollections(c echo.Context, u *util.User) error {
 // @Tags         collections
 // @Accept       json
 // @Produce      json
-// @Param        coluuid     path      string  true  "coluuid"
+// @Param        coluuid     path      string  true  "Collection UUID"
 // @Param        contentIDs  body      []uint  true  "Content IDs to add to collection"
 // @Success      200         {object}  string
 // @Failure      400  {object}  util.HttpError
@@ -3638,6 +3638,15 @@ func (s *Server) handleAddContentsToCollection(c echo.Context, u *util.User) err
 	var contentIDs []uint
 	if err := c.Bind(&contentIDs); err != nil {
 		return err
+	}
+
+	// no contents
+	if len(contentIDs) == 0 {
+		return &util.HttpError{
+			Code:    http.StatusBadRequest,
+			Reason:  util.ERR_INVALID_INPUT,
+			Details: fmt.Sprintf("no contents specified, need at least one"),
+		}
 	}
 
 	if len(contentIDs) > 128 {


### PR DESCRIPTION
The `POST /collections/:coluuid` had a bug where it would not correctly parse the `[]uint` list on the request body. This fixes it.