### PR TITLE
fixes duplicate collection contents

### DIFF
--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -3470,7 +3470,7 @@ func (s *apiV1) handleGetCollectionContents(c echo.Context, u *util.User) error 
 	// if queryDir is set, do the content listing
 	queryDir = filepath.Clean(queryDir)
 
-	out, err := collections.GetDirectoryContents(c, refs, queryDir, coluuid)
+	out, err := collections.GetDirectoryContents(refs, queryDir, coluuid)
 	if err != nil {
 		return err
 	}

--- a/collections/collections.go
+++ b/collections/collections.go
@@ -1,8 +1,11 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
+	"github.com/labstack/echo/v4"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -30,6 +33,29 @@ type CollectionRef struct {
 	Content    uint    `gorm:"index:,option:CONCURRENTLY;not null"`
 	Path       *string `gorm:"not null"`
 }
+
+type CidType string
+
+type CollectionListResponse struct {
+	Name      string      `json:"name"`
+	Type      CidType     `json:"type"`
+	Size      int64       `json:"size"`
+	ContID    uint        `json:"contId"`
+	Cid       *util.DbCID `json:"cid,omitempty"`
+	Dir       string      `json:"dir"`
+	ColUuid   string      `json:"coluuid"`
+	UpdatedAt time.Time   `json:"updatedAt"`
+}
+
+const (
+	CidTypeDir  CidType = "directory"
+	CidTypeFile CidType = "file"
+)
+
+const (
+	ERR_INTERNAL_SERVER = "ERR_INTERNAL_SERVER"
+	ERR_BAD_REQUEST     = "ERR_BAD_REQUEST"
+)
 
 func GetCollection(coluuid string, db *gorm.DB, u *util.User) (Collection, error) {
 	var col Collection
@@ -74,4 +100,100 @@ func GetContentsInPath(coluuid string, path string, db *gorm.DB, u *util.User) (
 	}
 
 	return selectedRefs, nil
+}
+
+func GetDirectoryContents(c echo.Context, refs []util.ContentWithPath, queryDir, coluuid string) ([]CollectionListResponse, error) {
+	dirs := make(map[string]bool)
+	var result []CollectionListResponse
+	for _, r := range refs {
+		directoryContent, traversedDirectories, err := getDirectoryContent(r, dirs, queryDir, coluuid)
+		dirs = traversedDirectories
+
+		if err != nil {
+			if err == errors.New(ERR_INTERNAL_SERVER) {
+				return nil, c.JSON(http.StatusInternalServerError, fmt.Errorf("errored while calculating relative contentPath queryDir=%s, contentPath=%s", queryDir, r.Path))
+			}
+
+			if err == errors.New(ERR_BAD_REQUEST) {
+				return nil, c.JSON(http.StatusInternalServerError, fmt.Errorf("errored while calculating relative contentPath queryDir=%s, contentPath=%s", queryDir, r.Path))
+			}
+			return nil, err
+		}
+
+		if directoryContent == (CollectionListResponse{}) {
+			result = append(result, directoryContent)
+		}
+	}
+	return result, nil
+}
+
+func getDirectoryContent(r util.ContentWithPath, dirs map[string]bool, queryDir, coluuid string) (CollectionListResponse, map[string]bool, error) {
+	if r.Path == "" || r.Name == "" {
+		return CollectionListResponse{}, dirs, nil
+	}
+
+	if !strings.HasPrefix(r.Path, queryDir) {
+		return CollectionListResponse{}, dirs, nil
+	}
+
+	relp, err := getRelativePath(r, queryDir)
+	if err != nil {
+		//return collections.CollectionListResponse{}, dirs, c.JSON(http.StatusInternalServerError, fmt.Errorf("errored while calculating relative contentPath queryDir=%s, contentPath=%s", queryDir, r.Path))
+		return CollectionListResponse{}, dirs, errors.New(ERR_INTERNAL_SERVER)
+	}
+
+	// Query directory is the complete path containing the content.
+	if relp == "." {
+		// trying to list a CID queryDir, not allowed
+		if r.Type == util.Directory {
+			//return collections.CollectionListResponse{}, dirs, c.JSON(http.StatusBadRequest, fmt.Errorf("listing CID directories is not allowed"))
+			return CollectionListResponse{}, dirs, errors.New(ERR_BAD_REQUEST)
+		}
+
+		return CollectionListResponse{
+			Name:      r.Name,
+			Type:      CidTypeFile,
+			Size:      r.Size,
+			ContID:    r.ID,
+			Cid:       &util.DbCID{CID: r.Cid.CID},
+			Dir:       queryDir,
+			ColUuid:   coluuid,
+			UpdatedAt: r.UpdatedAt,
+		}, dirs, nil
+	}
+
+	// Query directory has a subdirectory, which contains the actual content.
+	// if relative contentPath has a /, the file is in a subdirectory
+	// print the directory the file is in if we haven't already
+	if strings.Contains(relp, "/") {
+		parts := strings.Split(relp, "/")
+		subDir := parts[0]
+		if !dirs[subDir] {
+			dirs[subDir] = true
+			return CollectionListResponse{
+				Name:      subDir,
+				Type:      CidTypeDir,
+				Dir:       queryDir,
+				ColUuid:   coluuid,
+				UpdatedAt: r.UpdatedAt,
+			}, dirs, nil
+		}
+	}
+
+	return CollectionListResponse{
+		Name:      r.Name,
+		Type:      CidTypeFile,
+		Size:      r.Size,
+		ContID:    r.ID,
+		Cid:       &util.DbCID{CID: r.Cid.CID},
+		Dir:       queryDir,
+		ColUuid:   coluuid,
+		UpdatedAt: r.UpdatedAt,
+	}, dirs, nil
+}
+
+func getRelativePath(r util.ContentWithPath, queryDir string) (string, error) {
+	contentPath := r.Path
+	relp, err := filepath.Rel(queryDir, contentPath)
+	return relp, err
 }

--- a/collections/collections.go
+++ b/collections/collections.go
@@ -1,9 +1,7 @@
 package collections
 
 import (
-	"errors"
 	"fmt"
-	"github.com/labstack/echo/v4"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -52,11 +50,6 @@ const (
 	CidTypeFile CidType = "file"
 )
 
-const (
-	ERR_INTERNAL_SERVER = "ERR_INTERNAL_SERVER"
-	ERR_BAD_REQUEST     = "ERR_BAD_REQUEST"
-)
-
 func GetCollection(coluuid string, db *gorm.DB, u *util.User) (Collection, error) {
 	var col Collection
 	if err := db.First(&col, "uuid = ?", coluuid).Error; err != nil {
@@ -102,64 +95,45 @@ func GetContentsInPath(coluuid string, path string, db *gorm.DB, u *util.User) (
 	return selectedRefs, nil
 }
 
-func GetDirectoryContents(c echo.Context, refs []util.ContentWithPath, queryDir, coluuid string) ([]CollectionListResponse, error) {
+func GetDirectoryContents(refs []util.ContentWithPath, queryDir, coluuid string) ([]*CollectionListResponse, error) {
 	dirs := make(map[string]bool)
-	var result []CollectionListResponse
+	var result []*CollectionListResponse
 	for _, r := range refs {
-		directoryContent, traversedDirectories, err := getDirectoryContent(r, dirs, queryDir, coluuid)
-		dirs = traversedDirectories
+		directoryContent, subDir, err := getDirectoryContent(r, queryDir, coluuid)
 
 		if err != nil {
-			if err == errors.New(ERR_INTERNAL_SERVER) {
-				return nil, c.JSON(http.StatusInternalServerError, fmt.Errorf("errored while calculating relative contentPath queryDir=%s, contentPath=%s", queryDir, r.Path))
-			}
-
-			if err == errors.New(ERR_BAD_REQUEST) {
-				return nil, c.JSON(http.StatusInternalServerError, fmt.Errorf("errored while calculating relative contentPath queryDir=%s, contentPath=%s", queryDir, r.Path))
-			}
 			return nil, err
 		}
 
-		if directoryContent == (CollectionListResponse{}) {
+		if directoryContent != nil { // if there was content
+			if directoryContent.Type == CidTypeDir { // if the content was a directory
+				if dirs[subDir] { // if the directory had already been added to response, continue
+					continue
+				}
+				dirs[subDir] = true
+			}
 			result = append(result, directoryContent)
 		}
 	}
 	return result, nil
 }
 
-func getDirectoryContent(r util.ContentWithPath, dirs map[string]bool, queryDir, coluuid string) (CollectionListResponse, map[string]bool, error) {
+func getDirectoryContent(r util.ContentWithPath, queryDir, coluuid string) (*CollectionListResponse, string, error) {
 	if r.Path == "" || r.Name == "" {
-		return CollectionListResponse{}, dirs, nil
+		return nil, "", nil
 	}
 
 	if !strings.HasPrefix(r.Path, queryDir) {
-		return CollectionListResponse{}, dirs, nil
+		return nil, "", nil
 	}
 
 	relp, err := getRelativePath(r, queryDir)
 	if err != nil {
-		//return collections.CollectionListResponse{}, dirs, c.JSON(http.StatusInternalServerError, fmt.Errorf("errored while calculating relative contentPath queryDir=%s, contentPath=%s", queryDir, r.Path))
-		return CollectionListResponse{}, dirs, errors.New(ERR_INTERNAL_SERVER)
-	}
-
-	// Query directory is the complete path containing the content.
-	if relp == "." {
-		// trying to list a CID queryDir, not allowed
-		if r.Type == util.Directory {
-			//return collections.CollectionListResponse{}, dirs, c.JSON(http.StatusBadRequest, fmt.Errorf("listing CID directories is not allowed"))
-			return CollectionListResponse{}, dirs, errors.New(ERR_BAD_REQUEST)
+		return nil, "", &util.HttpError{
+			Code:    http.StatusInternalServerError,
+			Reason:  util.ERR_INTERNAL_SERVER,
+			Details: fmt.Sprintf("errored while calculating relative contentPath queryDir=%s, contentPath=%s", queryDir, r.Path),
 		}
-
-		return CollectionListResponse{
-			Name:      r.Name,
-			Type:      CidTypeFile,
-			Size:      r.Size,
-			ContID:    r.ID,
-			Cid:       &util.DbCID{CID: r.Cid.CID},
-			Dir:       queryDir,
-			ColUuid:   coluuid,
-			UpdatedAt: r.UpdatedAt,
-		}, dirs, nil
 	}
 
 	// Query directory has a subdirectory, which contains the actual content.
@@ -168,19 +142,24 @@ func getDirectoryContent(r util.ContentWithPath, dirs map[string]bool, queryDir,
 	if strings.Contains(relp, "/") {
 		parts := strings.Split(relp, "/")
 		subDir := parts[0]
-		if !dirs[subDir] {
-			dirs[subDir] = true
-			return CollectionListResponse{
-				Name:      subDir,
-				Type:      CidTypeDir,
-				Dir:       queryDir,
-				ColUuid:   coluuid,
-				UpdatedAt: r.UpdatedAt,
-			}, dirs, nil
-		}
+		return &CollectionListResponse{
+			Name:      subDir,
+			Type:      CidTypeDir,
+			Dir:       queryDir,
+			ColUuid:   coluuid,
+			UpdatedAt: r.UpdatedAt,
+		}, subDir, nil
 	}
 
-	return CollectionListResponse{
+	// trying to list a CID queryDir, not allowed
+	if r.Type == util.Directory {
+		return nil, "", &util.HttpError{
+			Code:    http.StatusBadRequest,
+			Reason:  util.ERR_BAD_REQUEST,
+			Details: fmt.Sprintf("listing CID directories is not allowed"),
+		}
+	}
+	return &CollectionListResponse{
 		Name:      r.Name,
 		Type:      CidTypeFile,
 		Size:      r.Size,
@@ -189,7 +168,7 @@ func getDirectoryContent(r util.ContentWithPath, dirs map[string]bool, queryDir,
 		Dir:       queryDir,
 		ColUuid:   coluuid,
 		UpdatedAt: r.UpdatedAt,
-	}, dirs, nil
+	}, "", nil
 }
 
 func getRelativePath(r util.ContentWithPath, queryDir string) (string, error) {

--- a/collections/collections_test.go
+++ b/collections/collections_test.go
@@ -100,7 +100,7 @@ func runTest(t *testing.T, ref util.ContentWithPath, queryDir, coluuid string, e
 		t.Fatalf("Error: %v\n", err)
 	}
 
-	parsedResponse := &CollectionListResponse{
+	parsedResponse := CollectionListResponse{
 		Name:    response.Name,
 		Type:    response.Type,
 		Size:    response.Size,
@@ -109,7 +109,7 @@ func runTest(t *testing.T, ref util.ContentWithPath, queryDir, coluuid string, e
 		ColUuid: response.ColUuid,
 	}
 
-	if parsedResponse != expectedResponse {
-		t.Fatalf("Expected %v, got %v, %v\n", expectedResponse, response, response.Cid.CID)
+	if parsedResponse != *expectedResponse {
+		t.Fatalf("Expected %v, got %v\n", expectedResponse, response)
 	}
 }

--- a/collections/collections_test.go
+++ b/collections/collections_test.go
@@ -33,7 +33,7 @@ func TestSubDirectory(t *testing.T) {
 		Dir:     queryDir,
 		ColUuid: coluuid,
 	}
-	runTest(t, ref, queryDir, coluuid, expectedResponse)
+	runTest(t, ref, queryDir, coluuid, &expectedResponse)
 }
 
 func TestSubDirectory2(t *testing.T) {
@@ -47,7 +47,7 @@ func TestSubDirectory2(t *testing.T) {
 		Dir:     queryDir,
 		ColUuid: coluuid,
 	}
-	runTest(t, ref, queryDir, coluuid, expectedResponse)
+	runTest(t, ref, queryDir, coluuid, &expectedResponse)
 }
 
 func TestSubDirectoryWithFileInIt(t *testing.T) {
@@ -61,7 +61,7 @@ func TestSubDirectoryWithFileInIt(t *testing.T) {
 		Dir:     queryDir,
 		ColUuid: coluuid,
 	}
-	runTest(t, ref, queryDir, coluuid, expectedResponse)
+	runTest(t, ref, queryDir, coluuid, &expectedResponse)
 }
 
 func TestFullPath(t *testing.T) {
@@ -75,25 +75,32 @@ func TestFullPath(t *testing.T) {
 		Dir:     queryDir,
 		ColUuid: coluuid,
 	}
-	runTest(t, ref, queryDir, coluuid, expectedResponse)
+	runTest(t, ref, queryDir, coluuid, &expectedResponse)
 }
 
 func TestInvalidDirectory(t *testing.T) {
 	ref := setupRef()
 	queryDir := "/dir0"
-	expectedResponse := CollectionListResponse{}
-	runTest(t, ref, queryDir, coluuid, expectedResponse)
+	response, _, err := getDirectoryContent(ref, queryDir, "collection uuid")
+
+	if err != nil {
+		t.Fatalf("Error: %v\n", err)
+	}
+
+	if response != nil {
+		t.Fatalf("Expected nil response but got %v\n", response)
+	}
 
 }
 
-func runTest(t *testing.T, ref util.ContentWithPath, queryDir, coluuid string, expectedResponse CollectionListResponse) {
+func runTest(t *testing.T, ref util.ContentWithPath, queryDir, coluuid string, expectedResponse *CollectionListResponse) {
 	response, _, err := getDirectoryContent(ref, queryDir, coluuid)
 
 	if err != nil {
 		t.Fatalf("Error: %v\n", err)
 	}
 
-	parsedResponse := CollectionListResponse{
+	parsedResponse := &CollectionListResponse{
 		Name:    response.Name,
 		Type:    response.Type,
 		Size:    response.Size,

--- a/collections/collections_test.go
+++ b/collections/collections_test.go
@@ -87,8 +87,7 @@ func TestInvalidDirectory(t *testing.T) {
 }
 
 func runTest(t *testing.T, ref util.ContentWithPath, queryDir, coluuid string, expectedResponse CollectionListResponse) {
-	dirs := make(map[string]bool)
-	response, _, err := getDirectoryContent(ref, dirs, queryDir, coluuid)
+	response, _, err := getDirectoryContent(ref, queryDir, coluuid)
 
 	if err != nil {
 		t.Fatalf("Error: %v\n", err)

--- a/collections/collections_test.go
+++ b/collections/collections_test.go
@@ -1,0 +1,109 @@
+package collections
+
+import (
+	"github.com/application-research/estuary/util"
+	"testing"
+)
+
+const (
+	name        = "a"
+	contentPath = "/dir1/dir2/dir3/a"
+	contentId   = uint(1)
+	coluuid     = "collection uuid"
+)
+
+func setupRef() util.ContentWithPath {
+	return util.ContentWithPath{
+		Path: contentPath,
+		Content: util.Content{
+			ID:   contentId,
+			Name: name,
+		},
+	}
+}
+
+func TestSubDirectory(t *testing.T) {
+	ref := setupRef()
+	queryDir := "/dir1"
+	expectedResponse := CollectionListResponse{
+		Name:    "dir2",
+		Type:    CidTypeDir,
+		Size:    0,
+		ContID:  0,
+		Dir:     queryDir,
+		ColUuid: coluuid,
+	}
+	runTest(t, ref, queryDir, coluuid, expectedResponse)
+}
+
+func TestSubDirectory2(t *testing.T) {
+	ref := setupRef()
+	queryDir := "/dir1/dir2"
+	expectedResponse := CollectionListResponse{
+		Name:    "dir3",
+		Type:    CidTypeDir,
+		Size:    0,
+		ContID:  0,
+		Dir:     queryDir,
+		ColUuid: coluuid,
+	}
+	runTest(t, ref, queryDir, coluuid, expectedResponse)
+}
+
+func TestSubDirectoryWithFileInIt(t *testing.T) {
+	ref := setupRef()
+	queryDir := "/dir1/dir2/dir3"
+	expectedResponse := CollectionListResponse{
+		Name:    name,
+		Type:    CidTypeFile,
+		Size:    0,
+		ContID:  contentId,
+		Dir:     queryDir,
+		ColUuid: coluuid,
+	}
+	runTest(t, ref, queryDir, coluuid, expectedResponse)
+}
+
+func TestFullPath(t *testing.T) {
+	ref := setupRef()
+	queryDir := "/dir1/dir2/dir3/a"
+	expectedResponse := CollectionListResponse{
+		Name:    name,
+		Type:    CidTypeFile,
+		Size:    0,
+		ContID:  contentId,
+		Dir:     queryDir,
+		ColUuid: coluuid,
+	}
+	runTest(t, ref, queryDir, coluuid, expectedResponse)
+}
+
+func TestInvalidDirectory(t *testing.T) {
+	ref := setupRef()
+	queryDir := "/dir0"
+	expectedResponse := CollectionListResponse{}
+	runTest(t, ref, queryDir, coluuid, expectedResponse)
+
+}
+
+func runTest(t *testing.T, ref util.ContentWithPath, queryDir, coluuid string, expectedResponse CollectionListResponse) {
+	dirs := make(map[string]bool)
+	response, _, err := getDirectoryContent(ref, dirs, queryDir, coluuid)
+
+	if err != nil {
+		t.Fatalf("Error: %v\n", err)
+	}
+
+	parsedResponse := CollectionListResponse{
+		Name:    response.Name,
+		Type:    response.Type,
+		Size:    response.Size,
+		ContID:  response.ContID,
+		Dir:     response.Dir,
+		ColUuid: response.ColUuid,
+	}
+
+	if parsedResponse != expectedResponse {
+		t.Fatalf("Expected %v, got %v, %v\n", expectedResponse, response, response.Cid.CID)
+	}
+}

--- a/util/http.go
+++ b/util/http.go
@@ -16,7 +16,7 @@ import (
 
 var log = logging.Logger("util")
 
-//#nosec G101 -- This is a false positive
+// #nosec G101 -- This is a false positive
 const (
 	ERR_INVALID_TOKEN                                      = "ERR_INVALID_TOKEN"
 	ERR_TOKEN_EXPIRED                                      = "ERR_TOKEN_EXPIRED"
@@ -55,6 +55,8 @@ const (
 	ERR_INVALID_MINER_CLAIM_POWER_BELOW_1TIB               = "ERR_INVALID_MINER_CLAIM_POWER_BELOW_1TIB"
 	ERR_INVALID_MINER_CLAIM_NO_ASK                         = "ERR_INVALID_MINER_CLAIM_NO_ASK"
 	ERR_INVALID_MINER_CLAIM_ASK_VERIFIED_PRICE_IS_NOT_ZERO = "ERR_INVALID_MINER_CLAIM_ASK_VERIFIED_PRICE_IS_NOT_ZERO"
+	ERR_INTERNAL_SERVER                                    = "ERR_INTERNAL_SERVER"
+	ERR_BAD_REQUEST                                        = "ERR_BAD_REQUEST"
 )
 
 const (


### PR DESCRIPTION
fixes https://github.com/application-research/estuary/issues/699

Test:

```
anjor@seven ~ $ curl -k "http://localhost:3004/collections/$coluuid?dir=/" -H "Authorization: Bearer $(cat ~/.estuary_local)" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   158  100   158    0     0  29867      0 --:--:-- --:--:-- --:--:--  154k
[
  {
    "name": "dir1",
    "type": "directory",
    "size": 0,
    "contId": 0,
    "dir": "/",
    "coluuid": "b9f372de-0301-4fc3-b70d-53a140b06143",
    "updatedAt": "2022-12-07T23:02:06.151684Z"
  }
]
anjor@seven ~ $ curl -k "http://localhost:3004/collections/$coluuid?dir=/dir1" -H "Authorization: Bearer $(cat ~/.estuary_local)" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0  47011      0 --:--:-- --:--:-- --:--:--  158k
[
  {
    "name": "dir2",
    "type": "directory",
    "size": 0,
    "contId": 0,
    "dir": "/dir1",
    "coluuid": "b9f372de-0301-4fc3-b70d-53a140b06143",
    "updatedAt": "2022-12-07T23:02:06.151684Z"
  }
]
anjor@seven ~ $ curl -k "http://localhost:3004/collections/$coluuid?dir=/dir1/dir2" -H "Authorization: Bearer $(cat ~/.estuary_local)" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   394  100   394    0     0   106k      0 --:--:-- --:--:-- --:--:--  384k
[
  {
    "name": "a",
    "type": "file",
    "size": 13,
    "contId": 85,
    "cid": "bafkreidame73g74ml6273rlrqp5vmii5s3e37nps6guduwlguei3k4ia54",
    "dir": "/dir1/dir2",
    "coluuid": "b9f372de-0301-4fc3-b70d-53a140b06143",
    "updatedAt": "2022-12-07T23:02:06.151684Z"
  },
  {
    "name": "dir3",
    "type": "directory",
    "size": 0,
    "contId": 0,
    "dir": "/dir1/dir2",
    "coluuid": "b9f372de-0301-4fc3-b70d-53a140b06143",
    "updatedAt": "2022-12-08T09:35:40.964261Z"
  }
]
anjor@seven ~ $ curl -k "http://localhost:3004/collections/$coluuid?dir=/dir1/dir2/a" -H "Authorization: Bearer $(cat ~/.estuary_local)" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   231  100   231    0     0  57121      0 --:--:-- --:--:-- --:--:--  225k
[
  {
    "name": "a",
    "type": "file",
    "size": 13,
    "contId": 85,
    "cid": "bafkreidame73g74ml6273rlrqp5vmii5s3e37nps6guduwlguei3k4ia54",
    "dir": "/dir1/dir2/a",
    "coluuid": "b9f372de-0301-4fc3-b70d-53a140b06143",
    "updatedAt": "2022-12-07T23:02:06.151684Z"
  }
]
anjor@seven ~ $ curl -k "http://localhost:3004/collections/$coluuid?dir=/dir1/dir2/dir3" -H "Authorization: Bearer $(cat ~/.estuary_local)" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   235  100   235    0     0  58240      0 --:--:-- --:--:-- --:--:--  229k
[
  {
    "name": "a",
    "type": "file",
    "size": 13,
    "contId": 114,
    "cid": "bafkreidame73g74ml6273rlrqp5vmii5s3e37nps6guduwlguei3k4ia54",
    "dir": "/dir1/dir2/dir3",
    "coluuid": "b9f372de-0301-4fc3-b70d-53a140b06143",
    "updatedAt": "2022-12-08T09:35:40.964261Z"
  }
]
anjor@seven ~ $ curl -k "http://localhost:3004/collections/$coluuid?dir=/dir1/dir2/dir3/a" -H "Authorization: Bearer $(cat ~/.estuary_local)" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   237  100   237    0     0  62931      0 --:--:-- --:--:-- --:--:--  231k
[
  {
    "name": "a",
    "type": "file",
    "size": 13,
    "contId": 114,
    "cid": "bafkreidame73g74ml6273rlrqp5vmii5s3e37nps6guduwlguei3k4ia54",
    "dir": "/dir1/dir2/dir3/a",
    "coluuid": "b9f372de-0301-4fc3-b70d-53a140b06143",
    "updatedAt": "2022-12-08T09:35:40.964261Z"
  }
]
anjor@seven ~ $ curl -k "http://localhost:3004/collections/$coluuid?dir=/dir1/dir4" -H "Authorization: Bearer $(cat ~/.estuary_local)" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     5  100     5    0     0   1488      0 --:--:-- --:--:-- --:--:--  5000
null

```