### PR TITLE
Sanitize PinningOperation.Peers (don't allow nil ma.Multiaddr)

### DIFF
--- a/pinner/pinmgr.go
+++ b/pinner/pinmgr.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/application-research/estuary/pinner/types"
 	"github.com/application-research/goque"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/ipfs/go-cid"
@@ -177,6 +178,7 @@ func (pm *PinManager) PinQueueSize() int {
 
 func (pm *PinManager) Add(op *PinningOperation) {
 	go func() {
+		sanitizePeers(op.Peers)
 		pm.pinQueueIn <- op
 	}()
 }
@@ -340,6 +342,18 @@ func createDQue(QueueDataDir string) *goque.PrefixQueue {
 
 func getUserForQueue(UserId uint) []byte {
 	return []byte(strconv.Itoa(int(UserId)))
+}
+
+func sanitizePeers(peers []*peer.AddrInfo) {
+	for _, peer := range peers {
+		addrs := []ma.Multiaddr{}
+		for _, addr := range peer.Addrs {
+			if addr != nil {
+				addrs = append(addrs, addr)
+			}
+		}
+		peer.Addrs = addrs
+	}
 }
 
 func encode_msgpack(po *PinningOperation) ([]byte, error) {

--- a/pinner/pinmgr_test.go
+++ b/pinner/pinmgr_test.go
@@ -53,6 +53,49 @@ func newManagerNoDelete(count *int) *PinManager {
 		})
 }
 
+func TestPeerSanitizeNil(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		peers := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{nil}}}
+		peers_original := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{nil}}}
+		peers_sanitized_expected := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{}}}
+		sanitizePeers(peers)
+		assert.NotEqual(t, peers_original, peers, "sanitized peers does not equal peer with nil value")
+		assert.Equal(t, peers_sanitized_expected, peers, "Sanitized peer does not equal expected value")
+
+	})
+}
+func TestPeerSanitizeValuesNoNil(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		addr, err := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/80")
+		if err != nil {
+			panic(err)
+		}
+
+		peers := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{addr}}}
+		peers_original := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{addr}}}
+		peers_sanitized_expected := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{addr}}}
+		sanitizePeers(peers)
+		assert.Equal(t, peers_original, peers, "sanitized peers does not equal expected value")
+		assert.Equal(t, peers_sanitized_expected, peers, "Sanitized peer does not equal expected value")
+
+	})
+}
+func TestPeerSanitizeValuesNil(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		addr, err := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/80")
+		if err != nil {
+			panic(err)
+		}
+
+		peers := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{addr, nil}}}
+		peers_original := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{addr, nil}}}
+		peers_sanitized_expected := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{addr}}}
+		sanitizePeers(peers)
+		assert.NotEqual(t, peers_original, peers, "sanitized peers does not equal peer with nil value")
+		assert.Equal(t, peers_sanitized_expected, peers, "Sanitized peer does not equal expected value")
+
+	})
+}
 func newPinData(name string, userid int, contid int) PinningOperation {
 	peers := []*peer.AddrInfo{{ID: peer.ID("12D3KooWCsxFFH242NZ4bjRMJEVc61La6Ha4yGVNXeEEwpf8KWCX"), Addrs: []ma.Multiaddr{nil}}}
 	return PinningOperation{


### PR DESCRIPTION
sanitize Peers ( not allow nil ma.Multiaddr) in pinmgr.Add and include several tests for coverage to validate the sanitize method

@en0ma / @alvin-reyes can you validate the sanitize method does what we intend? if it needs modifications please let me know 