### PR TITLE
Simplify staging zone readiness to size only

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1263,11 +1263,11 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 
 	// if splitting is disabled and uploaded content size is greater than content size limit
 	// reject the upload, as it will only get stuck and deals will never be made for it
-	if !u.FlagSplitContent() && mpf.Size > constants.DefaultContentSizeLimit {
+	if !u.FlagSplitContent() && mpf.Size > constants.MaxDealContentSize {
 		return &util.HttpError{
 			Code:    http.StatusBadRequest,
 			Reason:  util.ERR_CONTENT_SIZE_OVER_LIMIT,
-			Details: fmt.Sprintf("content size %d bytes, is over upload size limit of %d bytes, and content splitting is not enabled, please reduce the content size", mpf.Size, constants.DefaultContentSizeLimit),
+			Details: fmt.Sprintf("content size %d bytes, is over upload size limit of %d bytes, and content splitting is not enabled, please reduce the content size", mpf.Size, constants.MaxDealContentSize),
 		}
 	}
 
@@ -1397,11 +1397,11 @@ func (s *Shuttle) handleAddCar(c echo.Context, u *User) error {
 	// 		return err
 	// 	}
 
-	// 	if bdSize > util.DefaultContentSizeLimit {
+	// 	if bdSize > util.MaxDealContentSize {
 	// 		return &util.HttpError{
 	// 			Code:    http.StatusBadRequest,
 	// 			Reason:  util.ERR_CONTENT_SIZE_OVER_LIMIT,
-	// 			Details: fmt.Sprintf("content size %d bytes, is over upload size of limit %d bytes, and content splitting is not enabled, please reduce the content size", bdSize, util.DefaultContentSizeLimit),
+	// 			Details: fmt.Sprintf("content size %d bytes, is over upload size of limit %d bytes, and content splitting is not enabled, please reduce the content size", bdSize, util.MaxDealContentSize),
 	// 		}
 	// 	}
 

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -96,7 +96,6 @@ func NewEstuary(appVersion string) *Estuary {
 
 		StagingBucket: StagingBucket{
 			Enabled:                 true,
-			MaxItems:                constants.MaxBucketItems,
 			MaxSize:                 constants.MaxStagingZoneSizeLimit,
 			MinSize:                 constants.MinStagingZoneSizeLimit,
 			IndividualDealThreshold: constants.IndividualDealThreshold,

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -95,11 +95,10 @@ func NewEstuary(appVersion string) *Estuary {
 		},
 
 		StagingBucket: StagingBucket{
-			Enabled:                 true,
-			MaxSize:                 constants.MaxStagingZoneSizeLimit,
-			MinSize:                 constants.MinStagingZoneSizeLimit,
-			IndividualDealThreshold: constants.IndividualDealThreshold,
-			AggregateInterval:       time.Minute * 5, // aggregate staging buckets every 5 minutes
+			Enabled:           true,
+			MaxSize:           constants.MaxDealContentSize,
+			MinSize:           constants.MinDealContentSize,
+			AggregateInterval: time.Minute * 5, // aggregate staging buckets every 5 minutes
 		},
 
 		Jaeger: Jaeger{

--- a/config/estuary.go
+++ b/config/estuary.go
@@ -1,13 +1,14 @@
 package config
 
 import (
+	"github.com/application-research/estuary/constants"
+
 	"path/filepath"
 	"time"
 
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 
 	"github.com/application-research/estuary/build"
-	"github.com/application-research/estuary/constants"
 	"github.com/application-research/estuary/node/modules/peering"
 	"github.com/application-research/filclient"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -79,7 +80,7 @@ func NewEstuary(appVersion string) *Estuary {
 			IsDisabled:            false,
 			FailOnTransferFailure: false,
 			IsVerified:            true,
-			Duration:              abi.ChainEpoch(1555200 - (2880 * 21)), // Making default deal duration be three weeks less than the maximum to ensure miners who start their deals early dont run into issues
+			Duration:              abi.ChainEpoch(constants.DealDuration), // Making default deal duration be three weeks less than the maximum to ensure miners who start their deals early dont run into issues
 			EnabledDealProtocolsVersions: map[protocol.ID]bool{
 				filclient.DealProtocolv110: true,
 				filclient.DealProtocolv120: true,
@@ -95,15 +96,11 @@ func NewEstuary(appVersion string) *Estuary {
 
 		StagingBucket: StagingBucket{
 			Enabled:                 true,
-			MaxLifeTime:             time.Hour * 8,
-			MaxContentAge:           time.Hour * 24 * 7,
-			MaxItems:                10000,
-			MaxSize:                 int64((abi.PaddedPieceSize(16<<30).Unpadded() * 9) / 10),                // 14.29 Gib
-			MinSize:                 int64(int64((abi.PaddedPieceSize(16<<30).Unpadded()*9)/10) - (1 << 30)), // 13.29 GiB
-			KeepAlive:               time.Minute * 40,
-			MinDealSize:             256 << 20,                                               //0.25 Gib
-			IndividualDealThreshold: int64((abi.PaddedPieceSize(4<<30).Unpadded() * 9) / 10), // 90% of the unpadded data size for a 4GB piece, the 10% gap is to accommodate car file packing overhead, can probably do this better
-			AggregateInterval:       time.Minute * 5,                                         // aggregate staging buckets every 5 minutes
+			MaxItems:                constants.MaxBucketItems,
+			MaxSize:                 constants.MaxStagingZoneSizeLimit,
+			MinSize:                 constants.MinStagingZoneSizeLimit,
+			IndividualDealThreshold: constants.IndividualDealThreshold,
+			AggregateInterval:       time.Minute * 5, // aggregate staging buckets every 5 minutes
 		},
 
 		Jaeger: Jaeger{

--- a/config/staging_bucket.go
+++ b/config/staging_bucket.go
@@ -4,13 +4,11 @@ import "time"
 
 // MinSize - minimum staging bucket size before it can be aggregated
 // MaxSize - maximum staging bucket size before it can be aggregated
-// MaxItems - max number of items a bucket can hold before it is aggregated
 // AggregateInterval - interval to aggregate staging contents
 type StagingBucket struct {
 	Enabled                 bool          `json:"enabled"`
 	MinSize                 int64         `json:"min_size"`
 	MaxSize                 int64         `json:"max_size"`
 	IndividualDealThreshold int64         `json:"individual_deal_threshold"`
-	MaxItems                int           `json:"max_items"`
 	AggregateInterval       time.Duration `json:"aggregate_interval"`
 }

--- a/config/staging_bucket.go
+++ b/config/staging_bucket.go
@@ -2,23 +2,15 @@ package config
 
 import "time"
 
-// MaxLifeTime - amount of time a staging zone will remain open before we aggregate it into a piece of content
-// MaxContentAge - maximum amount of time a piece of content will go without either being aggregated or having a deal made for it
 // MinSize - minimum staging bucket size before it can be aggregated
 // MaxSize - maximum staging bucket size before it can be aggregated
-// KeepAlive - staging zones will remain open for at least this long after the last piece of content is added to them (unless they are full)
 // MaxItems - max number of items a bucket can hold before it is aggregated
-// MinDealSize - minimum deal size that bucket must meet before it is ever considered for aggregation
 // AggregateInterval - interval to aggregate staging contents
 type StagingBucket struct {
 	Enabled                 bool          `json:"enabled"`
 	MinSize                 int64         `json:"min_size"`
 	MaxSize                 int64         `json:"max_size"`
-	MinDealSize             int64         `json:"min_deal_size"`
 	IndividualDealThreshold int64         `json:"individual_deal_threshold"`
 	MaxItems                int           `json:"max_items"`
-	MaxContentAge           time.Duration `json:"max_content_age"`
-	KeepAlive               time.Duration `json:"keep_alive"`
-	MaxLifeTime             time.Duration `json:"max_life_time"`
 	AggregateInterval       time.Duration `json:"aggregate_interval"`
 }

--- a/config/staging_bucket.go
+++ b/config/staging_bucket.go
@@ -6,9 +6,8 @@ import "time"
 // MaxSize - maximum staging bucket size before it can be aggregated
 // AggregateInterval - interval to aggregate staging contents
 type StagingBucket struct {
-	Enabled                 bool          `json:"enabled"`
-	MinSize                 int64         `json:"min_size"`
-	MaxSize                 int64         `json:"max_size"`
-	IndividualDealThreshold int64         `json:"individual_deal_threshold"`
-	AggregateInterval       time.Duration `json:"aggregate_interval"`
+	Enabled           bool          `json:"enabled"`
+	MinSize           int64         `json:"min_size"`
+	MaxSize           int64         `json:"max_size"`
+	AggregateInterval time.Duration `json:"aggregate_interval"`
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -18,15 +18,16 @@ const MaxBucketItems = 10000
 // miners who start their deals early don't run into issues
 const DealDuration = 1555200 - (2880 * 21)
 
-// IndividualDealThreshold 90% of the un-padded data size for a 4GB piece
+// IndividualDealThreshold 3.6 GB
+// 90% of the un-padded data size for a 4GB piece
 // the 10% gap is to accommodate car file packing overhead, can probably do this better
-var IndividualDealThreshold = int64(abi.PaddedPieceSize(4<<30).Unpadded() * 9 / 10)
+var IndividualDealThreshold = int64((4 << 30) * 9 / 10)
 
-// MaxStagingZoneSizeLimit 14.29 GB
-var MaxStagingZoneSizeLimit = int64(abi.PaddedPieceSize(16<<30).Unpadded() * 9 / 10)
+// MaxStagingZoneSizeLimit 14.4 GB
+var MaxStagingZoneSizeLimit = int64((16 << 30) * 9 / 10)
 
-// MinStagingZoneSizeLimit 1.81 GB
-var MinStagingZoneSizeLimit = int64(abi.PaddedPieceSize(2<<30).Unpadded() * 9 / 10)
+// MinStagingZoneSizeLimit 3.6 GB
+var MinStagingZoneSizeLimit = int64((4 << 30) * 9 / 10)
 
 const TokenExpiryDurationAdmin = time.Hour * 24 * 365           // 1 year
 const TokenExpiryDurationRegister = time.Hour * 24 * 7          // 1 week

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-const DefaultContentSizeLimit = 34_000_000_000
+const DefaultContentSizeLimit = int64(34_000_000_000)
 const ContentLocationLocal = "local"
 const TopMinerSel = 15
 const MinSafeDealLifetime = 2880 * 21 // three weeks
@@ -24,10 +24,10 @@ const DealDuration = 1555200 - (2880 * 21)
 var IndividualDealThreshold = int64((4 << 30) * 9 / 10)
 
 // MaxStagingZoneSizeLimit 14.4 GB
-var MaxStagingZoneSizeLimit = int64((16 << 30) * 9 / 10)
+var MaxStagingZoneSizeLimit = DefaultContentSizeLimit
 
 // MinStagingZoneSizeLimit 3.6 GB
-var MinStagingZoneSizeLimit = int64((4 << 30) * 9 / 10)
+var MinStagingZoneSizeLimit = IndividualDealThreshold
 
 const TokenExpiryDurationAdmin = time.Hour * 24 * 365           // 1 year
 const TokenExpiryDurationRegister = time.Hour * 24 * 7          // 1 week

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -22,11 +22,11 @@ const DealDuration = 1555200 - (2880 * 21)
 // the 10% gap is to accommodate car file packing overhead, can probably do this better
 var IndividualDealThreshold = int64(abi.PaddedPieceSize(4<<30).Unpadded() * 9 / 10)
 
-// MaxStagingZoneSizeLimit 14.29 Gib
+// MaxStagingZoneSizeLimit 14.29 GB
 var MaxStagingZoneSizeLimit = int64(abi.PaddedPieceSize(16<<30).Unpadded() * 9 / 10)
 
-// MinStagingZoneSizeLimit 13.29 GiB
-var MinStagingZoneSizeLimit = MaxStagingZoneSizeLimit - 1<<30
+// MinStagingZoneSizeLimit 1.81 GB
+var MinStagingZoneSizeLimit = int64(abi.PaddedPieceSize(2<<30).Unpadded() * 9 / 10)
 
 const TokenExpiryDurationAdmin = time.Hour * 24 * 365           // 1 year
 const TokenExpiryDurationRegister = time.Hour * 24 * 7          // 1 week

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-const DefaultContentSizeLimit = int64(34_000_000_000)
 const ContentLocationLocal = "local"
 const TopMinerSel = 15
 const MinSafeDealLifetime = 2880 * 21 // three weeks
@@ -16,16 +15,13 @@ const MinSafeDealLifetime = 2880 * 21 // three weeks
 // miners who start their deals early don't run into issues
 const DealDuration = 1555200 - (2880 * 21)
 
-// IndividualDealThreshold 3.6 GB
+// MinDealContentSize 3.6 GB
 // 90% of the un-padded data size for a 4GB piece
 // the 10% gap is to accommodate car file packing overhead, can probably do this better
-var IndividualDealThreshold = int64((4 << 30) * 9 / 10)
+const MinDealContentSize = int64((4 << 30) * 9 / 10)
 
-// MaxStagingZoneSizeLimit 34 GB
-var MaxStagingZoneSizeLimit = DefaultContentSizeLimit
-
-// MinStagingZoneSizeLimit 3.6 GB
-var MinStagingZoneSizeLimit = IndividualDealThreshold
+// MaxDealContentSize 31.66 GB
+const MaxDealContentSize = int64(34_000_000_000)
 
 const TokenExpiryDurationAdmin = time.Hour * 24 * 365           // 1 year
 const TokenExpiryDurationRegister = time.Hour * 24 * 7          // 1 week

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -10,35 +10,23 @@ import (
 const DefaultContentSizeLimit = 34_000_000_000
 const ContentLocationLocal = "local"
 const TopMinerSel = 15
-const BucketingEnabled = true
 const MinSafeDealLifetime = 2880 * 21 // three weeks
-
-// amount of time a staging zone will remain open before we aggregate it into a piece of content
-const MaxStagingZoneLifetime = time.Hour * 8
-
-// maximum amount of time a piece of content will go without either being aggregated or having a deal made for it
-const MaxContentAge = time.Hour * 24 * 7
-
-// staging zones will remain open for at least this long after the last piece of content is added to them (unless they are full)
-const StagingZoneKeepAlive = time.Minute * 40
-
-const MinDealSize = 256 << 20
 
 const MaxBucketItems = 10000
 
-// Making default deal duration be three weeks less than the maximum to ensure
-// miners who start their deals early dont run into issues
+// DealDuration Making default deal duration be three weeks less than the maximum to ensure
+// miners who start their deals early don't run into issues
 const DealDuration = 1555200 - (2880 * 21)
 
-// 90% of the unpadded data size for a 4GB piece
+// IndividualDealThreshold 90% of the un-padded data size for a 4GB piece
 // the 10% gap is to accommodate car file packing overhead, can probably do this better
-var IndividualDealThreshold = (abi.PaddedPieceSize(4<<30).Unpadded() * 9) / 10
+var IndividualDealThreshold = int64(abi.PaddedPieceSize(4<<30).Unpadded() * 9 / 10)
 
-// 14.29 Gib
-var MaxStagingZoneSizeLimit = int64((abi.PaddedPieceSize(16<<30).Unpadded() * 9) / 10)
+// MaxStagingZoneSizeLimit 14.29 Gib
+var MaxStagingZoneSizeLimit = int64(abi.PaddedPieceSize(16<<30).Unpadded() * 9 / 10)
 
-// 13.29 GiB
-var MinStagingZoneSizeLimit = int64(MaxStagingZoneSizeLimit - (1 << 30))
+// MinStagingZoneSizeLimit 13.29 GiB
+var MinStagingZoneSizeLimit = MaxStagingZoneSizeLimit - 1<<30
 
 const TokenExpiryDurationAdmin = time.Hour * 24 * 365           // 1 year
 const TokenExpiryDurationRegister = time.Hour * 24 * 7          // 1 week

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -23,7 +23,7 @@ const DealDuration = 1555200 - (2880 * 21)
 // the 10% gap is to accommodate car file packing overhead, can probably do this better
 var IndividualDealThreshold = int64((4 << 30) * 9 / 10)
 
-// MaxStagingZoneSizeLimit 14.4 GB
+// MaxStagingZoneSizeLimit 34 GB
 var MaxStagingZoneSizeLimit = DefaultContentSizeLimit
 
 // MinStagingZoneSizeLimit 3.6 GB

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -12,8 +12,6 @@ const ContentLocationLocal = "local"
 const TopMinerSel = 15
 const MinSafeDealLifetime = 2880 * 21 // three weeks
 
-const MaxBucketItems = 10000
-
 // DealDuration Making default deal duration be three weeks less than the maximum to ensure
 // miners who start their deals early don't run into issues
 const DealDuration = 1555200 - (2880 * 21)

--- a/handlers.go
+++ b/handlers.go
@@ -869,17 +869,6 @@ func (s *Server) handleAdd(c echo.Context, u *util.User) error {
 		return err
 	}
 
-	// if upload size is smaller than (min deal size / staging bucket file count limit)
-	// reject the upload, to guarantee that all staging buckets will reach a viable dealmaking size
-	contentSizeMinimum := s.cfg.StagingBucket.MinSize / int64(s.cfg.StagingBucket.MaxItems)
-	if mpf.Size < contentSizeMinimum {
-		return &util.HttpError{
-			Code:    http.StatusBadRequest,
-			Reason:  util.ERR_CONTENT_SIZE_UNDER_MINIMUM,
-			Details: fmt.Sprintf("content size %d bytes, is under upload size minimum of %d bytes", mpf.Size, contentSizeMinimum),
-		}
-	}
-
 	// if splitting is disabled and uploaded content size is greater than content size limit
 	// reject the upload, as it will only get stuck and deals will never be made for it
 	if !u.FlagSplitContent() && mpf.Size > s.CM.contentSizeLimit {
@@ -4594,6 +4583,11 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 		return err
 	}
 
+	var exch exchange.Interface
+	if c.QueryParam("fetch") != "" {
+		exch = s.Node.Bitswap
+	}
+
 	var u util.User
 	if err := s.DB.First(&u, "id = ?", cont.UserID).Error; err != nil {
 		return err
@@ -4613,7 +4607,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 			return err
 		}
 
-		nd, err := s.CM.createAggregate(ctx, children)
+		nd, err := s.CM.createAggregate(ctx, s.Node.Blockstore, exch, children)
 		if err != nil {
 			return fmt.Errorf("failed to create aggregate: %w", err)
 		}
@@ -4659,7 +4653,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 			return err
 		}
 
-		nd, err := s.CM.createAggregate(ctx, children)
+		nd, err := s.CM.createAggregate(ctx, s.Node.Blockstore, exch, children)
 		if err != nil {
 			return fmt.Errorf("failed to create aggregate: %w", err)
 		}
@@ -4700,7 +4694,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 					ids = append(ids, c.ID)
 				}
 
-				dir, err := s.CM.createAggregate(ctx, aggr)
+				dir, err := s.CM.createAggregate(ctx, s.Node.Blockstore, exch, aggr)
 				if err != nil {
 					return err
 				}
@@ -4715,11 +4709,6 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 			// well that sucks
 			log.Warnf("content %d has messed up aggregation", cont.ID)
 		}
-	}
-
-	var exch exchange.Interface
-	if c.QueryParam("fetch") != "" {
-		exch = s.Node.Bitswap
 	}
 
 	bserv := blockservice.New(s.Node.Blockstore, exch)

--- a/handlers.go
+++ b/handlers.go
@@ -4583,11 +4583,6 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 		return err
 	}
 
-	var exch exchange.Interface
-	if c.QueryParam("fetch") != "" {
-		exch = s.Node.Bitswap
-	}
-
 	var u util.User
 	if err := s.DB.First(&u, "id = ?", cont.UserID).Error; err != nil {
 		return err
@@ -4607,7 +4602,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 			return err
 		}
 
-		nd, err := s.CM.createAggregate(ctx, s.Node.Blockstore, exch, children)
+		nd, err := s.CM.createAggregate(ctx, children)
 		if err != nil {
 			return fmt.Errorf("failed to create aggregate: %w", err)
 		}
@@ -4653,7 +4648,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 			return err
 		}
 
-		nd, err := s.CM.createAggregate(ctx, s.Node.Blockstore, exch, children)
+		nd, err := s.CM.createAggregate(ctx, children)
 		if err != nil {
 			return fmt.Errorf("failed to create aggregate: %w", err)
 		}
@@ -4694,7 +4689,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 					ids = append(ids, c.ID)
 				}
 
-				dir, err := s.CM.createAggregate(ctx, s.Node.Blockstore, exch, aggr)
+				dir, err := s.CM.createAggregate(ctx, aggr)
 				if err != nil {
 					return err
 				}
@@ -4709,6 +4704,11 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 			// well that sucks
 			log.Warnf("content %d has messed up aggregation", cont.ID)
 		}
+	}
+
+	var exch exchange.Interface
+	if c.QueryParam("fetch") != "" {
+		exch = s.Node.Bitswap
 	}
 
 	bserv := blockservice.New(s.Node.Blockstore, exch)

--- a/handlers.go
+++ b/handlers.go
@@ -742,11 +742,11 @@ func (s *Server) handleAddCar(c echo.Context, u *util.User) error {
 	// 		return err
 	// 	}
 
-	// 	if bdSize > util.DefaultContentSizeLimit {
+	// 	if bdSize > util.MaxDealContentSize {
 	// 		return &util.HttpError{
 	// 			Code:    http.StatusBadRequest,
 	// 			Reason:  util.ERR_CONTENT_SIZE_OVER_LIMIT,
-	// 			Details: fmt.Sprintf("content size %d bytes, is over upload size of limit %d bytes, and content splitting is not enabled, please reduce the content size", bdSize, util.DefaultContentSizeLimit),
+	// 			Details: fmt.Sprintf("content size %d bytes, is over upload size of limit %d bytes, and content splitting is not enabled, please reduce the content size", bdSize, util.MaxDealContentSize),
 	// 		}
 	// 	}
 
@@ -3383,7 +3383,7 @@ func (s *Server) handleGetViewer(c echo.Context, u *util.User) error {
 			Replication:           s.CM.Replication,
 			Verified:              s.cfg.Deal.IsVerified,
 			DealDuration:          s.cfg.Deal.Duration,
-			FileStagingThreshold:  s.cfg.StagingBucket.IndividualDealThreshold,
+			FileStagingThreshold:  s.cfg.StagingBucket.MinSize,
 			ContentAddingDisabled: s.isContentAddingDisabled(u),
 			DealMakingDisabled:    s.CM.dealMakingDisabled(),
 			UploadEndpoints:       uep,

--- a/replication.go
+++ b/replication.go
@@ -296,7 +296,7 @@ func NewContentManager(db *gorm.DB, api api.Gateway, fc *filclient.FilClient, tb
 		pinMgr:                       pinmgr,
 		remoteTransferStatus:         cache,
 		shuttles:                     make(map[string]*ShuttleConnection),
-		contentSizeLimit:             constants.DefaultContentSizeLimit,
+		contentSizeLimit:             constants.MaxDealContentSize,
 		hostname:                     cfg.Hostname,
 		inflightCids:                 make(map[cid.Cid]uint),
 		FailDealOnTransferFailure:    cfg.Deal.FailOnTransferFailure,
@@ -1486,7 +1486,7 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content util.Conten
 }
 
 func (cm *ContentManager) canStageContent(cont util.Content) bool {
-	return cont.Size < cm.cfg.StagingBucket.IndividualDealThreshold && cm.cfg.StagingBucket.Enabled
+	return cont.Size < cm.cfg.StagingBucket.MinSize && cm.cfg.StagingBucket.Enabled
 }
 
 func (cm *ContentManager) splitContent(ctx context.Context, cont util.Content, size int64) error {
@@ -2021,8 +2021,8 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content util.
 	))
 	defer span.End()
 
-	if content.Size < constants.IndividualDealThreshold {
-		return fmt.Errorf("content %d below individual deal size threshold. (size: %d, threshold: %d)", content.ID, content.Size, constants.IndividualDealThreshold)
+	if content.Size < constants.MinDealContentSize {
+		return fmt.Errorf("content %d below individual deal size threshold. (size: %d, threshold: %d)", content.ID, content.Size, constants.MinDealContentSize)
 	}
 
 	if content.Offloaded {

--- a/replication.go
+++ b/replication.go
@@ -2017,7 +2017,7 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content util.
 	))
 	defer span.End()
 
-	if content.Size < constants.MinStagingZoneSizeLimit {
+	if content.Size < constants.IndividualDealThreshold {
 		return fmt.Errorf("content %d too small to make deals for. (size: %d)", content.ID, content.Size)
 	}
 

--- a/replication.go
+++ b/replication.go
@@ -152,9 +152,6 @@ type stagingZoneReadiness struct {
 type contentStagingZone struct {
 	ZoneOpened time.Time `json:"zoneOpened"`
 
-	EarliestContent time.Time `json:"earliestContent"`
-	CloseTime       time.Time `json:"closeTime"`
-
 	Contents []util.Content `json:"contents"`
 
 	MinSize int64 `json:"minSize"`
@@ -169,9 +166,6 @@ type contentStagingZone struct {
 	ContID   uint   `json:"contentID"`
 	Location string `json:"location"`
 
-	MaxContentAge time.Duration `json:"max_content_age"`
-	MinDealSize   int64         `json:"min_deal_size"`
-
 	IsConsolidating bool `json:"is_consolidating"`
 
 	Readiness stagingZoneReadiness `json:"readiness"`
@@ -183,20 +177,16 @@ func (cb *contentStagingZone) DeepCopy() *contentStagingZone {
 	cb.lk.Lock()
 	defer cb.lk.Unlock()
 	cb2 := &contentStagingZone{
-		ZoneOpened:      cb.ZoneOpened,
-		EarliestContent: cb.EarliestContent,
-		CloseTime:       cb.CloseTime,
-		Contents:        make([]util.Content, len(cb.Contents)),
-		MinSize:         cb.MinSize,
-		MaxSize:         cb.MaxSize,
-		MaxItems:        cb.MaxItems,
-		CurSize:         cb.CurSize,
-		User:            cb.User,
-		ContID:          cb.ContID,
-		Location:        cb.Location,
-		MaxContentAge:   cb.MaxContentAge,
-		MinDealSize:     cb.MinSize,
-		Readiness:       cb.Readiness,
+		ZoneOpened: cb.ZoneOpened,
+		Contents:   make([]util.Content, len(cb.Contents)),
+		MinSize:    cb.MinSize,
+		MaxSize:    cb.MaxSize,
+		MaxItems:   cb.MaxItems,
+		CurSize:    cb.CurSize,
+		User:       cb.User,
+		ContID:     cb.ContID,
+		Location:   cb.Location,
+		Readiness:  cb.Readiness,
 	}
 	copy(cb2.Contents, cb.Contents)
 	return cb2
@@ -219,71 +209,33 @@ func (cm *ContentManager) newContentStagingZone(user uint, loc string) (*content
 	}
 
 	return &contentStagingZone{
-		MinDealSize:   cm.cfg.StagingBucket.MinDealSize,
-		MaxContentAge: cm.cfg.StagingBucket.MaxContentAge,
-		ZoneOpened:    time.Now(),
-		CloseTime:     time.Now().Add(cm.cfg.StagingBucket.MaxLifeTime),
-		MinSize:       cm.cfg.StagingBucket.MinSize,
-		MaxSize:       cm.cfg.StagingBucket.MaxSize,
-		MaxItems:      cm.cfg.StagingBucket.MaxItems,
-		User:          user,
-		ContID:        content.ID,
-		Location:      content.Location,
-		Readiness:     stagingZoneReadiness{false, "Readiness not yet evaluated"},
+		ZoneOpened: time.Now(),
+		MinSize:    cm.cfg.StagingBucket.MinSize,
+		MaxSize:    cm.cfg.StagingBucket.MaxSize,
+		MaxItems:   cm.cfg.StagingBucket.MaxItems,
+		User:       user,
+		ContID:     content.ID,
+		Location:   content.Location,
+		Readiness:  stagingZoneReadiness{false, "Readiness not yet evaluated"},
 	}, nil
 }
 
 func (cb *contentStagingZone) updateReadiness() {
-	if cb.CurSize < cb.MinDealSize {
-		cb.Readiness.IsReady = false
-		cb.Readiness.ReadinessReason = fmt.Sprintf(
-			"Current deal size of %d bytes is below minimum deal size of %d bytes",
-			cb.CurSize,
-			cb.MinDealSize)
-		return
-	}
-
-	// if its above the size requirement, go right ahead
+	// if it's above the size requirement, go right ahead
 	if cb.CurSize > cb.MinSize {
 		cb.Readiness.IsReady = true
 		cb.Readiness.ReadinessReason = fmt.Sprintf(
-			"Current deal size of %d bytes is above minimum size of %d bytes",
+			"Current deal size of %d bytes is above minimum size requirement of %d bytes",
 			cb.CurSize,
 			cb.MinSize)
 		return
 	}
 
-	if time.Now().After(cb.CloseTime) {
-		cb.Readiness.IsReady = true
-		cb.Readiness.ReadinessReason = "Staging zone's closing time has passed"
-		return
-	}
-
-	if time.Since(cb.EarliestContent) > cb.MaxContentAge {
-		cb.Readiness.IsReady = true
-		cb.Readiness.ReadinessReason = "The earliest content in the staging zone has reached the max content age"
-		return
-	}
-
-	// if its above the items count requirement, go right ahead
-	if len(cb.Contents) >= cb.MaxItems {
-		cb.Readiness.IsReady = true
-		cb.Readiness.ReadinessReason = fmt.Sprintf(
-			"The item count is %d, which is above the threshold of %d to trigger dealmaking",
-			len(cb.Contents),
-			cb.MaxItems)
-		return
-	}
 	cb.Readiness.IsReady = false
 	cb.Readiness.ReadinessReason = fmt.Sprintf(
-		"At least one of the following conditions must be met:\n"+
-			" - Minimum size requirement (current: %d bytes, minimum: %d bytes)\n"+
-			" - Pass staging zone's closing time\n"+
-			" - Item count (current: %d, minimum: %d)",
+		"Minimum size requirement not met (current: %d bytes, minimum: %d bytes)\n",
 		cb.CurSize,
-		cb.MinSize,
-		len(cb.Contents),
-		cb.MaxItems)
+		cb.MinSize)
 }
 
 func (cm *ContentManager) tryAddContent(cb *contentStagingZone, c util.Content) (bool, error) {
@@ -292,15 +244,15 @@ func (cm *ContentManager) tryAddContent(cb *contentStagingZone, c util.Content) 
 
 	// if this bucket is being consolidated, do not add anymore content
 	if cb.IsConsolidating {
-		return false, nil
+		return false, errors.New("cannot add content while bucket is consolidating")
 	}
 
 	if cb.CurSize+c.Size > cb.MaxSize {
-		return false, nil
+		return false, errors.Errorf("cannot add content because resulting size would exceed max bucket size of %d bytes", cb.MaxSize)
 	}
 
 	if len(cb.Contents) >= cb.MaxItems {
-		return false, nil
+		return false, errors.Errorf("cannot add content because resulting number of items would exceed max bucket limit of %d items", cb.MaxItems)
 	}
 
 	if err := cm.DB.Model(util.Content{}).
@@ -309,17 +261,9 @@ func (cm *ContentManager) tryAddContent(cb *contentStagingZone, c util.Content) 
 		return false, err
 	}
 
-	if len(cb.Contents) == 0 || c.CreatedAt.Before(cb.EarliestContent) {
-		cb.EarliestContent = c.CreatedAt
-	}
-
 	cb.Contents = append(cb.Contents, c)
 	cb.CurSize += c.Size
 
-	nowPlus := time.Now().Add(cm.cfg.StagingBucket.KeepAlive)
-	if cb.CloseTime.Before(nowPlus) {
-		cb.CloseTime = nowPlus
-	}
 	return true, nil
 }
 
@@ -775,21 +719,13 @@ func (cm *ContentManager) rebuildStagingBuckets() error {
 	zones := make(map[uint][]*contentStagingZone)
 	for _, c := range stages {
 		z := &contentStagingZone{
-			MinDealSize:   cm.cfg.StagingBucket.MinDealSize,
-			MaxContentAge: cm.cfg.StagingBucket.MaxContentAge,
-			ZoneOpened:    c.CreatedAt,
-			CloseTime:     c.CreatedAt.Add(cm.cfg.StagingBucket.MaxLifeTime),
-			MinSize:       cm.cfg.StagingBucket.MinSize,
-			MaxSize:       cm.cfg.StagingBucket.MaxSize,
-			MaxItems:      cm.cfg.StagingBucket.MaxItems,
-			User:          c.UserID,
-			ContID:        c.ID,
-			Location:      c.Location,
-		}
-
-		minClose := time.Now().Add(cm.cfg.StagingBucket.KeepAlive)
-		if z.CloseTime.Before(minClose) {
-			z.CloseTime = minClose
+			ZoneOpened: c.CreatedAt,
+			MinSize:    cm.cfg.StagingBucket.MinSize,
+			MaxSize:    cm.cfg.StagingBucket.MaxSize,
+			MaxItems:   cm.cfg.StagingBucket.MaxItems,
+			User:       c.UserID,
+			ContID:     c.ID,
+			Location:   c.Location,
 		}
 
 		var inZones []util.Content
@@ -1229,6 +1165,7 @@ func (cm *ContentManager) getStagingZonesForUser(ctx context.Context, user uint)
 	cm.bucketLk.Lock()
 	defer cm.bucketLk.Unlock()
 
+	// TODO: persist staging zones
 	blist, ok := cm.buckets[user]
 	if !ok {
 		return []*contentStagingZone{}
@@ -2080,7 +2017,7 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content util.
 	))
 	defer span.End()
 
-	if content.Size < (256 << 10) {
+	if content.Size < constants.MinStagingZoneSizeLimit {
 		return fmt.Errorf("content %d too small to make deals for. (size: %d)", content.ID, content.Size)
 	}
 
@@ -2180,7 +2117,7 @@ func (cm *ContentManager) makeDealsForContent(ctx context.Context, content util.
 				DealProtocolVersion: m.dealProtocolVersion,
 				MinerVersion:        m.ask.MinerVersion,
 			}); err != nil {
-				log.Errorw("failed to record deail failure", "error", err)
+				log.Errorw("failed to record deal failure", "error", err)
 			}
 			continue
 		}

--- a/util/http.go
+++ b/util/http.go
@@ -36,6 +36,7 @@ const (
 	ERR_CONTENT_ADDING_DISABLED    = "ERR_CONTENT_ADDING_DISABLED"
 	ERR_INVALID_INPUT              = "ERR_INVALID_INPUT"
 	ERR_CONTENT_SIZE_OVER_LIMIT    = "ERR_CONTENT_SIZE_OVER_LIMIT"
+	ERR_CONTENT_SIZE_UNDER_MINIMUM = "ERR_CONTENT_SIZE_UNDER_MINIMUM"
 	ERR_PEERING_PEERS_ADD_ERROR    = "ERR_PEERING_PEERS_ADD_ERROR"
 	ERR_PEERING_PEERS_REMOVE_ERROR = "ERR_PEERING_PEERS_REMOVE_ERROR"
 	ERR_PEERING_PEERS_START_ERROR  = "ERR_PEERING_PEERS_START_ERROR"
@@ -136,7 +137,6 @@ type UserSettings struct {
 	Replication           int            `json:"replication"`
 	Verified              bool           `json:"verified"`
 	DealDuration          abi.ChainEpoch `json:"dealDuration"`
-	MaxStagingWait        time.Duration  `json:"maxStagingWait"`
 	FileStagingThreshold  int64          `json:"fileStagingThreshold"`
 	ContentAddingDisabled bool           `json:"contentAddingDisabled"`
 	DealMakingDisabled    bool           `json:"dealMakingDisabled"`

--- a/util/http.go
+++ b/util/http.go
@@ -36,7 +36,6 @@ const (
 	ERR_CONTENT_ADDING_DISABLED    = "ERR_CONTENT_ADDING_DISABLED"
 	ERR_INVALID_INPUT              = "ERR_INVALID_INPUT"
 	ERR_CONTENT_SIZE_OVER_LIMIT    = "ERR_CONTENT_SIZE_OVER_LIMIT"
-	ERR_CONTENT_SIZE_UNDER_MINIMUM = "ERR_CONTENT_SIZE_UNDER_MINIMUM"
 	ERR_PEERING_PEERS_ADD_ERROR    = "ERR_PEERING_PEERS_ADD_ERROR"
 	ERR_PEERING_PEERS_REMOVE_ERROR = "ERR_PEERING_PEERS_REMOVE_ERROR"
 	ERR_PEERING_PEERS_START_ERROR  = "ERR_PEERING_PEERS_START_ERROR"
@@ -52,7 +51,7 @@ const (
 
 const (
 	ERR_AUTH_MISSING_DETAILS        = "no api key was specified"
-	ERR_AUTH_MISSING_BEARER_DETAILS = "Unsupported authorization scheme: Bearer is a required prefix. The Authorization HTTP Header should be in the format \"Authorization: Bearer ESTxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxARY\"."  //#nosec G101 -- This is a false positive and example API KEY
+	ERR_AUTH_MISSING_BEARER_DETAILS = "Unsupported authorization scheme: Bearer is a required prefix. The Authorization HTTP Header should be in the format \"Authorization: Bearer ESTxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxARY\"."                                                   //#nosec G101 -- This is a false positive and example API KEY
 	ERR_INVALID_AUTH_DETAILS        = "Invalid Auth: An Invalid API Key was specified. The Authorization HTTP Header should be in the format \"Authorization: Bearer ESTxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxARY\". You have the Bearer prefix but your API Key is empty or missing." //#nosec G101 -- This is a false positive and example API KEY
 )
 


### PR DESCRIPTION
1. Prevents a situation where we attempt to make deals with too small of content by adding a per-file size minimum
2. Simplifies staging zone readiness to: is it big enough?
3. Staging zones live indefinitely until they become ready
4. Changes accepted staging zone sizes from 13.4GB - 14.4GB to 3.6GB - 14.4GB

We definitely will need to move staging buckets into persisted storage to avoid bucket accumulation. This may be a blocker for this change to go through, but keeping this PR open to track + for discussion on the proposal.

I revisited the tuning of minStagingZoneSizeLimit and maxStagingZoneSizeLimit. It seemed like a fairly tight range that would be hard to hit (13.4GB-14.4GB). IMO the range should correlate to the typical piece size range an SP would accept. From some brief slack searching, it seems like 32GiB should be our absolute max, and some common min piece sizes are 16GB, 1GB, and 256 bytes. I settled on 3.6GB since it will yield consistent deal sizes by matching the individual deal threshold (also 3.6GB), and it strikes a balance between usable in FE but not irrelevantly small for SPs. This way, SPs should see deals from estuary consistently in the range of 3.6GB-14.4GB, likely skewed towards 3.6GB.

Associated FE PR since some metadata that is rendered in FE is removed by this PR: https://github.com/application-research/estuary-www/pull/97