### PR TITLE
Setup dependabot for opening PRs to update gomod dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: "dev"
+    labels:
+      - "gomod dependencies"
+    reviewers:
+      - "nvirdy"

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ peer.key
 wallet/
 duplicateGuard/
 pinQueue/
+stagingdata/
 
 cidlistsdir/*
 


### PR DESCRIPTION
This automates opening of PRs to update gomod dependencies. Made myself the default reviewer, happy to add anyone else who'd like to look at these. Ideally, we'd eventually allow auto-merging of these PRs as long as they still pass checks.

Inspired by station's setup: https://github.com/filecoin-station/filecoin-station/blame/main/.github/dependabot.yml

Other resources: 
- Core docs: https://github.com/dependabot/dependabot-core
- Gomod example: https://gist.github.com/magnetikonline/6f215db058e327905bce66c37f92426c

This also needs someone with repo admin perms to enable dependabot PRs. @jlogelin @alvin-reyes are one of you able to do this? Looks very quick to do. Docs: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#enabling-or-disabling-dependabot-security-updates-for-an-individual-repository