### PR TITLE
Fix minor swagger inconsistencies

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -111,9 +111,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "admin",
-                    "peering",
-                    "peers"
+                    "admin"
                 ],
                 "summary": "List all Peering peers",
                 "responses": {
@@ -143,9 +141,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "admin",
-                    "peering",
-                    "peers"
+                    "admin"
                 ],
                 "summary": "Add peers on Peering Service",
                 "responses": {
@@ -175,9 +171,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "admin",
-                    "peering",
-                    "peers"
+                    "admin"
                 ],
                 "summary": "Remove peers on Peering Service",
                 "parameters": [
@@ -223,9 +217,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "admin",
-                    "peering",
-                    "peers"
+                    "admin"
                 ],
                 "summary": "Start Peering",
                 "responses": {
@@ -257,9 +249,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "admin",
-                    "peering",
-                    "peers"
+                    "admin"
                 ],
                 "summary": "Check Peering Status",
                 "responses": {
@@ -291,9 +281,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "admin",
-                    "peering",
-                    "peers"
+                    "admin"
                 ],
                 "summary": "Stop Peering",
                 "responses": {
@@ -762,13 +750,6 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Collection ID",
                         "name": "coluuid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Content ID",
-                        "name": "contentid",
                         "in": "path",
                         "required": true
                     },
@@ -2184,42 +2165,18 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Pin ID",
+                        "description": "Pin ID to be replaced",
                         "name": "pinid",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "CID of new pin",
-                        "name": "cid",
+                        "description": "New pin",
+                        "name": "pin",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Name (filename) of new pin",
-                        "name": "name",
-                        "in": "body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Origins of new pin",
-                        "name": "origins",
-                        "in": "body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Meta information of new pin",
-                        "name": "meta",
-                        "in": "body",
-                        "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/types.IpfsPin"
                         }
                     }
                 ],
@@ -2510,7 +2467,8 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by miner",
                         "name": "miner",
-                        "in": "path"
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -2551,7 +2509,8 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by miner",
                         "name": "miner",
-                        "in": "path"
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -104,9 +104,7 @@
           "application/json"
         ],
         "tags": [
-          "admin",
-          "peering",
-          "peers"
+          "admin"
         ],
         "summary": "List all Peering peers",
         "responses": {
@@ -136,9 +134,7 @@
           "application/json"
         ],
         "tags": [
-          "admin",
-          "peering",
-          "peers"
+          "admin"
         ],
         "summary": "Add peers on Peering Service",
         "responses": {
@@ -168,9 +164,7 @@
           "application/json"
         ],
         "tags": [
-          "admin",
-          "peering",
-          "peers"
+          "admin"
         ],
         "summary": "Remove peers on Peering Service",
         "parameters": [
@@ -216,9 +210,7 @@
           "application/json"
         ],
         "tags": [
-          "admin",
-          "peering",
-          "peers"
+          "admin"
         ],
         "summary": "Start Peering",
         "responses": {
@@ -250,9 +242,7 @@
           "application/json"
         ],
         "tags": [
-          "admin",
-          "peering",
-          "peers"
+          "admin"
         ],
         "summary": "Check Peering Status",
         "responses": {
@@ -284,9 +274,7 @@
           "application/json"
         ],
         "tags": [
-          "admin",
-          "peering",
-          "peers"
+          "admin"
         ],
         "summary": "Stop Peering",
         "responses": {
@@ -755,13 +743,6 @@
             "type": "string",
             "description": "Collection ID",
             "name": "coluuid",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "Content ID",
-            "name": "contentid",
             "in": "path",
             "required": true
           },
@@ -2177,42 +2158,18 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Pin ID",
+            "description": "Pin ID to be replaced",
             "name": "pinid",
             "in": "path",
             "required": true
           },
           {
-            "description": "CID of new pin",
-            "name": "cid",
+            "description": "New pin",
+            "name": "pin",
             "in": "body",
             "required": true,
             "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Name (filename) of new pin",
-            "name": "name",
-            "in": "body",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Origins of new pin",
-            "name": "origins",
-            "in": "body",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Meta information of new pin",
-            "name": "meta",
-            "in": "body",
-            "schema": {
-              "type": "string"
+              "$ref": "#/definitions/types.IpfsPin"
             }
           }
         ],
@@ -2503,7 +2460,8 @@
             "type": "string",
             "description": "Filter by miner",
             "name": "miner",
-            "in": "path"
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {
@@ -2544,7 +2502,8 @@
             "type": "string",
             "description": "Filter by miner",
             "name": "miner",
-            "in": "path"
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -262,8 +262,6 @@ paths:
       summary: Remove peers on Peering Service
       tags:
         - admin
-        - peering
-        - peers
     get:
       description: This endpoint can be used to list all peers on Peering Service
       produces:
@@ -284,8 +282,6 @@ paths:
       summary: List all Peering peers
       tags:
         - admin
-        - peering
-        - peers
     post:
       description: This endpoint can be used to add a Peer from the Peering Service
       produces:
@@ -306,8 +302,6 @@ paths:
       summary: Add peers on Peering Service
       tags:
         - admin
-        - peering
-        - peers
   /admin/peering/start:
     post:
       description: This endpoint can be used to start the Peering Service
@@ -329,8 +323,6 @@ paths:
       summary: Start Peering
       tags:
         - admin
-        - peering
-        - peers
   /admin/peering/status:
     get:
       description: This endpoint can be used to check the Peering status
@@ -352,8 +344,6 @@ paths:
       summary: Check Peering Status
       tags:
         - admin
-        - peering
-        - peers
   /admin/peering/stop:
     post:
       description: This endpoint can be used to stop the Peering Service
@@ -375,8 +365,6 @@ paths:
       summary: Stop Peering
       tags:
         - admin
-        - peering
-        - peers
   /admin/system/config:
     get:
       description: This endpoint is used to get system configs.
@@ -631,11 +619,6 @@ paths:
         - description: Collection ID
           in: path
           name: coluuid
-          required: true
-          type: string
-        - description: Content ID
-          in: path
-          name: contentid
           required: true
           type: string
         - description: Variable to use when filtering for files (must be either 'path' or 'content_id')
@@ -1623,32 +1606,17 @@ paths:
     post:
       description: This endpoint replaces a pinned object.
       parameters:
-        - description: Pin ID
+        - description: Pin ID to be replaced
           in: path
           name: pinid
           required: true
           type: string
-        - description: CID of new pin
+        - description: New pin
           in: body
-          name: cid
+          name: pin
           required: true
           schema:
-            type: string
-        - description: Name (filename) of new pin
-          in: body
-          name: name
-          schema:
-            type: string
-        - description: Origins of new pin
-          in: body
-          name: origins
-          schema:
-            type: string
-        - description: Meta information of new pin
-          in: body
-          name: meta
-          schema:
-            type: string
+            $ref: '#/definitions/types.IpfsPin'
       produces:
         - application/json
       responses:
@@ -1819,6 +1787,7 @@ paths:
         - description: Filter by miner
           in: path
           name: miner
+          required: true
           type: string
       produces:
         - application/json
@@ -1846,6 +1815,7 @@ paths:
         - description: Filter by miner
           in: path
           name: miner
+          required: true
           type: string
       produces:
         - application/json

--- a/handlers.go
+++ b/handlers.go
@@ -2606,7 +2606,7 @@ func (s *Server) handleEstimateDealCost(c echo.Context) error {
 // @Success      200  {object}  string
 // @Failure      400  {object}  util.HttpError
 // @Failure      500  {object}  util.HttpError
-// @Param        miner  path      string  false  "Filter by miner"
+// @Param        miner  path      string  true  "Filter by miner"
 // @Router       /public/miners/failures/{miner} [get]
 func (s *Server) handleGetMinerFailures(c echo.Context) error {
 	maddr, err := address.NewFromString(c.Param("miner"))
@@ -2651,7 +2651,7 @@ type minerChainInfo struct {
 // @Success      200  {object}  string
 // @Failure      400  {object}  util.HttpError
 // @Failure      500  {object}  util.HttpError
-// @Param        miner  path      string  false  "Filter by miner"
+// @Param        miner  path      string  true  "Filter by miner"
 // @Router       /public/miners/stats/{miner} [get]
 func (s *Server) handleGetMinerStats(c echo.Context) error {
 	ctx, span := s.tracer.Start(c.Request().Context(), "handleGetMinerStats")
@@ -3982,7 +3982,6 @@ type deleteContentFromCollectionBody struct {
 // @Description  This endpoint is used to delete an existing content from an existing collection. If two or more files with the same contentid exist in the collection, delete the one in the specified path
 // @Tags         collections
 // @Param        coluuid    path  string                           true  "Collection ID"
-// @Param        contentid  path  string                           true  "Content ID"
 // @Param        body       body  deleteContentFromCollectionBody  true  "Variable to use when filtering for files (must be either 'path' or 'content_id')"
 // @Produce      json
 // @Success      200  {object}  string

--- a/handlers.go
+++ b/handlers.go
@@ -445,7 +445,7 @@ func (s *Server) handleStats(c echo.Context, u *util.User) error {
 // handlePeeringPeersAdd godoc
 // @Summary      Add peers on Peering Service
 // @Description  This endpoint can be used to add a Peer from the Peering Service
-// @Tags         admin,peering,peers
+// @Tags         admin
 // @Produce      json
 // @Success      200     {object}  string
 // @Failure      400      {object}  util.HttpError
@@ -508,7 +508,7 @@ type peerIDs []peerID // used for swagger
 // handlePeeringPeersRemove godoc
 // @Summary      Remove peers on Peering Service
 // @Description  This endpoint can be used to remove a Peer from the Peering Service
-// @Tags         admin,peering,peers
+// @Tags         admin
 // @Produce      json
 // @Success      200      {object}  string
 // @Failure      400     {object}  util.HttpError
@@ -534,7 +534,7 @@ func (s *Server) handlePeeringPeersRemove(c echo.Context) error {
 // handlePeeringPeersList godoc
 // @Summary      List all Peering peers
 // @Description  This endpoint can be used to list all peers on Peering Service
-// @Tags         admin,peering,peers
+// @Tags         admin
 // @Produce      json
 // @Success      200      {object}  string
 // @Failure      400   {object}  util.HttpError
@@ -560,7 +560,7 @@ func (s *Server) handlePeeringPeersList(c echo.Context) error {
 // handlePeeringStart godoc
 // @Summary      Start Peering
 // @Description  This endpoint can be used to start the Peering Service
-// @Tags         admin,peering,peers
+// @Tags         admin
 // @Produce      json
 // @Success      200     {object}  string
 // @Failure      400    {object}  util.HttpError
@@ -580,7 +580,7 @@ func (s *Server) handlePeeringStart(c echo.Context) error {
 // handlePeeringStop godoc
 // @Summary      Stop Peering
 // @Description  This endpoint can be used to stop the Peering Service
-// @Tags         admin,peering,peers
+// @Tags         admin
 // @Produce      json
 // @Success      200   {object}  string
 // @Failure      400    {object}  util.HttpError
@@ -600,7 +600,7 @@ func (s *Server) handlePeeringStop(c echo.Context) error {
 // handlePeeringStatus godoc
 // @Summary      Check Peering Status
 // @Description  This endpoint can be used to check the Peering status
-// @Tags         admin,peering,peers
+// @Tags         admin
 // @Produce      json
 // @Success      200    {object}  string
 // @Failure      400            {object}  util.HttpError

--- a/handlers.go
+++ b/handlers.go
@@ -278,13 +278,12 @@ func (s *Server) ServeAPI() error {
 	admin.POST("/cm/repinall/:shuttle", s.handleShuttleRepinAll)
 
 	//	peering
-	adminPeering := admin.Group("/peering")
-	adminPeering.POST("/peers", s.handlePeeringPeersAdd)
-	adminPeering.DELETE("/peers", s.handlePeeringPeersRemove)
-	adminPeering.GET("/peers", s.handlePeeringPeersList)
-	adminPeering.POST("/start", s.handlePeeringStart)
-	adminPeering.POST("/stop", s.handlePeeringStop)
-	adminPeering.GET("/status", s.handlePeeringStatus)
+	admin.POST("/peering/peers", s.handlePeeringPeersAdd)
+	admin.DELETE("/peering/peers", s.handlePeeringPeersRemove)
+	admin.GET("/peering/peers", s.handlePeeringPeersList)
+	admin.POST("/peering/start", s.handlePeeringStart)
+	admin.POST("/peering/stop", s.handlePeeringStop)
+	admin.GET("/peering/status", s.handlePeeringStatus)
 
 	admnetw := admin.Group("/net")
 	admnetw.GET("/peers", s.handleNetPeers)

--- a/pinning.go
+++ b/pinning.go
@@ -744,11 +744,8 @@ func (s *Server) handleGetPin(e echo.Context, u *util.User) error {
 // @Success      202	{object}	types.IpfsPinStatusResponse
 // @Failure      404	{object}	util.HttpError
 // @Failure      500  {object}  util.HttpError
-// @Param        pinid		path      string  true  "Pin ID"
-// @Param        cid		body      string  true  "CID of new pin"
-// @Param        name		body      string  false  "Name (filename) of new pin"
-// @Param        origins	body      string  false  "Origins of new pin"
-// @Param        meta		body      string  false  "Meta information of new pin"
+// @Param        pinid		path      string  true  "Pin ID to be replaced"
+// @Param        pin          body      types.IpfsPin  true   "New pin"
 // @Router       /pinning/pins/{pinid} [post]
 func (s *Server) handleReplacePin(e echo.Context, u *util.User) error {
 


### PR DESCRIPTION
I found a couple inconsistencies on our swagger annotations:
- `path` variables not being required
- multiple `@Param body`s (which is not allowed)
- an extra unused annotated variable 
- `/admin/peering` was a subgroup but we don't do that on other admin subgroups like `/admin/cm`
- remove `peering,peers` tags from `/admin/peering` endpoints (cause them to show up duplicated on swagger)