### PR TITLE
Add pinning retry worker

### DIFF
--- a/config/estuary.go
+++ b/config/estuary.go
@@ -104,8 +104,9 @@ func NewEstuary(appVersion string) *Estuary {
 
 		Pinning: Pinning{
 			RetryWorker: RetryWorker{
-				Interval:   1,
-				BatchLimit: 1000,
+				Interval:               1 * time.Hour, // check every 1hr
+				BatchSelectionLimit:    1000,
+				BatchSelectionDuration: time.Hour * 24 * 30 * 2, // select pins from 60 days ago only
 			},
 		},
 

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -32,6 +32,7 @@ type Estuary struct {
 	StagingBucket          StagingBucket `json:"staging_bucket"`
 	Replication            int           `json:"replication"`
 	RPCMessage             RPCMessage    `json:"rpc_message"`
+	Pinning                Pinning       `json:"pinning"`
 }
 
 func (cfg *Estuary) Load(filename string) error {
@@ -99,6 +100,13 @@ func NewEstuary(appVersion string) *Estuary {
 			MinDealSize:             256 << 20,                                               //0.25 Gib
 			IndividualDealThreshold: int64((abi.PaddedPieceSize(4<<30).Unpadded() * 9) / 10), // 90% of the unpadded data size for a 4GB piece, the 10% gap is to accommodate car file packing overhead, can probably do this better
 			AggregateInterval:       time.Minute * 5,                                         // aggregate staging buckets every 5 minutes
+		},
+
+		Pinning: Pinning{
+			RetryWorker: RetryWorker{
+				Interval:   1,
+				BatchLimit: 1000,
+			},
 		},
 
 		Jaeger: Jaeger{

--- a/config/pinning.go
+++ b/config/pinning.go
@@ -7,6 +7,7 @@ type Pinning struct {
 }
 
 type RetryWorker struct {
-	Interval   time.Duration `json:"interval"`
-	BatchLimit int           `json:"batch_limit"`
+	Interval               time.Duration `json:"interval"`
+	BatchSelectionLimit    int           `json:"batch_limit"`
+	BatchSelectionDuration time.Duration `json:"batch_duration"`
 }

--- a/config/pinning.go
+++ b/config/pinning.go
@@ -1,0 +1,12 @@
+package config
+
+import "time"
+
+type Pinning struct {
+	RetryWorker RetryWorker `json:"retry_worker"`
+}
+
+type RetryWorker struct {
+	Interval   time.Duration `json:"interval"`
+	BatchLimit int           `json:"batch_limit"`
+}

--- a/main.go
+++ b/main.go
@@ -714,6 +714,7 @@ func main() {
 
 		go cm.Run(cctx.Context)                                                 // deal making and deal reconciliation
 		go cm.handleShuttleMessages(cctx.Context, cfg.RPCMessage.QueueHandlers) // register workers/handlers to process shuttle rpc messages from a channel(queue)
+		go cm.RunPinningRetryWorker(cctx.Context)                               // pinning retry worker, re-attempt pinning contents, not yet pinned after a period of time
 
 		// Start autoretrieve if not disabled
 		if !cfg.DisableAutoRetrieve {

--- a/pinning_retry_worker.go
+++ b/pinning_retry_worker.go
@@ -9,6 +9,8 @@ import (
 
 // RunPinningRetryWorker re-attempt pinning contents that have not yet been pinned after a period of time
 func (cm *ContentManager) RunPinningRetryWorker(ctx context.Context) {
+	log.Info("running pinning retry worker .......")
+
 	timer := time.NewTicker(cm.cfg.Pinning.RetryWorker.Interval)
 	for {
 		select {

--- a/pinning_retry_worker.go
+++ b/pinning_retry_worker.go
@@ -9,16 +9,17 @@ import (
 
 // RunPinningRetryWorker re-attempt pinning contents that have not yet been pinned after a period of time
 func (cm *ContentManager) RunPinningRetryWorker(ctx context.Context) {
-	timer := time.NewTicker(time.Hour * cm.cfg.Pinning.RetryWorker.Interval)
+	timer := time.NewTicker(cm.cfg.Pinning.RetryWorker.Interval)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
 			startContentID := 0
+			batchDate := time.Now().Add(-cm.cfg.Pinning.RetryWorker.BatchSelectionDuration)
 			for {
 				var contents []util.Content
-				if err := cm.DB.Limit(cm.cfg.Pinning.RetryWorker.BatchLimit).Order("id ASC").Find(&contents, "pinning and not active and not failed and not aggregate and id > ? and created_at > NOW() + INTERVAL '1 HOURS'", startContentID).Error; err != nil {
+				if err := cm.DB.Limit(cm.cfg.Pinning.RetryWorker.BatchSelectionLimit).Order("id ASC").Find(&contents, "pinning and not active and not failed and not aggregate and id > ? and created_at > ?", startContentID, batchDate).Error; err != nil {
 					log.Errorf("failed to get contents for pinning monitor: %s", err)
 					return
 				}
@@ -28,7 +29,6 @@ func (cm *ContentManager) RunPinningRetryWorker(ctx context.Context) {
 				}
 
 				go cm.pinContents(ctx, contents)
-
 				startContentID = int(contents[len(contents)-1].ID)
 			}
 		}

--- a/pinning_retry_worker.go
+++ b/pinning_retry_worker.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/application-research/estuary/util"
+)
+
+// RunPinningRetryWorker re-attempt pinning contents that have not yet been pinned after a period of time
+func (cm *ContentManager) RunPinningRetryWorker(ctx context.Context) {
+	timer := time.NewTicker(time.Hour * cm.cfg.Pinning.RetryWorker.Interval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			go func() {
+				startContentID := 0
+				for {
+					var contents []util.Content
+					if err := cm.DB.Limit(cm.cfg.Pinning.RetryWorker.BatchLimit).Order("id ASC").Find(&contents, "pinning and not active and not failed and not aggregate and id > ? and created_at > NOW() + INTERVAL '1 HOURS'", startContentID).Error; err != nil {
+						log.Errorf("failed to get contents for pinning monitor: %s", err)
+						return
+					}
+
+					if len(contents) == 0 {
+						break
+					}
+
+					go cm.pinContents(ctx, contents)
+
+					startContentID = int(contents[len(contents)-1].ID)
+				}
+			}()
+		}
+	}
+}

--- a/pinning_retry_worker.go
+++ b/pinning_retry_worker.go
@@ -15,24 +15,22 @@ func (cm *ContentManager) RunPinningRetryWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			go func() {
-				startContentID := 0
-				for {
-					var contents []util.Content
-					if err := cm.DB.Limit(cm.cfg.Pinning.RetryWorker.BatchLimit).Order("id ASC").Find(&contents, "pinning and not active and not failed and not aggregate and id > ? and created_at > NOW() + INTERVAL '1 HOURS'", startContentID).Error; err != nil {
-						log.Errorf("failed to get contents for pinning monitor: %s", err)
-						return
-					}
-
-					if len(contents) == 0 {
-						break
-					}
-
-					go cm.pinContents(ctx, contents)
-
-					startContentID = int(contents[len(contents)-1].ID)
+			startContentID := 0
+			for {
+				var contents []util.Content
+				if err := cm.DB.Limit(cm.cfg.Pinning.RetryWorker.BatchLimit).Order("id ASC").Find(&contents, "pinning and not active and not failed and not aggregate and id > ? and created_at > NOW() + INTERVAL '1 HOURS'", startContentID).Error; err != nil {
+					log.Errorf("failed to get contents for pinning monitor: %s", err)
+					return
 				}
-			}()
+
+				if len(contents) == 0 {
+					break
+				}
+
+				go cm.pinContents(ctx, contents)
+
+				startContentID = int(contents[len(contents)-1].ID)
+			}
 		}
 	}
 }

--- a/replication.go
+++ b/replication.go
@@ -428,15 +428,6 @@ func (cm *ContentManager) runDealWorker(ctx context.Context) {
 }
 
 func (cm *ContentManager) Run(ctx context.Context) {
-	// if content adding is enabled, refresh pin queue for local contents
-	if !cm.localContentAddingDisabled {
-		go func() {
-			if err := cm.refreshPinQueue(ctx, constants.ContentLocationLocal); err != nil {
-				log.Errorf("failed to refresh pin queue: %s", err)
-			}
-		}()
-	}
-
 	// if staging buckets are enabled, rebuild the buckets, and run the bucket aggregate worker
 	if cm.cfg.StagingBucket.Enabled {
 		// rebuild the staging buckets


### PR DESCRIPTION
This PR replaces the existing `refreshPinQueue` implementation with a pinning monitor/retry worker. This new approach will not only refresh the pin queue when Estuary is restarted, but it will also handle missing pin requests while it runs.

**How it works**

- It runs every X hour interval (default is 1)
- It selects contents that have been created over 1hr that are still in the `pinning` state. So as not to stress the database; it batches the selection of the contents (default is 1000) to retry 

**Verifications**

- I have verified it picks up only contents that are an hour old that are still in `pinning` state
- I have verified it batches the selections correctly (only picks 1000 per loop until no more contents)
- I have verified contents are picked up and properly queued for re-pinning

