### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The Makefile has a target that will install a generic but workable systemd servi
 
 Run `make install-estuary-service` on the machine you wish to run estuary on.
 
-Make sure to follow the instructions output by the `make` command as configuration is required before the service can run succesfully.
+Make sure to follow the instructions output by the `make` command as configuration is required before the service can run successfully.
 
 ## Running estuary using docker
 


### PR DESCRIPTION
Fixes typo in README where succesfully was missing an s. 