### PR TITLE
upgrade swagger codegen cli to v3 docker container

### DIFF
--- a/.github/workflows/swagger-client.yml
+++ b/.github/workflows/swagger-client.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   BuildSwaggerClients:
     runs-on: ubuntu-latest
-    container: swaggerapi/swagger-codegen-cli
+    container: swaggerapi/swagger-codegen-cli-v3
 
     steps:
       - name: Build clients and push


### PR DESCRIPTION
related issue https://github.com/application-research/estuary/issues/524


currently .github/workflows/swagger-client.yml uses a docker container to build the swagger clients. This docker container contains swagger-codegen-cli v2. There's a newer docker container called swagger-codegen-cli-v3 for us to switch to.

This PR needs to update main/master and can be rebased into dev after it's approved

