### PR TITLE
don't exclude createdAt in content json responses

### DIFF
--- a/util/content.go
+++ b/util/content.go
@@ -60,7 +60,7 @@ type ContentCreateResponse struct {
 
 type Content struct {
 	ID        uint           `gorm:"primarykey" json:"id"`
-	CreatedAt time.Time      `json:"-"`
+	CreatedAt time.Time      `json:"createdAt"`
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 


### PR DESCRIPTION
include `createdAt` in json so `/content/deals` includes it and the deals page can render the content's created at timestamp

related thread: https://filecoinproject.slack.com/archives/C016APFREQK/p1670347934023049