### PR TITLE
Store consolidating and aggregating state in contents db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ peer.key
 wallet/
 duplicateGuard/
 pinQueue/
+pinQueue*/
 stagingdata/
 
 cidlistsdir/*
@@ -34,3 +35,5 @@ build/.*
 .envrc
 
 .idea
+
+**/.DS_Store

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -428,7 +428,9 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 		}
 
 		// if the content is a consolidated aggregate, it means aggregation has been completed and we can mark as finished
-		cm.MarkFinishedAggregating(cont)
+		if err := cm.MarkFinishedAggregating(cont); err != nil {
+			return err
+		}
 
 		// after aggregate is done, make deal for it
 		cm.ToCheck(cont.ID)

--- a/handlers.go
+++ b/handlers.go
@@ -4463,7 +4463,11 @@ func (s *Server) handleContentHealthCheck(c echo.Context) error {
 				break
 			}
 
-			if !s.CM.MarkStartedAggregating(cont) {
+			canAggregate, err := s.CM.MarkStartedAggregating(cont)
+			if err != nil {
+				return err
+			}
+			if !canAggregate {
 				// skip since it is already aggregating
 				return nil
 			}

--- a/pinning.go
+++ b/pinning.go
@@ -496,7 +496,15 @@ func (s *Server) handleDeletePin(e echo.Context, u *util.User) error {
 	}
 
 	if content.AggregatedIn > 0 {
-		if s.CM.IsZoneConsolidating(content.AggregatedIn) || s.CM.IsZoneAggregating(content.AggregatedIn) {
+		isConsolidating, err := s.CM.IsZoneConsolidating(content.AggregatedIn)
+		if err != nil {
+			return err
+		}
+		isAggregating, err := s.CM.IsZoneAggregating(content.AggregatedIn)
+		if err != nil {
+			return err
+		}
+		if isConsolidating || isAggregating {
 			return fmt.Errorf("unable to unpin content while zone is consolidating or aggregating (pin: %d, zone: %d)", content.ID, content.AggregatedIn)
 		}
 		var zone util.Content

--- a/util/content.go
+++ b/util/content.go
@@ -79,6 +79,10 @@ type Content struct {
 	AggregatedIn uint `json:"aggregatedIn" gorm:"index:,option:CONCURRENTLY"`
 	Aggregate    bool `json:"aggregate"`
 
+	// for staging zones, track if they're consolidating or aggregating to prevent concurrent attempts or modifications
+	Consolidating bool `json:"consolidating"`
+	Aggregating   bool `json:"aggregating"`
+
 	Pinning bool   `json:"pinning"`
 	PinMeta string `json:"pinMeta"`
 	Replace bool   `json:"replace" gorm:"default:0"`


### PR DESCRIPTION
waiting to validate after merging + rebasing #655. persisting this state in db makes retrying consolidation and aggregation less accessible, since the state is currently reset on a restart which can lead to retries. need to ensure consolidation consistently succeeds or that failures can be appropriately handled before persisting the state in db