### PR TITLE
Refactored KeyProviderFunc to prevent Memory Leakage

### DIFF
--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -409,7 +409,7 @@ func main() {
 		}
 
 		init := Initializer{&cfg.Node, db}
-		nd, err := node.Setup(context.TODO(), init)
+		nd, err := node.Setup(context.TODO(), &init)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Refactored `KeyProviderFunc` to pull data in batches to enforce garbage collection of large active content and pin sets:

Call/heap mem pprof of prod points to the goroutine in `KeyProviderFunc`:

![image](https://user-images.githubusercontent.com/1556714/206811826-8f4b3bf0-dcc8-4b5a-ac3f-b7a7e2a43b96.png)

**Test 1 integration - control:**

With the existing KeyProviderFunc call, the Sys Memory continues to crawl upwards as the VM garbage collector levels off, due to a single large query and serialization of Content or Pin models into memory.

```
Alloc = 2 MiB   TotalAlloc = 4 MiB      Sys = 15 MiB    NumGC = 1
Alloc = 18 MiB  TotalAlloc = 80 MiB     Sys = 53 MiB    NumGC = 12
Alloc = 74 MiB  TotalAlloc = 242 MiB    Sys = 135 MiB   NumGC = 17
Alloc = 123 MiB TotalAlloc = 387 MiB    Sys = 213 MiB   NumGC = 19
Alloc = 151 MiB TotalAlloc = 566 MiB    Sys = 261 MiB   NumGC = 21
Alloc = 193 MiB TotalAlloc = 712 MiB    Sys = 342 MiB   NumGC = 22
Alloc = 249 MiB TotalAlloc = 899 MiB    Sys = 443 MiB   NumGC = 23
Alloc = 291 MiB TotalAlloc = 1103 MiB   Sys = 568 MiB   NumGC = 24
Alloc = 381 MiB TotalAlloc = 1193 MiB   Sys = 570 MiB   NumGC = 24
Alloc = 400 MiB TotalAlloc = 1417 MiB   Sys = 725 MiB   NumGC = 25
Alloc = 422 MiB TotalAlloc = 1694 MiB   Sys = 916 MiB   NumGC = 26
Alloc = 539 MiB TotalAlloc = 1812 MiB   Sys = 917 MiB   NumGC = 26
Alloc = 525 MiB TotalAlloc = 2117 MiB   Sys = 919 MiB   NumGC = 27
Alloc = 617 MiB TotalAlloc = 2210 MiB   Sys = 919 MiB   NumGC = 27
Alloc = 704 MiB TotalAlloc = 2297 MiB   Sys = 920 MiB   NumGC = 27
Alloc = 669 MiB TotalAlloc = 2662 MiB   Sys = 1220 MiB  NumGC = 28
Alloc = 761 MiB TotalAlloc = 2753 MiB   Sys = 1221 MiB  NumGC = 28
Alloc = 845 MiB TotalAlloc = 2838 MiB   Sys = 1222 MiB  NumGC = 28
Alloc = 1294 MiB        TotalAlloc = 3286 MiB   Sys = 1592 MiB  NumGC = 28
Alloc = 878 MiB TotalAlloc = 3367 MiB   Sys = 1592 MiB  NumGC = 29
Alloc = 950 MiB TotalAlloc = 3439 MiB   Sys = 1593 MiB  NumGC = 29
Alloc = 1034 MiB        TotalAlloc = 3522 MiB   Sys = 1594 MiB  NumGC = 29
Alloc = 1129 MiB        TotalAlloc = 3618 MiB   Sys = 1596 MiB  NumGC = 29
Alloc = 1032 MiB        TotalAlloc = 4140 MiB   Sys = 2059 MiB  NumGC = 30
Alloc = 1119 MiB        TotalAlloc = 4228 MiB   Sys = 2059 MiB  NumGC = 30
Alloc = 1196 MiB        TotalAlloc = 4305 MiB   Sys = 2060 MiB  NumGC = 30
Alloc = 1286 MiB        TotalAlloc = 4394 MiB   Sys = 2061 MiB  NumGC = 30
Alloc = 1381 MiB        TotalAlloc = 4489 MiB   Sys = 2063 MiB  NumGC = 30
Alloc = 1465 MiB        TotalAlloc = 4573 MiB   Sys = 2065 MiB  NumGC = 30
Alloc = 1327 MiB        TotalAlloc = 5216 MiB   Sys = 2644 MiB  NumGC = 31
Alloc = 1400 MiB        TotalAlloc = 5289 MiB   Sys = 2644 MiB  NumGC = 31
Alloc = 1489 MiB        TotalAlloc = 5378 MiB   Sys = 2645 MiB  NumGC = 31

Final Sys Memory: 2645 MiB
```

**Test 2 integration - using batched pulls**

Utilizing gorm's `FindInBatches` function allows the Garbage collector to clean up the memory in batches. As you can see, the Garbage Collector consistently cleans up memory, keeping it at a reasonable consistent baseline.

```
Alloc = 1 MiB   TotalAlloc = 4 MiB      Sys = 16 MiB    NumGC = 2
Alloc = 25 MiB  TotalAlloc = 92 MiB     Sys = 61 MiB    NumGC = 14
Alloc = 74 MiB  TotalAlloc = 281 MiB    Sys = 162 MiB   NumGC = 19
Alloc = 46 MiB  TotalAlloc = 429 MiB    Sys = 162 MiB   NumGC = 24
Alloc = 18 MiB  TotalAlloc = 617 MiB    Sys = 190 MiB   NumGC = 28
Alloc = 57 MiB  TotalAlloc = 778 MiB    Sys = 190 MiB   NumGC = 34
Alloc = 18 MiB  TotalAlloc = 928 MiB    Sys = 190 MiB   NumGC = 38
Alloc = 74 MiB  TotalAlloc = 1115 MiB   Sys = 190 MiB   NumGC = 43
Alloc = 45 MiB  TotalAlloc = 1263 MiB   Sys = 190 MiB   NumGC = 48
Alloc = 110 MiB TotalAlloc = 1430 MiB   Sys = 190 MiB   NumGC = 51
Alloc = 59 MiB  TotalAlloc = 1615 MiB   Sys = 190 MiB   NumGC = 58
Alloc = 26 MiB  TotalAlloc = 1789 MiB   Sys = 190 MiB   NumGC = 63
Alloc = 88 MiB  TotalAlloc = 1964 MiB   Sys = 190 MiB   NumGC = 67
Alloc = 48 MiB  TotalAlloc = 2127 MiB   Sys = 190 MiB   NumGC = 73
Alloc = 24 MiB  TotalAlloc = 2302 MiB   Sys = 190 MiB   NumGC = 77
Alloc = 69 MiB  TotalAlloc = 2501 MiB   Sys = 190 MiB   NumGC = 83
Alloc = 42 MiB  TotalAlloc = 2650 MiB   Sys = 190 MiB   NumGC = 88
Alloc = 96 MiB  TotalAlloc = 2806 MiB   Sys = 190 MiB   NumGC = 91
Alloc = 57 MiB  TotalAlloc = 2971 MiB   Sys = 190 MiB   NumGC = 97
Alloc = 29 MiB  TotalAlloc = 3157 MiB   Sys = 190 MiB   NumGC = 102
Alloc = 77 MiB  TotalAlloc = 3345 MiB   Sys = 190 MiB   NumGC = 107
Alloc = 46 MiB  TotalAlloc = 3518 MiB   Sys = 190 MiB   NumGC = 113
Alloc = 24 MiB  TotalAlloc = 3696 MiB   Sys = 190 MiB   NumGC = 117
Alloc = 72 MiB  TotalAlloc = 3898 MiB   Sys = 190 MiB   NumGC = 123
Alloc = 48 MiB  TotalAlloc = 4077 MiB   Sys = 190 MiB   NumGC = 129
Alloc = 25 MiB  TotalAlloc = 4255 MiB   Sys = 190 MiB   NumGC = 134
Alloc = 74 MiB  TotalAlloc = 4458 MiB   Sys = 190 MiB   NumGC = 140
Alloc = 54 MiB  TotalAlloc = 4642 MiB   Sys = 190 MiB   NumGC = 146
Alloc = 23 MiB  TotalAlloc = 4833 MiB   Sys = 190 MiB   NumGC = 151
Alloc = 76 MiB  TotalAlloc = 5018 MiB   Sys = 190 MiB   NumGC = 156
Alloc = 41 MiB  TotalAlloc = 5160 MiB   Sys = 190 MiB   NumGC = 161
Alloc = 110 MiB TotalAlloc = 5331 MiB   Sys = 190 MiB   NumGC = 164
Alloc = 59 MiB  TotalAlloc = 5482 MiB   Sys = 190 MiB   NumGC = 170

Final Sys Memory: 190 MiB
```