### PR TITLE
When deleting pins, also remove from staging buckets

### DIFF
--- a/contentmgr/gc.go
+++ b/contentmgr/gc.go
@@ -171,10 +171,12 @@ func (cm *ContentManager) UnpinContent(ctx context.Context, contid uint) error {
 		}
 	}
 
-	buckets, _ := cm.Buckets[pin.UserID]
-	for _, bucket := range buckets {
-		if _, err := cm.tryRemoveContent(bucket, pin); err != nil {
-			return err
+	buckets, ok := cm.Buckets[pin.UserID]
+	if ok {
+		for _, bucket := range buckets {
+			if _, err := cm.tryRemoveContent(bucket, pin); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/contentmgr/gc.go
+++ b/contentmgr/gc.go
@@ -170,6 +170,13 @@ func (cm *ContentManager) UnpinContent(ctx context.Context, contid uint) error {
 			return err
 		}
 	}
+
+	buckets, _ := cm.Buckets[pin.UserID]
+	for _, bucket := range buckets {
+		if _, err := cm.tryRemoveContent(bucket, pin); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/contentmgr/replication.go
+++ b/contentmgr/replication.go
@@ -223,19 +223,15 @@ func (cm *ContentManager) tryAddContent(cb *contentStagingZone, c util.Content) 
 	return true, nil
 }
 
+// tryRemoveContent Removes content from in-memory buckets
+// Assumes content is already removed from DB
 func (cm *ContentManager) tryRemoveContent(cb *contentStagingZone, c util.Content) (bool, error) {
 	cb.lk.Lock()
 	defer cb.lk.Unlock()
 
-	// if this bucket is being consolidated, do not add anymore content
+	// if this bucket is being consolidated, do not remove content
 	if cb.IsConsolidating {
 		return false, nil
-	}
-
-	if err := cm.DB.Model(util.Content{}).
-		Where("id = ? AND aggregated_in = ?", c.ID, cb.ContID).
-		UpdateColumn("aggregated_in", 0).Error; err != nil {
-		return false, err
 	}
 
 	newContents := make([]util.Content, 0)


### PR DESCRIPTION
Fixes https://github.com/application-research/estuary/issues/236

This is the resulting staging bucket after adding 6 files and deleting 2 of them via:
`curl -X DELETE "http://localhost:3004/pinning/pins/2" -H "Authorization: Bearer <TOKEN>"`
`curl -X DELETE "http://localhost:3004/pinning/pins/6" -H "Authorization: Bearer <TOKEN>"`

Content ID 3 is taken by the bucket itself.

I also tested restarting my server and verified the staging bucket state remained consistent, so the DB and in-memory buckets were both handled accurately throughout this process. 

![image](https://user-images.githubusercontent.com/2850013/203149009-882a8854-979e-409d-b4e5-3ab01111cf44.png)
