### PR TITLE
Add /content/contents endpoint, include PinningStatus in Content

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -130,6 +130,7 @@ func (s *apiV1) RegisterRoutes(e *echo.Echo) {
 	content.GET("/by-cid/:cid", s.handleGetContentByCid)
 	content.GET("/:cont_id", withUser(s.handleGetContent))
 	content.GET("/stats", withUser(s.handleStats))
+	content.GET("/contents", withUser(s.handleGetUserContents))
 	content.GET("/ensure-replication/:datacid", s.handleEnsureReplication)
 	content.GET("/status/:id", withUser(s.handleContentStatus))
 	content.GET("/list", withUser(s.handleListContent))

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1113,6 +1113,54 @@ const docTemplate = `{
                 }
             }
         },
+        "/content/contents": {
+            "get": {
+                "description": "This endpoint is used to get user contents",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "content"
+                ],
+                "summary": "Get user contents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "limit",
+                        "name": "limit",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "offset",
+                        "name": "offset",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/util.HttpError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/util.HttpError"
+                        }
+                    }
+                }
+            }
+        },
         "/content/create": {
             "post": {
                 "description": "This endpoint adds a new content",
@@ -3554,13 +3602,15 @@ const docTemplate = `{
                 "pinning",
                 "pinned",
                 "failed",
-                "queued"
+                "queued",
+                "offloaded"
             ],
             "x-enum-varnames": [
                 "PinningStatusPinning",
                 "PinningStatusPinned",
                 "PinningStatusFailed",
-                "PinningStatusQueued"
+                "PinningStatusQueued",
+                "PinningStatusOffloaded"
             ]
         },
         "util.ContentAddResponse": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1106,6 +1106,54 @@
         }
       }
     },
+    "/content/contents": {
+      "get": {
+        "description": "This endpoint is used to get user contents",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "content"
+        ],
+        "summary": "Get user contents",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "limit",
+            "name": "limit",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "offset",
+            "name": "offset",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/util.HttpError"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/util.HttpError"
+            }
+          }
+        }
+      }
+    },
     "/content/create": {
       "post": {
         "description": "This endpoint adds a new content",
@@ -3547,13 +3595,15 @@
         "pinning",
         "pinned",
         "failed",
-        "queued"
+        "queued",
+        "offloaded"
       ],
       "x-enum-varnames": [
         "PinningStatusPinning",
         "PinningStatusPinned",
         "PinningStatusFailed",
-        "PinningStatusQueued"
+        "PinningStatusQueued",
+        "PinningStatusOffloaded"
       ]
     },
     "util.ContentAddResponse": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -187,12 +187,14 @@ definitions:
       - pinned
       - failed
       - queued
+      - offloaded
     type: string
     x-enum-varnames:
       - PinningStatusPinning
       - PinningStatusPinned
       - PinningStatusFailed
       - PinningStatusQueued
+      - PinningStatusOffloaded
   util.ContentAddResponse:
     properties:
       cid:
@@ -1044,6 +1046,38 @@ paths:
           schema:
             $ref: '#/definitions/util.HttpError'
       summary: Get content bandwidth
+      tags:
+        - content
+  /content/contents:
+    get:
+      description: This endpoint is used to get user contents
+      parameters:
+        - description: limit
+          in: query
+          name: limit
+          required: true
+          type: string
+        - description: offset
+          in: query
+          name: offset
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/util.HttpError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/util.HttpError'
+      summary: Get user contents
       tags:
         - content
   /content/create:

--- a/pinner/types/types.go
+++ b/pinner/types/types.go
@@ -14,11 +14,13 @@ const (
 	   - pinning    # pinning in progress; additional info can be returned in info[status_details]
 	   - pinned     # pinned successfully
 	   - failed     # pinning service was unable to finish pinning operation; additional info can be found in info[status_details]
+	   - offloaded  # content has been offloaded
 	*/
-	PinningStatusPinning PinningStatus = "pinning"
-	PinningStatusPinned  PinningStatus = "pinned"
-	PinningStatusFailed  PinningStatus = "failed"
-	PinningStatusQueued  PinningStatus = "queued"
+	PinningStatusPinning   PinningStatus = "pinning"
+	PinningStatusPinned    PinningStatus = "pinned"
+	PinningStatusFailed    PinningStatus = "failed"
+	PinningStatusQueued    PinningStatus = "queued"
+	PinningStatusOffloaded PinningStatus = "offloaded"
 )
 
 type IpfsPin struct {
@@ -50,6 +52,8 @@ func GetContentPinningStatus(cont util.Content) PinningStatus {
 		status = PinningStatusFailed
 	} else if cont.Pinning {
 		status = PinningStatusPinning
+	} else if cont.Offloaded {
+		status = PinningStatusOffloaded
 	}
 	return status
 }

--- a/util/content.go
+++ b/util/content.go
@@ -92,6 +92,8 @@ type Content struct {
 	// them (unlike with aggregates)
 	DagSplit  bool `json:"dagSplit"`
 	SplitFrom uint `json:"splitFrom"`
+
+	PinningStatus string `json:"pinningStatus" gorm:"-"`
 }
 
 type ContentWithPath struct {


### PR DESCRIPTION
1. Add `/content/contents` endpoint that is like `/content/stats` but returns actual `Content`s instead of `statsResp`
2. Include `PinningStatus` in the Content struct so it is accessible from both the `/content/contents` endpoint and the `/content/staging-zones/:staging_zone/contents` endpoint
3. Adds "offloaded" `PinningStatus`

enables https://github.com/application-research/estuary-www/pull/136