### PR TITLE
Composite index for primaryStagingLocation on contents

### DIFF
--- a/util/content.go
+++ b/util/content.go
@@ -59,7 +59,7 @@ type Content struct {
 
 	Cid         DbCID       `json:"cid"`
 	Name        string      `json:"name"`
-	UserID      uint        `json:"userId" gorm:"index"`
+	UserID      uint        `json:"userId" gorm:"index,index:idx_primaryStagingLocation"`
 	Description string      `json:"description"`
 	Size        int64       `json:"size"`
 	Type        ContentType `json:"type"`

--- a/util/content.go
+++ b/util/content.go
@@ -63,14 +63,14 @@ type Content struct {
 	Description string      `json:"description"`
 	Size        int64       `json:"size"`
 	Type        ContentType `json:"type"`
-	Active      bool        `json:"active"`
+	Active      bool        `json:"active" gorm:"index"`
 	Offloaded   bool        `json:"offloaded"`
 	Replication int         `json:"replication"`
 
 	// TODO: shift most of the 'state' booleans in here into a single state
 	// field, should make reasoning about things much simpler
 	AggregatedIn uint `json:"aggregatedIn" gorm:"index:,option:CONCURRENTLY"`
-	Aggregate    bool `json:"aggregate"`
+	Aggregate    bool `json:"aggregate" gorm:"index"`
 
 	Pinning bool   `json:"pinning"`
 	PinMeta string `json:"pinMeta"`

--- a/util/content.go
+++ b/util/content.go
@@ -63,14 +63,14 @@ type Content struct {
 	Description string      `json:"description"`
 	Size        int64       `json:"size"`
 	Type        ContentType `json:"type"`
-	Active      bool        `json:"active" gorm:"index"`
+	Active      bool        `json:"active" gorm:"index:idx_primaryStagingLocation"`
 	Offloaded   bool        `json:"offloaded"`
 	Replication int         `json:"replication"`
 
 	// TODO: shift most of the 'state' booleans in here into a single state
 	// field, should make reasoning about things much simpler
 	AggregatedIn uint `json:"aggregatedIn" gorm:"index:,option:CONCURRENTLY"`
-	Aggregate    bool `json:"aggregate" gorm:"index"`
+	Aggregate    bool `json:"aggregate" gorm:"index:idx_primaryStagingLocation"`
 
 	Pinning bool   `json:"pinning"`
 	PinMeta string `json:"pinMeta"`


### PR DESCRIPTION
~90% of our DB time is spent on this query:
![image](https://user-images.githubusercontent.com/2850013/207925300-de42c8cf-2ee6-4327-912d-9135107dda5d.png)

Link to specific query analytics: https://app.pganalyze.com/databases/-675815701/queries/5815925939?t=7d

Query itself:
![image](https://user-images.githubusercontent.com/2850013/207925426-c13b5c5e-206a-46db-a8ff-98b6cf0ec396.png)

This gets called by `primaryStagingLocation`: https://github.com/application-research/estuary/blob/a427628ba8dfd0cc71cf6f8099d539e885513091/shuttle/location.go#L82

Gorm composite index docs: https://gorm.io/docs/indexes.html#Composite-Indexes

By adding this composite index, we can avoid doing db scans on this query and it should become much faster, freeing up DB time.