### PR TITLE
Add put / get endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2033,6 +2033,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/get/{cid}": {
+            "get": {
+                "description": "This endpoint returns the content associated with a CID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "public"
+                ],
+                "summary": "Get Full Content by Cid",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cid",
+                        "name": "cid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "307": {
+                        "description": "Temporary Redirect",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/util.HttpError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/util.HttpError"
+                        }
+                    }
+                }
+            }
+        },
         "/net/addrs": {
             "get": {
                 "description": "This endpoint is used to get net addrs",
@@ -2283,7 +2324,7 @@ const docTemplate = `{
         },
         "/public/by-cid/{cid}": {
             "get": {
-                "description": "This endpoint returns the content associated with a CID",
+                "description": "This endpoint returns the content record associated with a CID",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2026,6 +2026,47 @@
         }
       }
     },
+    "/get/{cid}": {
+      "get": {
+        "description": "This endpoint returns the content associated with a CID",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "public"
+        ],
+        "summary": "Get Full Content by Cid",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Cid",
+            "name": "cid",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Temporary Redirect",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/util.HttpError"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/util.HttpError"
+            }
+          }
+        }
+      }
+    },
     "/net/addrs": {
       "get": {
         "description": "This endpoint is used to get net addrs",
@@ -2276,7 +2317,7 @@
     },
     "/public/by-cid/{cid}": {
       "get": {
-        "description": "This endpoint returns the content associated with a CID",
+        "description": "This endpoint returns the content record associated with a CID",
         "produces": [
           "application/json"
         ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1508,6 +1508,33 @@ paths:
       summary: Get Deal Status
       tags:
         - deals
+  /get/{cid}:
+    get:
+      description: This endpoint returns the content associated with a CID
+      parameters:
+        - description: Cid
+          in: path
+          name: cid
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        "307":
+          description: Temporary Redirect
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/util.HttpError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/util.HttpError'
+      summary: Get Full Content by Cid
+      tags:
+        - public
   /net/addrs:
     get:
       description: This endpoint is used to get net addrs
@@ -1673,7 +1700,7 @@ paths:
         - pinning
   /public/by-cid/{cid}:
     get:
-      description: This endpoint returns the content associated with a CID
+      description: This endpoint returns the content record associated with a CID
       parameters:
         - description: Cid
           in: path


### PR DESCRIPTION
Added convenience methods for adding/retrieving content with 

- `put` - a synonym for `content/add`, and 
- `get` - which redirects to the estuary gateway as `/gw/ipfs/{cid}`

![image](https://user-images.githubusercontent.com/1556714/202867686-e39929d8-fe44-45a6-aa4d-600d4a4d115d.png)

![image](https://user-images.githubusercontent.com/1556714/202867731-4a94bc1e-bbed-403d-9b26-c2a8694f2a68.png)
