### PR TITLE
create sharded dir in shuttle for shuttle contents

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1330,7 +1330,7 @@ func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 		return xerrors.Errorf("failed to move data from staging to main blockstore: %w", err)
 	}
 
-	s.sendPinCompleteMessage(ctx, contid, totalSize, objects)
+	s.sendPinCompleteMessage(ctx, contid, totalSize, objects, nd.Cid())
 
 	if err := s.Provide(ctx, nd.Cid()); err != nil {
 		log.Warnf("failed to provide: %+v", err)
@@ -1473,7 +1473,7 @@ func (s *Shuttle) handleAddCar(c echo.Context, u *User) error {
 		return xerrors.Errorf("failed to move data from staging to main blockstore: %w", err)
 	}
 
-	s.sendPinCompleteMessage(ctx, contid, totalSize, objects)
+	s.sendPinCompleteMessage(ctx, contid, totalSize, objects, root)
 
 	if err := s.Provide(ctx, root); err != nil {
 		log.Warn(err)
@@ -1624,7 +1624,7 @@ func (d *Shuttle) doPinning(ctx context.Context, op *pinner.PinningOperation, cb
 		return errors.Wrapf(err, "failed to addDatabaseTrackingToContent - contID(%d), cid(%s)", op.ContId, op.Obj.String())
 	}
 
-	d.sendPinCompleteMessage(ctx, op.ContId, totalSize, objects)
+	d.sendPinCompleteMessage(ctx, op.ContId, totalSize, objects, op.Obj)
 
 	if err := d.Provide(ctx, op.Obj); err != nil {
 		return errors.Wrapf(err, "failed to provide - contID(%d), cid(%s)", op.ContId, op.Obj.String())
@@ -2195,7 +2195,7 @@ func (s *Shuttle) handleResendPinComplete(c echo.Context) error {
 		return fmt.Errorf("failed to get objects for pin: %w", err)
 	}
 
-	s.sendPinCompleteMessage(ctx, p.Content, p.Size, objects)
+	s.sendPinCompleteMessage(ctx, p.Content, p.Size, objects, p.Cid.CID)
 
 	return c.JSON(http.StatusOK, map[string]string{})
 }
@@ -2411,7 +2411,7 @@ func (s *Shuttle) handleImportDeal(c echo.Context, u *User) error {
 		return err
 	}
 
-	s.sendPinCompleteMessage(ctx, contid, totalSize, objects)
+	s.sendPinCompleteMessage(ctx, contid, totalSize, objects, cc)
 
 	return c.JSON(http.StatusOK, &util.ContentAddResponse{
 		Cid:                 cc.String(),

--- a/cmd/estuary-shuttle/retrieval.go
+++ b/cmd/estuary-shuttle/retrieval.go
@@ -84,7 +84,7 @@ func (s *Shuttle) runRetrieval(ctx context.Context, req *drpc.RetrieveContent, s
 			return fmt.Errorf("failed to get objects for pin: %w", err)
 		}
 
-		s.sendPinCompleteMessage(ctx, pin.Content, pin.Size, objects)
+		s.sendPinCompleteMessage(ctx, pin.Content, pin.Size, objects, req.Cid)
 		return nil
 	}
 
@@ -145,7 +145,7 @@ func (s *Shuttle) runRetrieval(ctx context.Context, req *drpc.RetrieveContent, s
 			return err
 		}
 
-		s.sendPinCompleteMessage(ctx, req.Content, totalSize, objects)
+		s.sendPinCompleteMessage(ctx, req.Content, totalSize, objects, req.Cid)
 		return nil
 	}
 	return fmt.Errorf("failed to retrieve with any miner we have deals with")

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -47,7 +47,7 @@ func (d *Shuttle) handleRpcCmd(cmd *drpc.Command) error {
 	case drpc.CMD_TakeContent:
 		return d.handleRpcTakeContent(ctx, cmd.Params.TakeContent)
 	case drpc.CMD_AggregateContent:
-		return d.handleRpcAggregateStagedContent(ctx, cmd.Params.AggregateContents)
+		return d.handleRpcAggregateStagedContent(ctx, cmd.Params.AggregateContent)
 	case drpc.CMD_StartTransfer:
 		return d.handleRpcStartTransfer(ctx, cmd.Params.StartTransfer)
 	case drpc.CMD_PrepareForDataRequest:

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -37,7 +37,7 @@ func (d *Shuttle) handleRpcCmd(cmd *drpc.Command) error {
 		}
 	}
 
-	log.Debugf("handling rpc message: %s", cmd.Op)
+	log.Debugf("handling rpc message:%s, for shuttle:%s", d.shuttleHandle)
 
 	switch cmd.Op {
 	case drpc.CMD_AddPin:
@@ -73,7 +73,8 @@ func (d *Shuttle) sendRpcMessage(ctx context.Context, msg *drpc.Message) error {
 	// if a span is contained in `ctx` its SpanContext will be carried in the message, otherwise
 	// a noopspan context will be carried and ignored by the receiver.
 	msg.TraceCarrier = drpc.NewTraceCarrier(trace.SpanFromContext(ctx).SpanContext())
-	log.Debugf("sending rpc message: %s", msg.Op)
+	log.Debugf("sending rpc message: %s, from shuttle:%s", msg.Op, msg.Handle)
+
 	select {
 	case d.outgoing <- msg:
 		return nil

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -325,6 +325,8 @@ func (s *Shuttle) handleRpcAggregateStagedContent(ctx context.Context, aggregate
 		if p.Active {
 			return s.resendPinComplete(ctx, p)
 		}
+		log.Warnf("failed to aggregate staging zone:%d, aggregate exist but not active", aggregate.DBID)
+		// TODO, handle this case
 		return nil
 	case gorm.ErrRecordNotFound:
 		// normal case

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -409,14 +409,14 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 			Size: pincomp.Objects[0].Size,
 		}
 		if err := cm.DB.Create(obj).Error; err != nil {
-			return err
+			return xerrors.Errorf("failed to create Object: %w", err)
 		}
 
 		if err := cm.DB.Create(&util.ObjRef{
 			Content: cont.ID,
 			Object:  obj.ID,
 		}).Error; err != nil {
-			return err
+			return xerrors.Errorf("failed to create Object reference: %w", err)
 		}
 
 		if err := cm.DB.Model(util.Content{}).Where("id = ?", cont.ID).UpdateColumns(map[string]interface{}{

--- a/contentmgr/replication.go
+++ b/contentmgr/replication.go
@@ -120,7 +120,7 @@ type ContentStagingZone struct {
 	User            uint                 `json:"user"`
 	ContID          uint                 `json:"contentID"`
 	Location        string               `json:"location"`
-	IsConsolidating bool                 `json:"is_consolidating"`
+	IsConsolidating bool                 `json:"isConsolidating"`
 	Readiness       stagingZoneReadiness `json:"readiness"`
 	lk              sync.Mutex
 }

--- a/contentmgr/replication.go
+++ b/contentmgr/replication.go
@@ -1047,10 +1047,10 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content util.Conten
 		go func() {
 			_, _, _, err := cm.GetPieceCommitment(context.Background(), content.Cid.CID, cm.Blockstore)
 			if err != nil {
-				if err != ErrWaitForRemoteCompute {
-					cm.log.Errorf("failed to compute piece commitment for content %d: %s", content.ID, err)
-				} else {
+				if err == ErrWaitForRemoteCompute {
 					cm.log.Debugf("waiting for shuttle:%s to finish commp for cont:%d", content.Location, content.ID)
+				} else {
+					cm.log.Errorf("failed to compute piece commitment for content %d: %s", content.ID, err)
 				}
 				done(time.Minute * 5)
 			} else {

--- a/contentmgr/shuttle.go
+++ b/contentmgr/shuttle.go
@@ -131,7 +131,7 @@ func (cm *ContentManager) processShuttleMessage(handle string, msg *drpc.Message
 	ctx, span := cm.tracer.Start(ctx, "processShuttleMessage")
 	defer span.End()
 
-	cm.log.Debugf("handling shuttle message: %s", msg.Op)
+	cm.log.Debugf("handling rpc message:%s from shuttle:%s", msg.Op, handle)
 
 	switch msg.Op {
 	case drpc.OP_UpdatePinStatus:
@@ -231,6 +231,8 @@ func (cm *ContentManager) SendShuttleCommand(ctx context.Context, handle string,
 	if handle == "" {
 		return fmt.Errorf("attempted to send command to empty shuttle handle")
 	}
+
+	cm.log.Debugf("sending rpc message:%s to shuttle:%s", cmd.Op, handle)
 
 	cm.ShuttlesLk.Lock()
 	d, ok := cm.Shuttles[handle]

--- a/contentmgr/shuttle.go
+++ b/contentmgr/shuttle.go
@@ -336,8 +336,6 @@ func (cm *ContentManager) handleRpcTransferFinished(ctx context.Context, handle 
 }
 
 func (cm *ContentManager) HandleRpcTransferStatus(ctx context.Context, handle string, param *drpc.TransferStatus) error {
-	cm.log.Debugf("handling transfer status rpc update: %d %v", param.DealDBID, param.State == nil)
-
 	if param.DealDBID == 0 {
 		return fmt.Errorf("received transfer status update with no identifier")
 	}

--- a/contentmgr/shuttle.go
+++ b/contentmgr/shuttle.go
@@ -131,7 +131,7 @@ func (cm *ContentManager) processShuttleMessage(handle string, msg *drpc.Message
 	ctx, span := cm.tracer.Start(ctx, "processShuttleMessage")
 	defer span.End()
 
-	cm.log.Debugf("handling rpc message:%s from shuttle:%s", msg.Op, handle)
+	cm.log.Debugf("handling rpc message:%s, from shuttle:%s", msg.Op, handle)
 
 	switch msg.Op {
 	case drpc.OP_UpdatePinStatus:
@@ -232,7 +232,7 @@ func (cm *ContentManager) SendShuttleCommand(ctx context.Context, handle string,
 		return fmt.Errorf("attempted to send command to empty shuttle handle")
 	}
 
-	cm.log.Debugf("sending rpc message:%s to shuttle:%s", cmd.Op, handle)
+	cm.log.Debugf("sending rpc message:%s, to shuttle:%s", cmd.Op, handle)
 
 	cm.ShuttlesLk.Lock()
 	d, ok := cm.Shuttles[handle]

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -37,7 +37,7 @@ type CmdParams struct {
 	AddPin                 *AddPin                 `json:",omitempty"`
 	ComputeCommP           *ComputeCommP           `json:",omitempty"`
 	TakeContent            *TakeContent            `json:",omitempty"`
-	AggregateContents      *AggregateContents      `json:",omitempty"`
+	AggregateContent       *AggregateContents      `json:",omitempty"`
 	StartTransfer          *StartTransfer          `json:",omitempty"`
 	PrepareForDataRequest  *PrepareForDataRequest  `json:",omitempty"`
 	CleanupPreparedRequest *CleanupPreparedRequest `json:",omitempty"`

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -194,9 +194,9 @@ type PinObj struct {
 const OP_PinComplete = "PinComplete"
 
 type PinComplete struct {
-	DBID uint
-	Size int64
-
+	DBID    uint
+	Size    int64
+	CID     cid.Cid
 	Objects []PinObj
 }
 

--- a/drpc/rpc.go
+++ b/drpc/rpc.go
@@ -37,7 +37,7 @@ type CmdParams struct {
 	AddPin                 *AddPin                 `json:",omitempty"`
 	ComputeCommP           *ComputeCommP           `json:",omitempty"`
 	TakeContent            *TakeContent            `json:",omitempty"`
-	AggregateContent       *AggregateContent       `json:",omitempty"`
+	AggregateContents      *AggregateContents      `json:",omitempty"`
 	StartTransfer          *StartTransfer          `json:",omitempty"`
 	PrepareForDataRequest  *PrepareForDataRequest  `json:",omitempty"`
 	CleanupPreparedRequest *CleanupPreparedRequest `json:",omitempty"`
@@ -71,12 +71,16 @@ type TakeContent struct {
 
 const CMD_AggregateContent = "AggregateContent"
 
-type AggregateContent struct {
+type AggregateContents struct {
 	DBID     uint
 	UserID   uint
-	Contents []uint
-	Root     cid.Cid
-	ObjData  []byte
+	Contents []AggregateContent
+}
+
+type AggregateContent struct {
+	ID   uint
+	CID  cid.Cid
+	Name string
 }
 
 const CMD_StartTransfer = "StartTransfer"

--- a/handlers.go
+++ b/handlers.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/application-research/estuary/collections"
 	"github.com/application-research/estuary/constants"
+	"github.com/application-research/estuary/contentmgr"
 	"github.com/application-research/estuary/model"
 	"github.com/application-research/estuary/node/modules/peering"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -4533,38 +4534,50 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 		return err
 	}
 
+	var aggr []util.Content
+	if err := s.DB.Find(&aggr, "aggregated_in = ?", cont.ID).Error; err != nil {
+		return err
+	}
+
+	var aggrLocs map[string]string
+	for _, child := range aggr {
+		aggrLocs[child.Location] = child.Location
+	}
+
 	var fixedAggregateSize bool
-	if cont.Aggregate && cont.Size == 0 {
-		// if this is an aggregate and its size is zero, then that means we
+	if cont.Aggregate && cont.Size == 0 && cont.Active {
+		// if this is an active aggregate and its size is zero, then that means we
 		// failed at some point while updating the aggregate, we can fix that
-		var children []util.Content
-		if err := s.DB.Find(&children, "aggregated_in = ?", cont.ID).Error; err != nil {
-			return err
-		}
 
-		nd, err := s.CM.CreateAggregate(ctx, children)
-		if err != nil {
-			return fmt.Errorf("failed to create aggregate: %w", err)
-		}
+		switch len(aggrLocs) {
+		case 0:
+			log.Warnf("content %d has nothing aggregated in it", cont.ID)
+		case 1:
+			var zSize int64
+			for _, zc := range aggr {
+				zSize += zc.Size
+			}
 
-		// just to be safe, put it into the blockstore again
-		if err := s.Node.Blockstore.Put(ctx, nd); err != nil {
-			return err
-		}
+			z := &contentmgr.ContentStagingZone{
+				ZoneOpened: cont.CreatedAt,
+				Contents:   aggr,
+				MinSize:    s.cfg.Content.MinSize,
+				MaxSize:    s.cfg.Content.MaxSize,
+				CurSize:    zSize,
+				User:       cont.UserID,
+				ContID:     cont.ID,
+				Location:   cont.Location,
+			}
 
-		size, err := nd.Size()
-		if err != nil {
-			return err
-		}
+			if err := s.CM.AggregateStagingZone(ctx, z, aggrLocs); err != nil {
+				return err
+			}
+			fixedAggregateSize = true
 
-		// now, update size and cid
-		if err := s.DB.Model(util.Content{}).Where("id = ?", cont.ID).UpdateColumns(map[string]interface{}{
-			"cid":  util.DbCID{CID: nd.Cid()},
-			"size": size,
-		}).Error; err != nil {
-			return err
+		default:
+			// well that sucks, this will need migration
+			log.Warnf("content %d has messed up aggregation", cont.ID)
 		}
-		fixedAggregateSize = true
 	}
 
 	if cont.Location != constants.ContentLocationLocal {
@@ -4583,12 +4596,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 
 	if cont.Aggregate && rootFetchErr != nil {
 		// if this is an aggregate and we dont have the root, thats funky, but we can regenerate the root
-		var children []util.Content
-		if err := s.DB.Find(&children, "aggregated_in = ?", cont.ID).Error; err != nil {
-			return err
-		}
-
-		nd, err := s.CM.CreateAggregate(ctx, children)
+		nd, err := s.CM.CreateAggregate(ctx, aggr)
 		if err != nil {
 			return fmt.Errorf("failed to create aggregate: %w", err)
 		}
@@ -4602,45 +4610,28 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 		}
 	}
 
-	var aggrLocs map[string]int
 	var fixedAggregateLocation bool
 	if c.QueryParam("check-locations") != "" && cont.Aggregate {
 		// TODO: check if the contents of the aggregate are somewhere other than where the aggregate root is
-		var aggr []util.Content
-		if err := s.DB.Find(&aggr, "aggregated_in = ?", cont.ID).Error; err != nil {
-			return err
-		}
-
-		aggrLocs = make(map[string]int)
-		for _, child := range aggr {
-			aggrLocs[child.Location]++
-		}
-
 		switch len(aggrLocs) {
 		case 0:
 			log.Warnf("content %d has nothing aggregated in it", cont.ID)
 		case 1:
 			loc := aggr[0].Location
-
 			if loc != cont.Location {
 				// should be safe to send a re-aggregate command to the shuttle in question
-				var ids []uint
+				var aggrConts []drpc.AggregateContent
 				for _, c := range aggr {
-					ids = append(ids, c.ID)
+					aggrConts = append(aggrConts, drpc.AggregateContent{ID: c.ID, Name: c.Name, CID: c.Cid.CID})
 				}
 
-				dir, err := s.CM.CreateAggregate(ctx, aggr)
-				if err != nil {
-					return err
-				}
-
-				if err := s.CM.SendAggregateCmd(ctx, loc, cont, ids, dir.RawData()); err != nil {
+				if err := s.CM.SendAggregateCmd(ctx, loc, cont, aggrConts); err != nil {
 					return err
 				}
 				fixedAggregateLocation = true
 			}
 		default:
-			// well that sucks
+			// well that sucks, this will need migration
 			log.Warnf("content %d has messed up aggregation", cont.ID)
 		}
 	}


### PR DESCRIPTION
This PR moves shuttle content aggregation to shuttle (its faster, cleaner, and more deterministic).

I tested the previous implementation where aggregation happens on primary, for shuttle contents, sharded dir requires bitswap so it takes time.

**verification**

I have tested this, it works as expected - super fast!