### PR TITLE
fix: use the default links per block for importing file

### DIFF
--- a/util/unixfs.go
+++ b/util/unixfs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ipfs/go-cidutil"
 	chunker "github.com/ipfs/go-ipfs-chunker"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/ipfs/go-merkledag"
@@ -23,18 +22,13 @@ func ImportFile(dserv ipld.DAGService, fi io.Reader) (ipld.Node, error) {
 		return nil, err
 	}
 	prefix.MhType = DefaultHashFunction
+	prefix.MhLength = -1
 
 	spl := chunker.NewSizeSplitter(fi, 1024*1024)
 	dbp := ihelper.DagBuilderParams{
-		Maxlinks:  1024,
-		RawLeaves: true,
-
-		CidBuilder: cidutil.InlineBuilder{
-			Builder: prefix,
-			Limit:   32,
-		},
-
-		Dagserv: dserv,
+		Dagserv:    dserv,
+		Maxlinks:   ihelper.DefaultLinksPerBlock,
+		CidBuilder: &prefix,
 	}
 
 	db, err := dbp.New(spl)

--- a/util/unixfs.go
+++ b/util/unixfs.go
@@ -28,6 +28,7 @@ func ImportFile(dserv ipld.DAGService, fi io.Reader) (ipld.Node, error) {
 	dbp := ihelper.DagBuilderParams{
 		Dagserv:    dserv,
 		Maxlinks:   ihelper.DefaultLinksPerBlock,
+		RawLeaves:  true,
 		CidBuilder: &prefix,
 	}
 


### PR DESCRIPTION
# Changes

I noticed that the dag builder generates a different cid when from IPFS. 

This PR will use the same default number of links per block configuration on the dag builder which will make it par with IPFS/Kubo. 

I have tested it with several files and it works as expected. @en0ma please test this against your files as well.

