### PR TITLE
feat: shuttle libp2p ping

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -843,14 +843,14 @@ var backoffTimer = backoff.ExponentialBackOff{
 }
 
 type Shuttle struct {
-	Node       *node.Node
-	Api        api.Gateway
-	DB         *gorm.DB
-	PinMgr     *pinner.PinManager
-	Filc       *filclient.FilClient
-	StagingMgr *stagingbs.StagingBSMgr
-
+	Node        *node.Node
+	Api         api.Gateway
+	DB          *gorm.DB
+	PinMgr      *pinner.PinManager
+	Filc        *filclient.FilClient
+	StagingMgr  *stagingbs.StagingBSMgr
 	gwayHandler *gateway.GatewayHandler
+	PPM         *PeerPingManager
 
 	Tracer trace.Tracer
 
@@ -893,7 +893,6 @@ type Shuttle struct {
 
 	apiQueueEngEnabled *bool
 	queueEng           queueng.IShuttleRpcEngine
-	PPM                PeerPingManager
 }
 
 func (d *Shuttle) isInflight(c cid.Cid) bool {

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -481,6 +481,7 @@ func main() {
 		}
 		s.Node = nd
 		s.gwayHandler = gateway.NewGatewayHandler(nd.Blockstore)
+		s.PPM = NewPPM(nd)
 
 		// send a CLI context to lotus that contains only the node "api-url" flag set, so that other flags don't accidentally conflict with lotus cli flags
 		// https://github.com/filecoin-project/lotus/blob/731da455d46cb88ee5de9a70920a2d29dec9365c/cli/util/api.go#L37

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"golang.org/x/time/rate"
 	"io"
 	"io/ioutil"
 	"net/http"
+
+	"golang.org/x/time/rate"
 
 	//#nosec G108 - exposing the profiling endpoint is expected
 	httpprof "net/http/pprof"
@@ -328,7 +329,7 @@ func main() {
 			Value: cfg.Dev,
 		},
 		&cli.StringSliceFlag{
-			Name:  "announce-addr",
+			Name: "announce-addr",
 			Usage: "specify multiaddrs that this node can be connected to	",
 			Value: cli.NewStringSlice(cfg.Node.AnnounceAddrs...),
 		},
@@ -892,6 +893,7 @@ type Shuttle struct {
 
 	apiQueueEngEnabled *bool
 	queueEng           queueng.IShuttleRpcEngine
+	PPM                PeerPingManager
 }
 
 func (d *Shuttle) isInflight(c cid.Cid) bool {

--- a/cmd/estuary-shuttle/ping.go
+++ b/cmd/estuary-shuttle/ping.go
@@ -12,6 +12,11 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
+type PeerPingManager struct {
+	*Shuttle
+	Result PingManyResult
+}
+
 type Libp2pHost struct {
 	addr   multiaddr.Multiaddr
 	peerID peer.ID
@@ -20,30 +25,30 @@ type Libp2pHost struct {
 type PingManyResult map[peer.ID]time.Duration
 
 // Ping a list of hosts, returning RTT for each of them. Errors will be ignored, unresponsive hosts will not be returned
-func (s *Shuttle) PingMany(ctx context.Context, hosts []Libp2pHost) PingManyResult {
+func (ppm PeerPingManager) PingMany(ctx context.Context, hosts []Libp2pHost) {
 	result := make(PingManyResult)
 
 	// TODO: Batch them in go funcs for faster performance
 	for _, h := range hosts {
-		res, err := s.PingOne(ctx, h.addr, h.peerID)
+		res, err := ppm.pingOne(ctx, h.addr, h.peerID)
 
 		if err == nil {
 			result[h.peerID] = *res
 		}
 	}
 
-	return result
+	ppm.Result = result
 }
 
 // Perform a libp2p network ping to a specified host, returning the Round trip time (RTT)
-func (s *Shuttle) PingOne(ctx context.Context, addr multiaddr.Multiaddr, pID peer.ID) (*time.Duration, error) {
+func (ppm PeerPingManager) pingOne(ctx context.Context, addr multiaddr.Multiaddr, pID peer.ID) (*time.Duration, error) {
 	// Add the host to the peerstore so it can be found
-	s.Node.Host.Peerstore().AddAddr(pID, addr, peerstore.TempAddrTTL)
+	ppm.Node.Host.Peerstore().AddAddr(pID, addr, peerstore.TempAddrTTL)
 
 	tctx, cancel := context.WithTimeout(ctx, time.Duration(time.Millisecond*1000))
 	defer cancel()
 
-	t, err := netPing(tctx, s.Node.Host, pID)
+	t, err := netPing(tctx, ppm.Node.Host, pID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/estuary-shuttle/ping.go
+++ b/cmd/estuary-shuttle/ping.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
@@ -48,6 +49,22 @@ func (s *Shuttle) PingOne(ctx context.Context, addr multiaddr.Multiaddr, pID pee
 	}
 
 	return &t, nil
+}
+
+// Returns a slice of the top-performing (lowest-latency) peers in the ping result.
+// Output will be truncated to the top `n`
+func GetTopPeers(p PingManyResult, n int) []peer.ID {
+	result := make([]peer.ID, 0, len(p))
+
+	for k := range p {
+		result = append(result, k)
+	}
+
+	sort.SliceStable(result, func(i, j int) bool {
+		return p[result[i]] < p[result[j]]
+	})
+
+	return result[0:n]
 }
 
 func netPing(ctx context.Context, p peer.ID, h host.Host) (time.Duration, error) {

--- a/cmd/estuary-shuttle/ping.go
+++ b/cmd/estuary-shuttle/ping.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	"github.com/multiformats/go-multiaddr"
+)
+
+// Perform a libp2p network ping to a specified multiaddr/peer, returning the Round trip time (RTT)
+func (s *Shuttle) PingOne(ctx context.Context, addr multiaddr.Multiaddr, pID peer.ID) (*time.Duration, error) {
+	// Add the host to the peerstore so it can be found
+	s.Node.Host.Peerstore().AddAddr(pID, addr, peerstore.TempAddrTTL)
+
+	tctx, cancel := context.WithTimeout(ctx, time.Duration(time.Millisecond*1000))
+	defer cancel()
+
+	t, err := netPing(tctx, pID, s.Node.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+func netPing(ctx context.Context, p peer.ID, h host.Host) (time.Duration, error) {
+	result, ok := <-ping.Ping(ctx, h, p)
+	if !ok {
+		return result.RTT, ctx.Err()
+	}
+	return result.RTT, result.Error
+}

--- a/cmd/estuary-shuttle/ping.go
+++ b/cmd/estuary-shuttle/ping.go
@@ -43,7 +43,7 @@ func (s *Shuttle) PingOne(ctx context.Context, addr multiaddr.Multiaddr, pID pee
 	tctx, cancel := context.WithTimeout(ctx, time.Duration(time.Millisecond*1000))
 	defer cancel()
 
-	t, err := netPing(tctx, pID, s.Node.Host)
+	t, err := netPing(tctx, s.Node.Host, pID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (s *Shuttle) PingOne(ctx context.Context, addr multiaddr.Multiaddr, pID pee
 
 // Returns a slice of the top-performing (lowest-latency) peers in the ping result.
 // Output will be truncated to the top `n`
-func GetTopPeers(p PingManyResult, n int) []peer.ID {
+func (p PingManyResult) GetTopPeers(n int) []peer.ID {
 	result := make([]peer.ID, 0, len(p))
 
 	for k := range p {
@@ -67,7 +67,7 @@ func GetTopPeers(p PingManyResult, n int) []peer.ID {
 	return result[0:n]
 }
 
-func netPing(ctx context.Context, p peer.ID, h host.Host) (time.Duration, error) {
+func netPing(ctx context.Context, h host.Host, p peer.ID) (time.Duration, error) {
 	result, ok := <-ping.Ping(ctx, h, p)
 	if !ok {
 		return result.RTT, ctx.Err()

--- a/cmd/estuary-shuttle/ping.go
+++ b/cmd/estuary-shuttle/ping.go
@@ -25,8 +25,16 @@ type Libp2pHost struct {
 
 type PingManyResult map[peer.ID]time.Duration
 
+func NewPPM(node *node.Node) *PeerPingManager {
+
+	return &PeerPingManager{
+		Node:   node,
+		Result: make(map[peer.ID]time.Duration),
+	}
+}
+
 // Ping a list of hosts, returning RTT for each of them. Errors will be ignored, unresponsive hosts will not be returned
-func (ppm PeerPingManager) PingMany(ctx context.Context, hosts []Libp2pHost) {
+func (ppm *PeerPingManager) PingMany(ctx context.Context, hosts []Libp2pHost) {
 	result := make(PingManyResult)
 
 	// TODO: Batch them in go funcs for faster performance
@@ -42,7 +50,8 @@ func (ppm PeerPingManager) PingMany(ctx context.Context, hosts []Libp2pHost) {
 }
 
 // Perform a libp2p network ping to a specified host, returning the Round trip time (RTT)
-func (ppm PeerPingManager) pingOne(ctx context.Context, addr multiaddr.Multiaddr, pID peer.ID) (*time.Duration, error) {
+// Note: this function may take as long as 1 second to complete, while it waits for pings back from the remote host
+func (ppm *PeerPingManager) pingOne(ctx context.Context, addr multiaddr.Multiaddr, pID peer.ID) (*time.Duration, error) {
 	// Add the host to the peerstore so it can be found
 	ppm.Node.Host.Peerstore().AddAddr(pID, addr, peerstore.TempAddrTTL)
 

--- a/cmd/estuary-shuttle/ping.go
+++ b/cmd/estuary-shuttle/ping.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/application-research/estuary/node"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
@@ -13,7 +14,7 @@ import (
 )
 
 type PeerPingManager struct {
-	*Shuttle
+	Node   *node.Node
 	Result PingManyResult
 }
 

--- a/cmd/estuary-shuttle/ping.go
+++ b/cmd/estuary-shuttle/ping.go
@@ -11,7 +11,30 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-// Perform a libp2p network ping to a specified multiaddr/peer, returning the Round trip time (RTT)
+type Libp2pHost struct {
+	addr   multiaddr.Multiaddr
+	peerID peer.ID
+}
+
+type PingManyResult map[peer.ID]time.Duration
+
+// Ping a list of hosts, returning RTT for each of them. Errors will be ignored, unresponsive hosts will not be returned
+func (s *Shuttle) PingMany(ctx context.Context, hosts []Libp2pHost) PingManyResult {
+	result := make(PingManyResult)
+
+	// TODO: Batch them in go funcs for faster performance
+	for _, h := range hosts {
+		res, err := s.PingOne(ctx, h.addr, h.peerID)
+
+		if err == nil {
+			result[h.peerID] = *res
+		}
+	}
+
+	return result
+}
+
+// Perform a libp2p network ping to a specified host, returning the Round trip time (RTT)
 func (s *Shuttle) PingOne(ctx context.Context, addr multiaddr.Multiaddr, pID peer.ID) (*time.Duration, error) {
 	// Add the host to the peerstore so it can be found
 	s.Node.Host.Peerstore().AddAddr(pID, addr, peerstore.TempAddrTTL)


### PR DESCRIPTION
closes #677 

This PR adds the `PeerPingManager`, which will be used to ping SP's. The actual ping service / communication with API node / caching of data will be done in a separate PR.