### PR TITLE
docs: Add content types to pinning endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2098,6 +2098,9 @@ const docTemplate = `{
             },
             "post": {
                 "description": "This endpoint adds a pin to the IPFS daemon.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -2174,6 +2177,9 @@ const docTemplate = `{
             },
             "post": {
                 "description": "This endpoint replaces a pinned object.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2091,6 +2091,9 @@
       },
       "post": {
         "description": "This endpoint adds a pin to the IPFS daemon.",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/json"
         ],
@@ -2167,6 +2170,9 @@
       },
       "post": {
         "description": "This endpoint replaces a pinned object.",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/json"
         ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1551,6 +1551,8 @@ paths:
       tags:
         - pinning
     post:
+      consumes:
+        - application/json
       description: This endpoint adds a pin to the IPFS daemon.
       parameters:
         - description: Pin Body {cid:cid, name:name}
@@ -1621,6 +1623,8 @@ paths:
       tags:
         - pinning
     post:
+      consumes:
+        - application/json
       description: This endpoint replaces a pinned object.
       parameters:
         - description: Pin ID

--- a/pinning.go
+++ b/pinning.go
@@ -630,6 +630,7 @@ func filterForStatusQuery(q *gorm.DB, statuses map[types.PinningStatus]bool) (*g
 // @Summary      Add and pin object
 // @Description  This endpoint adds a pin to the IPFS daemon.
 // @Tags         pinning
+// @Accept		 json
 // @Produce      json
 // @Success      202	{object}  types.IpfsPinStatusResponse
 // @Failure      500    {object}  util.HttpError
@@ -740,6 +741,7 @@ func (s *Server) handleGetPin(e echo.Context, u *util.User) error {
 // @Summary      Replace a pinned object
 // @Description  This endpoint replaces a pinned object.
 // @Tags         pinning
+// @Accept		 json
 // @Produce      json
 // @Success      202	{object}	types.IpfsPinStatusResponse
 // @Failure      404	{object}	util.HttpError


### PR DESCRIPTION
This is necessary because otherwise the `estuary-clients` package won't generate Go code that sets the Content-Type header, which means the server will reject the request.

I've confirmed that this is the final change required to get the Pinning API working using the Go client.