### PR TITLE
Added datecreated to the query at the GET /invites endpoint

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1948,12 +1948,13 @@ type getInvitesResp struct {
 	Code      string `json:"code"`
 	Username  string `json:"createdBy"`
 	ClaimedBy string `json:"claimedBy"`
+	CreatedAt string `json:"createdAt"`
 }
 
 func (s *Server) handleAdminGetInvites(c echo.Context) error {
 	var invites []getInvitesResp
 	if err := s.DB.Model(&util.InviteCode{}).
-		Select("code, username, (?) as claimed_by", s.DB.Table("users").Select("username").Where("id = invite_codes.claimed_by")).
+		Select("code, username, invite_codes.created_at, (?) as claimed_by", s.DB.Table("users").Select("username").Where("id = invite_codes.claimed_by")).
 		//Where("claimed_by IS NULL").
 		Joins("left join users on users.id = invite_codes.created_by").
 		Order("invite_codes.created_at ASC").


### PR DESCRIPTION
Datecreated is now returned when querying GET /invites. Implemented this inorder to show analytics on how many invites are sent out each month on estuary-www.