### PR TITLE
make pinner peer addr to be string

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -1616,7 +1616,7 @@ func (d *Shuttle) doPinning(ctx context.Context, op *operation.PinningOperation,
 	ctx, span := d.Tracer.Start(ctx, "doPinning")
 	defer span.End()
 
-	prs, _ := operation.UnSerializePeers(op.Peers)
+	prs := operation.UnSerializePeers(op.Peers)
 	for _, pi := range prs {
 		if err := d.Node.Host.Connect(ctx, *pi); err != nil {
 			log.Warnf("failed to connect to origin node for pinning operation: %s", err)

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -176,7 +176,7 @@ func (cm *ContentManager) GetPinOperation(cont util.Content, peers []*peer.AddrI
 		Name:     cont.Name,
 		Peers:    operation.SerializePeers(peers),
 		Started:  cont.CreatedAt,
-		Status:   types.PinningStatusQueued,
+		Status:   types.GetContentPinningStatus(cont),
 		Replace:  replaceID,
 		Location: cont.Location,
 		MakeDeal: makeDeal,
@@ -428,7 +428,7 @@ func (cm *ContentManager) DoPinning(ctx context.Context, op *operation.PinningOp
 		}()
 	}
 
-	prs, _ := operation.UnSerializePeers(op.Peers)
+	prs := operation.UnSerializePeers(op.Peers)
 	for _, pi := range prs {
 		if err := cm.node.Host.Connect(ctx, *pi); err != nil {
 			cm.log.Warnf("failed to connect to origin node for pinning operation: %s", err)

--- a/pinner/pinmgr_test.go
+++ b/pinner/pinmgr_test.go
@@ -78,10 +78,10 @@ func TestEncodeDecode(t *testing.T) {
 			originsStr = string(b)
 		}
 
-		var origins2 []*peer.AddrInfo
-		_ = json.Unmarshal([]byte(originsStr), &origins2)
+		var originsUnmarshalled []*peer.AddrInfo
+		_ = json.Unmarshal([]byte(originsStr), &originsUnmarshalled)
 
-		po := &operation.PinningOperation{Peers: operation.SerializePeers(origins2), Name: "pinning operation name"}
+		po := &operation.PinningOperation{Peers: operation.SerializePeers(originsUnmarshalled), Name: "pinning operation name"}
 		bytes, err := encodeMsgPack(po)
 		if err != nil {
 			assert.Nil(t, err, "encodeMsgPack should not fail")
@@ -97,8 +97,8 @@ func TestEncodeDecode(t *testing.T) {
 		newPoPeers := operation.UnSerializePeers(newpo.Peers)
 
 		assert.Equal(t, newpo.Name, po.Name, "name doesnt match")
-		assert.Equal(t, newPoPeers[0].Addrs[0].String(), origins2[0].Addrs[0].String(), "addr doesnt match")
-		assert.Equal(t, newPoPeers[0].ID, origins2[0].ID, "ID doesnt match")
+		assert.Equal(t, newPoPeers[0].Addrs[0].String(), originsUnmarshalled[0].Addrs[0].String(), "addr doesnt match")
+		assert.Equal(t, newPoPeers[0].ID, originsUnmarshalled[0].ID, "ID doesnt match")
 	})
 }
 


### PR DESCRIPTION
I initially used bytes for the peer ID as I could not get it to work with string. I figured we did not init the peer ID correctly that was stringifying it was failing. This PR changes it to a string, so now, the operation payload is a simple object.

I have verified pinning works on both API and shuttle nodes - peers are encoded and decoded correctly.