### PR TITLE
catch panic from http request

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1109,6 +1109,7 @@ func (s *Shuttle) ServeAPI() error {
 	e.Use(s.tracingMiddleware)
 	e.Use(util.AppVersionMiddleware(s.shuttleConfig.AppVersion))
 	e.HTTPErrorHandler = util.ErrorHandler
+	e.Use(middleware.Recover())
 
 	e.GET("/debug/metrics", func(e echo.Context) error {
 		estumetrics.Exporter().ServeHTTP(e.Response().Writer, e.Request())

--- a/handlers.go
+++ b/handlers.go
@@ -128,6 +128,7 @@ func (s *Server) ServeAPI() error {
 	})
 
 	e.Use(middleware.CORS())
+	e.Use(middleware.Recover())
 
 	e.POST("/register", s.handleRegisterUser)
 	e.POST("/login", s.handleLoginUser)


### PR DESCRIPTION
This makes sure HTTP request does not crash the servers. I have verified this by adding a panic on an endpoint, calling the endpoint, and got a 500 response as expected