### PR TITLE
feat: add DealUUID to logs

### DIFF
--- a/dbmgr/dbmgr.go
+++ b/dbmgr/dbmgr.go
@@ -732,6 +732,7 @@ type DFERecord struct {
 	gorm.Model
 
 	Miner        string
+	DealUUID     string
 	Phase        string
 	Message      string
 	Content      uint `gorm:"index"`

--- a/replication.go
+++ b/replication.go
@@ -2471,13 +2471,14 @@ func (cm *ContentManager) getProposalRecord(propCid cid.Cid) (*market.ClientDeal
 }
 
 func (cm *ContentManager) recordDealFailure(dfe *DealFailureError) error {
-	log.Debugw("deal failure error", "miner", dfe.Miner, "phase", dfe.Phase, "msg", dfe.Message, "content", dfe.Content)
+	log.Debugw("deal failure error", "miner", dfe.Miner, "uuid", dfe.DealUUID, "phase", dfe.Phase, "msg", dfe.Message, "content", dfe.Content)
 	rec := dfe.Record()
 	return cm.DB.Create(rec).Error
 }
 
 type DealFailureError struct {
 	Miner               address.Address
+	DealUUID            string
 	Phase               string
 	Message             string
 	Content             uint
@@ -2490,6 +2491,7 @@ type DealFailureError struct {
 type dfeRecord struct {
 	gorm.Model
 	Miner               string      `json:"miner"`
+	DealUUID            string      `json:"deal_uuid"`
 	Phase               string      `json:"phase"`
 	Message             string      `json:"message"`
 	Content             uint        `json:"content" gorm:"index"`
@@ -2501,6 +2503,7 @@ type dfeRecord struct {
 func (dfe *DealFailureError) Record() *dfeRecord {
 	return &dfeRecord{
 		Miner:               dfe.Miner.String(),
+		DealUUID:            dfe.DealUUID,
 		Phase:               dfe.Phase,
 		Message:             dfe.Message,
 		Content:             dfe.Content,
@@ -2511,7 +2514,7 @@ func (dfe *DealFailureError) Record() *dfeRecord {
 }
 
 func (dfe *DealFailureError) Error() string {
-	return fmt.Sprintf("deal with miner %s failed in phase %s: %s", dfe.Message, dfe.Phase, dfe.Message)
+	return fmt.Sprintf("deal %s with miner %s failed in phase %s: %s", dfe.DealUUID, dfe.Message, dfe.Phase, dfe.Message)
 }
 
 type PieceCommRecord struct {

--- a/shuttle.go
+++ b/shuttle.go
@@ -362,6 +362,7 @@ func (cm *ContentManager) handleRpcTransferStatus(ctx context.Context, handle st
 			UserID:              cd.UserID,
 			MinerVersion:        cd.MinerVersion,
 			DealProtocolVersion: cd.DealProtocolVersion,
+			DealUUID:            cd.DealUUID,
 		}); oerr != nil {
 			return oerr
 		}


### PR DESCRIPTION
related: https://github.com/application-research/estuary-www/pull/96

Update `replication.go` to log out the Deal UUID in the event of a deal failure