### PR TITLE
[draft] feat: stop creating deals for unreachable content

### DIFF
--- a/contentmgr/replication.go
+++ b/contentmgr/replication.go
@@ -1089,6 +1089,13 @@ func (cm *ContentManager) ensureStorage(ctx context.Context, content util.Conten
 		}
 	}
 
+	bserv := blockservice.New(cm.Blockstore, cm.Node.Bitswap)
+	dserv := merkledag.NewDAGService(bserv)
+	_, err = dserv.Get(ctx, content.Cid.CID)
+	if err != nil {
+		return errors.New("will not make deal as the content is unretrievable")
+	}
+
 	go func() {
 		// make some more deals!
 		cm.log.Debugw("making more deals for content", "content", content.ID, "curDealCount", len(deals), "newDeals", dealsToBeMade)


### PR DESCRIPTION
Check if the content is accessible before creating a deal with SP. 

TODO: Persist this in some metadata so we don't have to constantly do the lookup on the content everytime it tries to make deals