### PR TITLE
fix: by-cid endpoint to check version explicitly

### DIFF
--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -70,7 +70,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	_ "github.com/application-research/estuary/docs"
-	"github.com/multiformats/go-multihash"
 )
 
 func serveCpuProfile(c echo.Context) error {
@@ -1209,9 +1208,9 @@ func (s *apiV1) handleGetContentByCid(c echo.Context) error {
 	}
 
 	v0 := cid.Undef
-	dec, err := multihash.Decode(obj.Hash())
+
 	if err == nil {
-		if dec.Code == multihash.SHA2_256 || dec.Length == 32 {
+		if obj.Prefix().Version == 0 {
 			v0 = cid.NewCidV0(obj.Hash())
 		}
 	}


### PR DESCRIPTION
The `/verify/by-cid` endpoint now properly determines the CID version based on the prefix, instead of checking the codec and length. 

The previous approach caused it to mistakenly determine that it was V1 if the length was `32` as the condition was `|| length = 32`