### PR TITLE
check content-type on handleAdd early

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1250,10 +1250,6 @@ func (s *Shuttle) handleLogLevel(c echo.Context) error {
 func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 	ctx := c.Request().Context()
 
-	if err := util.WithMultipartFormDataChecker(c.Request().Header); err != nil {
-		return err
-	}
-
 	if err := util.ErrorIfContentAddingDisabled(s.isContentAddingDisabled(u)); err != nil {
 		return err
 	}

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -313,7 +313,7 @@ func main() {
 			Value: cfg.Dev,
 		},
 		&cli.StringSliceFlag{
-			Name:  "announce-addr",
+			Name: "announce-addr",
 			Usage: "specify multiaddrs that this node can be connected to	",
 			Value: cli.NewStringSlice(cfg.Node.AnnounceAddrs...),
 		},
@@ -1145,7 +1145,7 @@ func (s *Shuttle) ServeAPI() error {
 
 	content := e.Group("/content")
 	content.Use(s.AuthRequired(util.PermLevelUpload))
-	content.POST("/add", withUser(s.handleAdd))
+	content.POST("/add", util.WithMultipartFormDataChecker(withUser(s.handleAdd)))
 	content.POST("/add-car", util.WithContentLengthCheck(withUser(s.handleAddCar)))
 	content.GET("/read/:cont", withUser(s.handleReadContent))
 	content.POST("/importdeal", withUser(s.handleImportDeal))
@@ -1250,7 +1250,7 @@ func (s *Shuttle) handleLogLevel(c echo.Context) error {
 func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 	ctx := c.Request().Context()
 
-	if err := util.CheckContentTypeIsMultipartFormData(c.Request().Header); err != nil {
+	if err := util.WithMultipartFormDataChecker(c.Request().Header); err != nil {
 		return err
 	}
 

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -313,7 +313,7 @@ func main() {
 			Value: cfg.Dev,
 		},
 		&cli.StringSliceFlag{
-			Name: "announce-addr",
+			Name:  "announce-addr",
 			Usage: "specify multiaddrs that this node can be connected to	",
 			Value: cli.NewStringSlice(cfg.Node.AnnounceAddrs...),
 		},
@@ -1249,6 +1249,10 @@ func (s *Shuttle) handleLogLevel(c echo.Context) error {
 // @Router       /content/add [post]
 func (s *Shuttle) handleAdd(c echo.Context, u *User) error {
 	ctx := c.Request().Context()
+
+	if err := util.CheckContentTypeIsMultipartFormData(c.Request().Header); err != nil {
+		return err
+	}
 
 	if err := util.ErrorIfContentAddingDisabled(s.isContentAddingDisabled(u)); err != nil {
 		return err

--- a/handlers.go
+++ b/handlers.go
@@ -157,7 +157,7 @@ func (s *Server) ServeAPI() error {
 
 	contmeta := e.Group("/content")
 	uploads := contmeta.Group("", s.AuthRequired(util.PermLevelUpload))
-	uploads.POST("/add", withUser(s.handleAdd))
+	uploads.POST("/add", util.WithMultipartFormDataChecker(withUser(s.handleAdd)))
 	uploads.POST("/add-ipfs", withUser(s.handleAddIpfs))
 	uploads.POST("/add-car", util.WithContentLengthCheck(withUser(s.handleAddCar)))
 	uploads.POST("/create", withUser(s.handleCreateContent))
@@ -857,7 +857,7 @@ func (s *Server) handleAdd(c echo.Context, u *util.User) error {
 	ctx, span := s.tracer.Start(c.Request().Context(), "handleAdd", trace.WithAttributes(attribute.Int("user", int(u.ID))))
 	defer span.End()
 
-	if err := util.CheckContentTypeIsMultipartFormData(c.Request().Header); err != nil {
+	if err := util.WithMultipartFormDataChecker(c.Request().Header); err != nil {
 		return err
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -857,8 +857,8 @@ func (s *Server) handleAdd(c echo.Context, u *util.User) error {
 	ctx, span := s.tracer.Start(c.Request().Context(), "handleAdd", trace.WithAttributes(attribute.Int("user", int(u.ID))))
 	defer span.End()
 
-	if c.Request().Header.Get("Content-Type") != "multipart/form-data" {
-		return errors.New("request Content-Type isn't multipart/form-data")
+	if err := util.CheckContentTypeIsMultipartFormData(c.Request().Header); err != nil {
+		return err
 	}
 
 	if err := util.ErrorIfContentAddingDisabled(s.isContentAddingDisabled(u)); err != nil {

--- a/handlers.go
+++ b/handlers.go
@@ -857,10 +857,6 @@ func (s *Server) handleAdd(c echo.Context, u *util.User) error {
 	ctx, span := s.tracer.Start(c.Request().Context(), "handleAdd", trace.WithAttributes(attribute.Int("user", int(u.ID))))
 	defer span.End()
 
-	if err := util.WithMultipartFormDataChecker(c.Request().Header); err != nil {
-		return err
-	}
-
 	if err := util.ErrorIfContentAddingDisabled(s.isContentAddingDisabled(u)); err != nil {
 		return err
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -857,6 +857,10 @@ func (s *Server) handleAdd(c echo.Context, u *util.User) error {
 	ctx, span := s.tracer.Start(c.Request().Context(), "handleAdd", trace.WithAttributes(attribute.Int("user", int(u.ID))))
 	defer span.End()
 
+	if c.Request().Header.Get("Content-Type") != "multipart/form-data" {
+		return errors.New("request Content-Type isn't multipart/form-data")
+	}
+
 	if err := util.ErrorIfContentAddingDisabled(s.isContentAddingDisabled(u)); err != nil {
 		return err
 	}

--- a/util/content.go
+++ b/util/content.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -213,11 +212,4 @@ func GetContent(contentid string, db *gorm.DB, u *User) (Content, error) {
 		return Content{}, err
 	}
 	return content, nil
-}
-
-func CheckContentTypeIsMultipartFormData(header http.Header) error {
-	if header.Get("Content-Type") != "multipart/form-data" {
-		return errors.New("request Content-Type isn't multipart/form-data")
-	}
-	return nil
 }

--- a/util/content.go
+++ b/util/content.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -212,4 +213,11 @@ func GetContent(contentid string, db *gorm.DB, u *User) (Content, error) {
 		return Content{}, err
 	}
 	return content, nil
+}
+
+func CheckContentTypeIsMultipartFormData(header http.Header) error {
+	if header.Get("Content-Type") != "multipart/form-data" {
+		return errors.New("request Content-Type isn't multipart/form-data")
+	}
+	return nil
 }

--- a/util/misc.go
+++ b/util/misc.go
@@ -109,28 +109,32 @@ func (b Binder) Bind(i interface{}, c echo.Context) error {
 
 func JSONPayloadMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		if c.Request().Header.Get("Content-Type") != "application/json" {
-			return &HttpError{
-				Code:    http.StatusUnsupportedMediaType,
-				Reason:  ERR_UNSUPPORTED_CONTENT_TYPE,
-				Details: "this endpoint only supports json payloads",
-			}
+		if err := checkContentType(c.Request().Header, "application/json"); err != nil {
+			return err
 		}
 		return next(c)
+	}
 	}
 }
 
 func WithMultipartFormDataChecker(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		if c.Request().Header.Get("Content-Type") != "multipart/form-data" {
-			return &HttpError{
-				Code:    http.StatusUnsupportedMediaType,
-				Reason:  ERR_UNSUPPORTED_CONTENT_TYPE,
-				Details: "this endpoint only supports multipart/form-data payloads",
-			}
+		if err := checkContentType(c.Request().Header, "multipart/form-data"); err != nil {
+			return err
 		}
 		return next(c)
 	}
+}
+
+func checkContentType(header http.Header, expectedContentType string) error {
+	if header.Get("Content-Type") != expectedContentType {
+		return &HttpError{
+			Code: http.StatusUnsupportedMediaType,
+			Reason: ERR_UNSUPPORTED_CONTENT_TYPE,
+			Details: fmt.Sprintf("this endpoint only supports %s paylods", expectedContentType),
+		}
+	}
+	return nil
 }
 
 func DumpBlockstoreTo(ctx context.Context, tc trace.Tracer, from, to blockstore.Blockstore) error {

--- a/util/misc.go
+++ b/util/misc.go
@@ -114,7 +114,6 @@ func JSONPayloadMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 		return next(c)
 	}
-	}
 }
 
 func WithMultipartFormDataChecker(next echo.HandlerFunc) echo.HandlerFunc {
@@ -129,8 +128,8 @@ func WithMultipartFormDataChecker(next echo.HandlerFunc) echo.HandlerFunc {
 func checkContentType(header http.Header, expectedContentType string) error {
 	if header.Get("Content-Type") != expectedContentType {
 		return &HttpError{
-			Code: http.StatusUnsupportedMediaType,
-			Reason: ERR_UNSUPPORTED_CONTENT_TYPE,
+			Code:    http.StatusUnsupportedMediaType,
+			Reason:  ERR_UNSUPPORTED_CONTENT_TYPE,
 			Details: fmt.Sprintf("this endpoint only supports %s paylods", expectedContentType),
 		}
 	}

--- a/util/misc.go
+++ b/util/misc.go
@@ -120,6 +120,19 @@ func JSONPayloadMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
+func WithMultipartFormDataChecker(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if c.Request().Header.Get("Content-Type") != "multipart/form-data" {
+			return &HttpError{
+				Code:    http.StatusUnsupportedMediaType,
+				Reason:  ERR_UNSUPPORTED_CONTENT_TYPE,
+				Details: "this endpoint only supports multipart/form-data payloads",
+			}
+		}
+		return next(c)
+	}
+}
+
 func DumpBlockstoreTo(ctx context.Context, tc trace.Tracer, from, to blockstore.Blockstore) error {
 	ctx, span := tc.Start(ctx, "blockstoreCopy")
 	defer span.End()


### PR DESCRIPTION
I was trying to upload a large dataset and it failed after nearly 7 minutes because I had the wrong content-type in my request:

```
root@c3-small-x86-01:/data# time curl https://upload.estuary.tech/content/add -H "Authorization: Bearer $(cat /data/.estuary_auth)" -H "Content-Type: multipar/form-data" -F "data=@longitudinal-nutrient-deficiency.tar"
{"error":{"code":500,"reason":"Internal Server Error","details":"request Content-Type isn't multipart/form-data"}}

real	6m52.221s
user	0m15.953s
sys	0m18.861s
```

Checking it early to handle similar instances.