### PR TITLE
docs: Correct response type for AddCar API.

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -921,7 +921,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/util.ContentAddResponse"
                         }
                     },
                     "400": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -914,7 +914,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/util.ContentAddResponse"
             }
           },
           "400": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -803,7 +803,7 @@ paths:
         "200":
           description: OK
           schema:
-            type: string
+            $ref: '#/definitions/util.ContentAddResponse'
         "400":
           description: Bad Request
           schema:

--- a/handlers.go
+++ b/handlers.go
@@ -714,7 +714,7 @@ func (s *Server) handleAddIpfs(c echo.Context, u *util.User) error {
 // @Description  This endpoint is used to add a car object to the network. The object can be a file or a directory.
 // @Tags         content
 // @Produce      json
-// @Success      200           {object}  string
+// @Success      200           {object}  util.ContentAddResponse
 // @Failure      400           {object}  util.HttpError
 // @Failure      500           {object}  util.HttpError
 // @Param        body          body      string  true   "Car"


### PR DESCRIPTION
Without this, the `estuary-clients` don't understand how to parse the response from the Add CAR API, so that API doesn't work.