### PR TITLE
Handle pin failures during consolidation to prevent stuck staging zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build/.*
 .envrc
 
 .idea
+
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ peer.key
 wallet/
 duplicateGuard/
 pinQueue/
+pinQueue*/
 stagingdata/
 
 cidlistsdir/*

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -144,6 +144,7 @@ func (d *Shuttle) addPin(ctx context.Context, contid uint, data cid.Cid, user ui
 			}); err != nil {
 				log.Errorf("failed to send pin status update: %s", err)
 			}
+			return nil
 		}
 
 		if !existing.Pinning && existing.Active {

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -128,21 +129,17 @@ func (d *Shuttle) addPin(ctx context.Context, contid uint, data cid.Cid, user ui
 		existing := search[0]
 
 		if existing.Failed {
-			// being asked to pin a thing we have marked as failed means the
-			// primary node isnt aware that this pin failed, we need to resend
-			// that notification
-
-			if err := d.sendRpcMessage(ctx, &drpc.Message{
-				Op: drpc.OP_UpdatePinStatus,
-				Params: drpc.MsgParams{
-					UpdatePinStatus: &drpc.UpdatePinStatus{
-						DBID:   contid,
-						Status: types.PinningStatusFailed,
-					},
-				},
-			}); err != nil {
-				log.Errorf("failed to send pin status update: %s", err)
+			// retry a failed existing pin
+			op := &pinner.PinningOperation{
+				Obj:         data,
+				ContId:      contid,
+				UserId:      user,
+				Status:      types.PinningStatusQueued,
+				SkipLimiter: skipLimiter,
+				Peers:       peers,
 			}
+
+			d.PinMgr.Add(op)
 			return nil
 		}
 
@@ -300,22 +297,35 @@ func (d *Shuttle) handleRpcTakeContent(ctx context.Context, cmd *drpc.TakeConten
 	defer d.addPinLk.Unlock()
 
 	for _, c := range cmd.Contents {
-		var count int64
-		err := d.DB.Model(Pin{}).Where("content = ?", c.ID).Limit(1).Count(&count).Error
+		var pin Pin
+		err := d.DB.First(&pin, "content = ?", c.ID).Error
 		if err != nil {
-			return err
-		}
-
-		// if this content is already in this shuttle, ignore pinning it
-		if count > 0 {
-			continue
-		}
-
-		go func(c drpc.ContentFetch) {
-			if err := d.addPin(ctx, c.ID, c.Cid, c.UserID, c.Peers, true); err != nil {
-				log.Errorf("failed to pin takeContent: %d", c.ID)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				go func(c drpc.ContentFetch) {
+					if err := d.addPin(ctx, c.ID, c.Cid, c.UserID, c.Peers, true); err != nil {
+						log.Errorf("failed to pin takeContent: %d", c.ID)
+					}
+				}(c)
+			} else {
+				log.Errorf("error finding pin: %s", err)
+				return err
 			}
-		}(c)
+		}
+
+		if pin.Active {
+			// if this content is already in this shuttle, resend pin complete
+			if err := d.resendPinComplete(ctx, pin); err != nil {
+				log.Error(err)
+			}
+		}
+		if pin.Failed {
+			// retry addPin if failed
+			go func(c drpc.ContentFetch) {
+				if err := d.addPin(ctx, c.ID, c.Cid, c.UserID, c.Peers, true); err != nil {
+					log.Errorf("failed to pin takeContent: %d", c.ID)
+				}
+			}(c)
+		}
 	}
 	return nil
 }
@@ -358,7 +368,7 @@ func (s *Shuttle) handleRpcAggregateStagedContent(ctx context.Context, aggregate
 			return err
 		}
 
-		if !cont.Active || cont.Failed {
+		if !cont.Active {
 			return fmt.Errorf("content i am being asked to aggregate is not pinned: %d", c.ID)
 		}
 	}

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -367,13 +367,13 @@ func (cm *ContentManager) UpdatePinStatus(location string, contID uint, status t
 		if c.AggregatedIn > 0 {
 			// unmark zone as consolidating if a staged content fails to pin
 			cm.MarkFinishedConsolidating(c.AggregatedIn)
-			// TODO: call the content failed and remove it from the zone, so it can retry and succeed without this content
 		}
 
 		if err := cm.DB.Model(util.Content{}).Where("id = ?", contID).UpdateColumns(map[string]interface{}{
-			"active":  false,
-			"pinning": false,
-			"failed":  true,
+			"active":        false,
+			"pinning":       false,
+			"failed":        true,
+			"aggregated_in": 0, // remove from staging zone so the zone can consolidate without it
 		}).Error; err != nil {
 			cm.log.Errorf("failed to mark content as failed in database: %s", err)
 		}

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -370,9 +370,10 @@ func (cm *ContentManager) UpdatePinStatus(location string, contID uint, status t
 		}
 
 		if err := cm.DB.Model(util.Content{}).Where("id = ?", contID).UpdateColumns(map[string]interface{}{
-			"active":        false,
-			"pinning":       false,
-			"failed":        true,
+			"active":  false,
+			"pinning": false,
+			"failed":  true,
+			// TODO: consider if we should not clear aggregated_in, but instead filter for not failed contents when aggregating
 			"aggregated_in": 0, // remove from staging zone so the zone can consolidate without it
 		}).Error; err != nil {
 			cm.log.Errorf("failed to mark content as failed in database: %s", err)

--- a/contentmgr/replication.go
+++ b/contentmgr/replication.go
@@ -489,19 +489,19 @@ func (cm *ContentManager) consolidateStagedContent(ctx context.Context, zone uti
 
 	cm.log.Debugw("consolidating content to single location for aggregation", "user", zone.UserID, "dstLocation", dstLocation, "numItems", len(toMove), "primaryWeight", curMax)
 	if dstLocation == constants.ContentLocationLocal {
-		defer cm.MarkFinishedConsolidating(zone)
+		defer cm.MarkFinishedConsolidating(zone.ID)
 		return cm.migrateContentsToLocalNode(ctx, toMove)
 	} else if dstLocation != "" {
 		if err := cm.SendConsolidateContentCmd(ctx, dstLocation, toMove); err != nil {
 			// unmark as consolidating and retry later if failed to send consolidate cmd
-			cm.MarkFinishedConsolidating(zone)
+			cm.MarkFinishedConsolidating(zone.ID)
 			return err
 		}
 		return nil
 	} else {
 		// unable to find a destination location, unmark as consolidating and let it retry later
 		cm.log.Warnf("unable to find a destination location for consolidating zone: %d", zone.ID)
-		cm.MarkFinishedConsolidating(zone)
+		cm.MarkFinishedConsolidating(zone.ID)
 		return nil
 	}
 }
@@ -512,20 +512,20 @@ func (cm *ContentManager) IsZoneConsolidating(zoneID uint) bool {
 	return cm.consolidatingZones[zoneID]
 }
 
-func (cm *ContentManager) MarkStartedConsolidating(zone util.Content) bool {
+func (cm *ContentManager) MarkStartedConsolidating(zoneID uint) bool {
 	cm.consolidatingZonesLk.Lock()
 	defer cm.consolidatingZonesLk.Unlock()
-	if cm.consolidatingZones[zone.ID] {
+	if cm.consolidatingZones[zoneID] {
 		// skip since it is already processing
 		return false
 	}
-	cm.consolidatingZones[zone.ID] = true
+	cm.consolidatingZones[zoneID] = true
 	return true
 }
 
-func (cm *ContentManager) MarkFinishedConsolidating(zone util.Content) {
+func (cm *ContentManager) MarkFinishedConsolidating(zoneID uint) {
 	cm.consolidatingZonesLk.Lock()
-	delete(cm.consolidatingZones, zone.ID)
+	delete(cm.consolidatingZones, zoneID)
 	cm.consolidatingZonesLk.Unlock()
 }
 
@@ -535,20 +535,20 @@ func (cm *ContentManager) IsZoneAggregating(zoneID uint) bool {
 	return cm.aggregatingZones[zoneID]
 }
 
-func (cm *ContentManager) MarkStartedAggregating(zone util.Content) bool {
+func (cm *ContentManager) MarkStartedAggregating(zoneID uint) bool {
 	cm.aggregatingZonesLk.Lock()
 	defer cm.aggregatingZonesLk.Unlock()
-	if cm.aggregatingZones[zone.ID] {
+	if cm.aggregatingZones[zoneID] {
 		// skip since it is already processing
 		return false
 	}
-	cm.aggregatingZones[zone.ID] = true
+	cm.aggregatingZones[zoneID] = true
 	return true
 }
 
-func (cm *ContentManager) MarkFinishedAggregating(zone util.Content) {
+func (cm *ContentManager) MarkFinishedAggregating(zoneID uint) {
 	cm.aggregatingZonesLk.Lock()
-	delete(cm.aggregatingZones, zone.ID)
+	delete(cm.aggregatingZones, zoneID)
 	cm.aggregatingZonesLk.Unlock()
 }
 
@@ -569,7 +569,7 @@ func (cm *ContentManager) processStagingZone(ctx context.Context, zone util.Cont
 		// Only attempt consolidation on a zone if one is not ongoing, prevents re-consolidation request
 
 		// should never be aggregating here but check anyways
-		if cm.IsZoneAggregating(zone.ID) || !cm.MarkStartedConsolidating(zone) {
+		if cm.IsZoneAggregating(zone.ID) || !cm.MarkStartedConsolidating(zone.ID) {
 			// skip if it is aggregating or already consolidating
 			return nil
 		}
@@ -589,8 +589,8 @@ func (cm *ContentManager) processStagingZone(ctx context.Context, zone util.Cont
 	}
 
 	// if we reached here, consolidation is done and we can move to aggregating
-	cm.MarkFinishedConsolidating(zone)
-	if !cm.MarkStartedAggregating(zone) {
+	cm.MarkFinishedConsolidating(zone.ID)
+	if !cm.MarkStartedAggregating(zone.ID) {
 		// skip if zone is consolidating or already aggregating
 		return nil
 	}
@@ -660,7 +660,7 @@ func (cm *ContentManager) AggregateStagingZone(ctx context.Context, zone util.Co
 			cm.ToCheck(zone.ID)
 		}()
 
-		cm.MarkFinishedAggregating(zone)
+		cm.MarkFinishedAggregating(zone.ID)
 
 		return nil
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -4463,7 +4463,7 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 				break
 			}
 
-			if !s.CM.MarkStartedAggregating(cont) {
+			if !s.CM.MarkStartedAggregating(cont.ID) {
 				// skip since it is already aggregating
 				return nil
 			}


### PR DESCRIPTION
Handle pin failures during consolidations by removing the failed contents from the staging zone and unmarking it as consolidating, so the staging worker will retry consolidation without the failed contents on the next interval.

Also, prevent staging zones from getting stuck in consolidating when the take content command doesn't even get successfully sent to the shuttle.