### PR TITLE
Fix/pin panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -322,6 +322,8 @@ require (
 	github.com/twmb/murmur3 v1.1.6 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc // indirect
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba // indirect
 	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1745,6 +1745,10 @@ github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
 github.com/warpfork/go-testmark v0.3.0/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
 github.com/warpfork/go-testmark v0.10.0 h1:E86YlUMYfwIacEsQGlnTvjk1IgYkyTGjPhF0RnwTCmw=

--- a/pinner/pinmgr_test.go
+++ b/pinner/pinmgr_test.go
@@ -24,7 +24,7 @@ func onPinStatusUpdate(cont uint, location string, status types.PinningStatus) e
 func newManager(count *int) *PinManager {
 
 	_ = os.RemoveAll("/tmp/duplicateGuard")
-	_ = os.RemoveAll("/tmp/pinQueue")
+	_ = os.RemoveAll("/tmp/pinQueueMsgPack")
 
 	return NewPinManager(
 		func(ctx context.Context, op *PinningOperation, cb PinProgressCB) error {

--- a/pinner/pinmgr_test.go
+++ b/pinner/pinmgr_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/application-research/estuary/pinner/types"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,8 +54,10 @@ func newManagerNoDelete(count *int) *PinManager {
 }
 
 func newPinData(name string, userid int, contid int) PinningOperation {
+	peers := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{nil}}}
 	return PinningOperation{
 		Name:   name,
+		Peers:  peers,
 		UserId: uint(userid),
 		lk:     sync.Mutex{},
 		ContId: uint(contid),


### PR DESCRIPTION
Swap out the GOB encoder for msg pack as this doesn't panic. 
Also change the working directory for the queue since the data format is different now, so we don't have collisions 