### PR TITLE
Fix error when deleting content from inactive zone

### DIFF
--- a/pinning.go
+++ b/pinning.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -501,9 +502,13 @@ func (s *Server) handleDeletePin(e echo.Context, u *util.User) error {
 			return fmt.Errorf("unable to unpin content while zone is consolidating or aggregating (pin: %d, zone: %d)", content.ID, content.AggregatedIn)
 		}
 		var zone util.Content
-		if err := s.DB.Find(&zone).Where("id = ?", content.AggregatedIn).Error; err != nil {
+		if err := s.DB.First(&zone, "id = ?", content.AggregatedIn).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				log.Errorf("content %d's aggregatedIn zone %d not found in DB", content.ID, content.AggregatedIn)
+			}
 			return err
 		}
+
 		if zone.Active {
 			// don't unpin content belonging to a pinned aggregate
 			return fmt.Errorf("unable to unpin content belonging to a pinned aggregate (pin: %d, zone: %d)", content.ID, content.AggregatedIn)


### PR DESCRIPTION
Previously was returning an error even when the zone was inactive due to the gorm query being miswritten.

Validated the delete now works in cases where the zone is not active yet, but still fails when the zone is active.