### PR TITLE
move content markers and queue out of shuttle handler

### DIFF
--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -437,12 +437,13 @@ func (s *apiV1) handleAddIpfs(c echo.Context, u *util.User) error {
 	}
 
 	makeDeal := true
-	pinstatus, pinOp, err := s.CM.PinContent(ctx, u.ID, rcid, filename, cols, origins, 0, nil, makeDeal)
+	pinstatus, pinOp, contID, err := s.CM.PinContent(ctx, u.ID, rcid, filename, cols, origins, 0, nil, makeDeal)
 	if err != nil {
 		return err
 	}
 
 	s.pinMgr.Add(pinOp)
+	s.CM.ToCheck(contID)
 
 	return c.JSON(http.StatusAccepted, pinstatus)
 }
@@ -3412,12 +3413,13 @@ func (s *apiV1) handleCommitCollection(c echo.Context, u *util.User) error {
 	ctx := c.Request().Context()
 	makeDeal := false
 
-	pinstatus, pinOp, err := s.CM.PinContent(ctx, u.ID, collectionNode.Cid(), collectionNode.Cid().String(), nil, origins, 0, nil, makeDeal)
+	pinstatus, pinOp, contID, err := s.CM.PinContent(ctx, u.ID, collectionNode.Cid(), collectionNode.Cid().String(), nil, origins, 0, nil, makeDeal)
 	if err != nil {
 		return err
 	}
 
 	s.pinMgr.Add(pinOp)
+	s.CM.ToCheck(contID)
 
 	return c.JSON(http.StatusOK, pinstatus)
 }
@@ -4654,6 +4656,8 @@ func (s *apiV1) handleCreateContent(c echo.Context, u *util.User) error {
 		return err
 	}
 
+	defer s.CM.ToCheck(content.ID)
+
 	if req.CollectionID != "" {
 		if req.CollectionDir == "" {
 			req.CollectionDir = "/"
@@ -4963,6 +4967,8 @@ func (s *apiV1) handleShuttleCreateContent(c echo.Context) error {
 	if err := s.DB.Create(content).Error; err != nil {
 		return err
 	}
+
+	s.CM.ToCheck(content.ID)
 
 	return c.JSON(http.StatusOK, util.ContentCreateResponse{
 		ID: content.ID,

--- a/api/v1/pinning.go
+++ b/api/v1/pinning.go
@@ -297,12 +297,14 @@ func (s *apiV1) handleAddPin(e echo.Context, u *util.User) error {
 	}
 
 	makeDeal := true
-	status, pinOp, err := s.CM.PinContent(ctx, u.ID, obj, pin.Name, cols, origins, 0, pin.Meta, makeDeal)
+	status, pinOp, contID, err := s.CM.PinContent(ctx, u.ID, obj, pin.Name, cols, origins, 0, pin.Meta, makeDeal)
 	if err != nil {
 		return err
 	}
 
 	s.pinMgr.Add(pinOp)
+	s.CM.ToCheck(contID)
+
 	return e.JSON(http.StatusAccepted, status)
 }
 
@@ -404,12 +406,13 @@ func (s *apiV1) handleReplacePin(e echo.Context, u *util.User) error {
 	}
 
 	makeDeal := true
-	status, pinOp, err := s.CM.PinContent(e.Request().Context(), u.ID, pinCID, pin.Name, nil, origins, uint(pinID), pin.Meta, makeDeal)
+	status, pinOp, contID, err := s.CM.PinContent(e.Request().Context(), u.ID, pinCID, pin.Name, nil, origins, uint(pinID), pin.Meta, makeDeal)
 	if err != nil {
 		return err
 	}
 
 	s.pinMgr.Add(pinOp)
+	s.CM.ToCheck(contID)
 
 	return e.JSON(http.StatusAccepted, status)
 }

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -161,7 +161,7 @@ func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	return ipfsRes, pinOp, 0, nil
+	return ipfsRes, pinOp, cont.ID, nil
 }
 
 func (cm *ContentManager) GetPinOperation(cont util.Content, peers []*peer.AddrInfo, replaceID uint, makeDeal bool) *operation.PinningOperation {

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -317,23 +317,26 @@ func (cm *ContentManager) UpdatePinStatus(location string, contID uint, status t
 			return errors.Wrap(err, "failed to look up content")
 		}
 
+		// if content is already active, ignore it
 		if c.Active {
-			return fmt.Errorf("got failed pin status message from location: %s where content(%d) was already active, refusing to do anything", location, contID)
+			return nil
 		}
 
-		if c.AggregatedIn > 0 {
-			// unmark zone as consolidating if a staged content fails to pin
-			cm.MarkFinishedConsolidating(c.AggregatedIn)
+		// if an aggregate zone is failing, zone is stuck
+		// TODO - not sure if this is happening, but we should look (next pr will have a zone status), ignore for now
+		if c.Aggregate {
+			cm.log.Errorf("a zone is stuck, as an aggregate zone: %d, failed to aggregate(pin) on location: %s", c.ID, location)
+			return nil
 		}
 
 		if err := cm.db.Model(util.Content{}).Where("id = ?", contID).UpdateColumns(map[string]interface{}{
-			"active":  false,
-			"pinning": false,
-			"failed":  true,
-			// TODO: consider if we should not clear aggregated_in, but instead filter for not failed contents when aggregating
+			"active":        false,
+			"pinning":       false,
+			"failed":        true,
 			"aggregated_in": 0, // remove from staging zone so the zone can consolidate without it
 		}).Error; err != nil {
 			cm.log.Errorf("failed to mark content as failed in database: %s", err)
+			return err
 		}
 	}
 	return nil
@@ -390,14 +393,10 @@ func (cm *ContentManager) handlePinningComplete(ctx context.Context, handle stri
 		}).Error; err != nil {
 			return xerrors.Errorf("failed to update content in database: %w", err)
 		}
-
-		// if the content is a consolidated aggregate, it means aggregation has been completed and we can mark as finished
-		cm.MarkFinishedAggregating(cont.ID)
-
-		// after aggregate is done, make deal for it
-		cm.ToCheck(cont.ID)
 		return nil
 	}
+
+	// for individual content pin complete notification
 
 	objects := make([]*util.Object, 0, len(pincomp.Objects))
 	for _, o := range pincomp.Objects {

--- a/contentmgr/pinning.go
+++ b/contentmgr/pinning.go
@@ -89,16 +89,16 @@ func (cm *ContentManager) PinDelegatesForContent(cont util.Content) []string {
 	}
 }
 
-func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid, filename string, cols []*collections.CollectionRef, origins []*peer.AddrInfo, replaceID uint, meta map[string]interface{}, makeDeal bool) (*types.IpfsPinStatusResponse, *operation.PinningOperation, error) {
+func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid, filename string, cols []*collections.CollectionRef, origins []*peer.AddrInfo, replaceID uint, meta map[string]interface{}, makeDeal bool) (*types.IpfsPinStatusResponse, *operation.PinningOperation, uint, error) {
 	loc, err := cm.selectLocationForContent(ctx, obj, user)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("selecting location for content failed: %w", err)
+		return nil, nil, 0, xerrors.Errorf("selecting location for content failed: %w", err)
 	}
 
 	if replaceID > 0 {
 		// mark as replace since it will removed and so it should not be fetched anymore
 		if err := cm.db.Model(&util.Content{}).Where("id = ?", replaceID).Update("replace", true).Error; err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 	}
 
@@ -106,7 +106,7 @@ func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid
 	if meta != nil {
 		b, err := json.Marshal(meta)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 		metaStr = string(b)
 	}
@@ -115,7 +115,7 @@ func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid
 	if origins != nil {
 		b, err := json.Marshal(origins)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 		originsStr = string(b)
 	}
@@ -132,7 +132,7 @@ func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid
 		Origins:     originsStr,
 	}
 	if err := cm.db.Create(&cont).Error; err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	if len(cols) > 0 {
@@ -144,7 +144,7 @@ func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid
 			Columns:   []clause.Column{{Name: "path"}, {Name: "collection"}},
 			DoUpdates: clause.AssignmentColumns([]string{"created_at", "content"}),
 		}).Create(cols).Error; err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 	}
 
@@ -153,15 +153,15 @@ func (cm *ContentManager) PinContent(ctx context.Context, user uint, obj cid.Cid
 		pinOp = cm.GetPinOperation(cont, origins, replaceID, makeDeal)
 	} else {
 		if err := cm.PinContentOnShuttle(ctx, cont, origins, replaceID, loc, makeDeal); err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
 	}
 
 	ipfsRes, err := cm.PinStatus(cont, origins)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	return ipfsRes, pinOp, nil
+	return ipfsRes, pinOp, 0, nil
 }
 
 func (cm *ContentManager) GetPinOperation(cont util.Content, peers []*peer.AddrInfo, replaceID uint, makeDeal bool) *operation.PinningOperation {

--- a/contentmgr/staging.go
+++ b/contentmgr/staging.go
@@ -117,9 +117,9 @@ func (cm *ContentManager) runStagingBucketWorker(ctx context.Context) {
 			cm.log.Debugf("found ready staging zones: %d", len(readyZones))
 			for _, z := range readyZones {
 
-				// if this zone is no longer pinning(mean it has pinned), activate it
+				// if this zone is no longer pinning(meaning it has been pinned), activate it
 				if !z.Pinning && !z.Active {
-					if err := cm.db.Model(util.Content{}).Where("id = ?", z.ID).UpdateColumn("active", false).Error; err != nil {
+					if err := cm.db.Model(util.Content{}).Where("id = ?", z.ID).UpdateColumn("active", true).Error; err != nil {
 						cm.log.Errorf("failed to get ready staging zones: %s", err)
 					} else {
 						// aggregation has been completed and we can mark as finished

--- a/contentmgr/staging.go
+++ b/contentmgr/staging.go
@@ -116,6 +116,20 @@ func (cm *ContentManager) runStagingBucketWorker(ctx context.Context) {
 
 			cm.log.Debugf("found ready staging zones: %d", len(readyZones))
 			for _, z := range readyZones {
+
+				// if this zone is no longer pinning(mean it has pinned), activate it
+				if !z.Pinning && !z.Active {
+					if err := cm.db.Model(util.Content{}).Where("id = ?", z.ID).UpdateColumn("active", false).Error; err != nil {
+						cm.log.Errorf("failed to get ready staging zones: %s", err)
+					} else {
+						// aggregation has been completed and we can mark as finished
+						cm.MarkFinishedAggregating(z.ID)
+						// after aggregate is done, make deal for it
+						cm.ToCheck(z.ID)
+					}
+					continue
+				}
+
 				if err := cm.processStagingZone(ctx, z); err != nil {
 					cm.log.Errorf("content aggregation failed (zone %d): %s", z.ID, err)
 					continue
@@ -125,10 +139,11 @@ func (cm *ContentManager) runStagingBucketWorker(ctx context.Context) {
 	}
 }
 
+// getReadyStagingZones gets zones that are not activated yet (but could have been pinned)
 func (cm *ContentManager) getReadyStagingZones() ([]util.Content, error) {
 	var readyZones []util.Content
 	if err := cm.db.Model(&util.Content{}).
-		Where("not active and pinning and aggregate and size >= ?", constants.MinDealContentSize).
+		Where("not active and aggregate and size >= ?", constants.MinDealContentSize).
 		Find(&readyZones).Error; err != nil {
 		return nil, err
 	}
@@ -173,6 +188,12 @@ func (cm *ContentManager) IsZoneConsolidating(zoneID uint) bool {
 	return cm.consolidatingZones[zoneID]
 }
 
+func (cm *ContentManager) IsZoneAggregating(zoneID uint) bool {
+	cm.aggregatingZonesLk.Lock()
+	defer cm.aggregatingZonesLk.Unlock()
+	return cm.aggregatingZones[zoneID]
+}
+
 func (cm *ContentManager) MarkStartedConsolidating(zoneID uint) bool {
 	cm.consolidatingZonesLk.Lock()
 	defer cm.consolidatingZonesLk.Unlock()
@@ -188,12 +209,6 @@ func (cm *ContentManager) MarkFinishedConsolidating(zoneID uint) {
 	cm.consolidatingZonesLk.Lock()
 	delete(cm.consolidatingZones, zoneID)
 	cm.consolidatingZonesLk.Unlock()
-}
-
-func (cm *ContentManager) IsZoneAggregating(zoneID uint) bool {
-	cm.aggregatingZonesLk.Lock()
-	defer cm.aggregatingZonesLk.Unlock()
-	return cm.aggregatingZones[zoneID]
 }
 
 func (cm *ContentManager) MarkStartedAggregating(zoneID uint) bool {
@@ -243,6 +258,8 @@ func (cm *ContentManager) processStagingZone(ctx context.Context, zone util.Cont
 		}()
 		return nil
 	}
+	// if we reached here, consolidation is done and we can move to aggregating
+	cm.MarkFinishedConsolidating(zone.ID)
 
 	var loc string
 	for grpLoc := range grpLocs {
@@ -250,8 +267,6 @@ func (cm *ContentManager) processStagingZone(ctx context.Context, zone util.Cont
 		break
 	}
 
-	// if we reached here, consolidation is done and we can move to aggregating
-	cm.MarkFinishedConsolidating(zone.ID)
 	if !cm.MarkStartedAggregating(zone.ID) {
 		// skip if zone is consolidating or already aggregating
 		return nil
@@ -473,9 +488,10 @@ func (cm *ContentManager) recomputeStagingZoneSizes() error {
 	return nil
 }
 
+// getStagedContentsGroupedByLocation gets the active(pin) contents only for aggregation and consolidation
 func (cm *ContentManager) getStagedContentsGroupedByLocation(ctx context.Context, zoneID uint) (map[string][]util.Content, error) {
 	var conts []util.Content
-	if err := cm.db.Find(&conts, "aggregated_in = ?", zoneID).Error; err != nil {
+	if err := cm.db.Find(&conts, "active and aggregated_in = ?", zoneID).Error; err != nil {
 		return nil, err
 	}
 
@@ -492,7 +508,7 @@ func (cm *ContentManager) getStagedContentsGroupedByLocation(ctx context.Context
 
 func (cm *ContentManager) buildStagingZoneFromContent(zone util.Content) (*ContentStagingZone, error) {
 	var contents []util.Content
-	if err := cm.db.Find(&contents, "aggregated_in = ?", zone.ID).Error; err != nil {
+	if err := cm.db.Find(&contents, "active and aggregated_in = ?", zone.ID).Error; err != nil {
 		return nil, errors.Wrapf(err, "could not build ContentStagingZone struct from content id")
 	}
 

--- a/contentmgr/staging.go
+++ b/contentmgr/staging.go
@@ -287,6 +287,11 @@ func (cm *ContentManager) consolidateStagedContent(ctx context.Context, zone uti
 		}
 	}
 
+	//TODO (next pr) - update zone status
+	if dstLocation == "" {
+		return fmt.Errorf("zone: %d failed to consolidate as no destination location could be determined", zone.ID)
+	}
+
 	// okay, move everything to 'primary'
 	var toMove []util.Content
 	for loc, conts := range contentByLoc {
@@ -297,21 +302,9 @@ func (cm *ContentManager) consolidateStagedContent(ctx context.Context, zone uti
 
 	cm.log.Debugw("consolidating content to single location for aggregation", "user", zone.UserID, "dstLocation", dstLocation, "numItems", len(toMove), "primaryWeight", curMax)
 	if dstLocation == constants.ContentLocationLocal {
-		defer cm.MarkFinishedConsolidating(zone.ID)
 		return cm.migrateContentsToLocalNode(ctx, toMove)
-	} else if dstLocation != "" {
-		if err := cm.SendConsolidateContentCmd(ctx, dstLocation, toMove); err != nil {
-			// unmark as consolidating and retry later if failed to send consolidate cmd
-			cm.MarkFinishedConsolidating(zone.ID)
-			return err
-		}
-		return nil
-	} else {
-		// unable to find a destination location, unmark as consolidating and let it retry later
-		cm.log.Warnf("unable to find a destination location for consolidating zone: %d", zone.ID)
-		cm.MarkFinishedConsolidating(zone.ID)
-		return nil
 	}
+	return cm.SendConsolidateContentCmd(ctx, dstLocation, toMove)
 }
 
 // AggregateStagingZone assumes zone is already in consolidatingZones


### PR DESCRIPTION
This is the first PR to get queue messaging for IPC between shuttles and the API node to work. The shuttle handlers will no longer be aware of the content markers' state and content queue state. 

It also takes the markers closer to where there are needed, and they are driven by the staging worker that uses them.