### PR TITLE
cleaner flag for splitContent

### DIFF
--- a/contentmgr/replication.go
+++ b/contentmgr/replication.go
@@ -1147,7 +1147,7 @@ func (cm *ContentManager) splitContent(ctx context.Context, cont util.Content, s
 		return fmt.Errorf("failed to load contents user from db: %w", err)
 	}
 
-	if !u.FlagSplitContent() {
+	if !u.SplitContent {
 		return fmt.Errorf("user does not have content splitting enabled")
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -863,7 +863,7 @@ func (s *Server) handleAdd(c echo.Context, u *util.User) error {
 
 	// if splitting is disabled and uploaded content size is greater than content size limit
 	// reject the upload, as it will only get stuck and deals will never be made for it
-	if !u.FlagSplitContent() && mpf.Size > s.cfg.Content.MaxSize {
+	if !u.SplitContent && mpf.Size > s.cfg.Content.MaxSize {
 		return &util.HttpError{
 			Code:    http.StatusBadRequest,
 			Reason:  util.ERR_CONTENT_SIZE_OVER_LIMIT,
@@ -3233,7 +3233,7 @@ func (s *Server) handleGetViewer(c echo.Context, u *util.User) error {
 			ContentAddingDisabled: s.isContentAddingDisabled(u),
 			DealMakingDisabled:    s.CM.DealMakingDisabled(),
 			UploadEndpoints:       uep,
-			Flags:                 u.Flags,
+			Flags:                 u.SplitContent,
 		},
 		AuthExpiry: u.AuthToken.Expiry,
 	})

--- a/util/users.go
+++ b/util/users.go
@@ -16,16 +16,12 @@ type User struct {
 
 	UserEmail string
 
-	Address   DbAddr
-	AuthToken AuthToken `gorm:"-"`
-	Perm      int
-	Flags     int
+	Address      DbAddr
+	AuthToken    AuthToken `gorm:"-"`
+	Perm         int
+	SplitContent bool
 
 	StorageDisabled bool
-}
-
-func (u *User) FlagSplitContent() bool {
-	return u.Flags&8 != 0
 }
 
 type AuthToken struct {


### PR DESCRIPTION
I am not sure what this means for the existing data model though. Do we need to write a migration? 