### PR TITLE
Use ExpirableLRU to cache http requests with TTL

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -143,7 +143,7 @@ func (s *apiV1) RegisterRoutes(e *echo.Echo) {
 	content.GET("/deals", withUser(s.handleListContentWithDeals))
 	content.GET("/failures/:content", withUser(s.handleGetContentFailures))
 	content.GET("/bw-usage/:content", withUser(s.handleGetContentBandwidth))
-	content.GET("/staging-zones", withUser(s.handleGetStagingZoneForUser))
+	content.GET("/staging-zones", withUser(s.handleGetStagingZonesForUser))
 	content.GET("/staging-zones/:staging_zone", withUser(s.handleGetStagingZoneWithoutContents))
 	content.GET("/staging-zones/:staging_zone/contents", withUser(s.handleGetStagingZoneContents))
 	content.GET("/aggregated/:content", withUser(s.handleGetAggregatedForContent))

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -15,28 +15,29 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/whyrusleeping/memo"
+	explru "github.com/paskal/golang-lru/simplelru"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
 type apiV1 struct {
-	cfg          *config.Estuary
-	DB           *gorm.DB
-	tracer       trace.Tracer
-	Node         *node.Node
-	FilClient    *filclient.FilClient
-	Api          api.Gateway
-	CM           *contentmgr.ContentManager
-	StagingMgr   *stagingbs.StagingBSMgr
-	gwayHandler  *gateway.GatewayHandler
-	cacher       *memo.Cacher
-	minerManager miner.IMinerManager
-	pinMgr       *pinner.EstuaryPinManager
-	log          *zap.SugaredLogger
-	shuttleMgr   shuttle.IManager
-	transferMgr  transfer.IManager
+	cfg            *config.Estuary
+	DB             *gorm.DB
+	tracer         trace.Tracer
+	Node           *node.Node
+	FilClient      *filclient.FilClient
+	Api            api.Gateway
+	CM             *contentmgr.ContentManager
+	StagingMgr     *stagingbs.StagingBSMgr
+	gwayHandler    *gateway.GatewayHandler
+	cacher         *explru.ExpirableLRU
+	extendedCacher *explru.ExpirableLRU
+	minerManager   miner.IMinerManager
+	pinMgr         *pinner.EstuaryPinManager
+	log            *zap.SugaredLogger
+	shuttleMgr     shuttle.IManager
+	transferMgr    transfer.IManager
 }
 
 func NewAPIV1(
@@ -47,6 +48,8 @@ func NewAPIV1(
 	gwApi api.Gateway,
 	sbm *stagingbs.StagingBSMgr,
 	cm *contentmgr.ContentManager,
+	cacher *explru.ExpirableLRU,
+	extendedCacher *explru.ExpirableLRU,
 	mm miner.IMinerManager,
 	pinMgr *pinner.EstuaryPinManager,
 	log *zap.SugaredLogger,
@@ -55,21 +58,22 @@ func NewAPIV1(
 	transferMgr transfer.IManager,
 ) *apiV1 {
 	return &apiV1{
-		cfg:          cfg,
-		DB:           db,
-		tracer:       trc,
-		Node:         nd,
-		FilClient:    fc,
-		Api:          gwApi,
-		CM:           cm,
-		StagingMgr:   sbm,
-		gwayHandler:  gateway.NewGatewayHandler(nd.Blockstore),
-		cacher:       memo.NewCacher(),
-		minerManager: mm,
-		pinMgr:       pinMgr,
-		log:          log,
-		shuttleMgr:   shuttleMgr,
-		transferMgr:  transferMgr,
+		cfg:            cfg,
+		DB:             db,
+		tracer:         trc,
+		Node:           nd,
+		FilClient:      fc,
+		Api:            gwApi,
+		CM:             cm,
+		StagingMgr:     sbm,
+		gwayHandler:    gateway.NewGatewayHandler(nd.Blockstore),
+		cacher:         cacher,
+		extendedCacher: extendedCacher,
+		minerManager:   mm,
+		pinMgr:         pinMgr,
+		log:            log,
+		shuttleMgr:     shuttleMgr,
+		transferMgr:    transferMgr,
 	}
 }
 

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -3605,7 +3605,7 @@ func (s *apiV1) computePublicStatsWithExtensiveLookups() (*publicStatsResponse, 
 // @Failure      400  {object}  util.HttpError
 // @Failure      500  {object}  util.HttpError
 // @Router       /content/staging-zones [get]
-func (s *apiV1) handleGetStagingZoneForUser(c echo.Context, u *util.User) error {
+func (s *apiV1) handleGetStagingZonesForUser(c echo.Context, u *util.User) error {
 	key := cacheKey(c, u)
 	cached, ok := s.cacher.Get(key)
 	if ok {

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -3766,7 +3766,7 @@ type metricsDealJoin struct {
 // @Router       /public/metrics/deals-on-chain [get]
 func (s *apiV1) handleMetricsDealOnChain(c echo.Context) error {
 	key := cacheKey(c, nil)
-	cached, ok := s.cacher.Get(key)
+	cached, ok := s.extendedCacher.Get(key)
 	if ok {
 		return c.JSON(http.StatusOK, cached)
 	}
@@ -3779,7 +3779,7 @@ func (s *apiV1) handleMetricsDealOnChain(c echo.Context) error {
 		val = []*dealMetricsInfo{}
 	}
 
-	s.cacher.Add(key, val)
+	s.extendedCacher.Add(key, val)
 	return c.JSON(http.StatusOK, val)
 }
 

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -157,6 +157,8 @@ func (s *apiV1) handleStats(c echo.Context, u *util.User) error {
 	return c.JSON(http.StatusOK, out)
 }
 
+// cacheKey returns a key based on the request being made, the user associated to it, and optional tags
+// this key is used when calling Get or Add from a cache
 func cacheKey(c echo.Context, u *util.User, tags ...string) string {
 	paramNames := strings.Join(c.ParamNames(), ",")
 	paramVals := strings.Join(c.ParamValues(), ",")

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -11,7 +11,7 @@ import (
 	"github.com/application-research/filclient"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/labstack/echo/v4"
-	"github.com/whyrusleeping/memo"
+	explru "github.com/paskal/golang-lru/simplelru"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -27,7 +27,7 @@ type apiV2 struct {
 	CM           *contentmgr.ContentManager
 	StagingMgr   *stagingbs.StagingBSMgr
 	gwayHandler  *gateway.GatewayHandler
-	cacher       *memo.Cacher
+	cacher       *explru.ExpirableLRU
 	minerManager miner.IMinerManager
 	pinMgr       *pinner.EstuaryPinManager
 	log          *zap.SugaredLogger
@@ -41,6 +41,7 @@ func NewAPIV2(
 	gwApi api.Gateway,
 	sbm *stagingbs.StagingBSMgr,
 	cm *contentmgr.ContentManager,
+	cacher *explru.ExpirableLRU,
 	mm miner.IMinerManager,
 	pinMgr *pinner.EstuaryPinManager,
 	log *zap.SugaredLogger,
@@ -56,7 +57,7 @@ func NewAPIV2(
 		CM:           cm,
 		StagingMgr:   sbm,
 		gwayHandler:  gateway.NewGatewayHandler(nd.Blockstore),
-		cacher:       memo.NewCacher(),
+		cacher:       cacher,
 		minerManager: mm,
 		pinMgr:       pinMgr,
 		log:          log,

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -7,6 +7,14 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+const CacheSize = 256 * 1024 * 1024 // 256MB
+const CacheDuration = time.Second * 10
+const CachePurgeEveryDuration = time.Minute * 5
+
+const ExtendedCacheSize = 16 * 1024 * 1024 // 16MB
+const ExtendedCacheDuration = time.Minute * 60
+const ExtendedCachePurgeEveryDuration = time.Minute * 120
+
 const ContentLocationLocal = "local"
 const TopMinerSel = 15
 const MinSafeDealLifetime = 2880 * 21 // three weeks

--- a/content/staging.go
+++ b/content/staging.go
@@ -3,6 +3,7 @@ package contentmgr
 import (
 	"context"
 	"fmt"
+	pinningtypes "github.com/application-research/estuary/pinner/types"
 	"sort"
 	"time"
 
@@ -434,6 +435,10 @@ func (cm *ContentManager) GetStagingZoneContents(ctx context.Context, user uint,
 	var zoneConts []util.Content
 	if err := cm.db.Limit(limit).Offset(offset).Order("created_at desc").Find(&zoneConts, "active and user_id = ? and aggregated_in = ?", user, zc.ContID).Error; err != nil {
 		return nil, errors.Wrapf(err, "could not get contents for staging zone: %d", zc.ContID)
+	}
+
+	for i, c := range zoneConts {
+		zoneConts[i].PinningStatus = string(pinningtypes.GetContentPinningStatus(c))
 	}
 	return zoneConts, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/multiformats/go-multihash v0.2.1
+	github.com/paskal/golang-lru v0.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.8.1
@@ -98,6 +99,7 @@ require (
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	github.com/whyrusleeping/go-bs-measure v0.0.0-20220728174732-077cd42cf89d
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 )
 
 require (
@@ -341,7 +343,6 @@ require (
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 // indirect
 	google.golang.org/grpc v1.46.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1513,6 +1513,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/paskal/golang-lru v0.6.0 h1:AxWFN2KV1bv84hN2BAdIOaLKA9+GmiAJ8neLkriCLqg=
+github.com/paskal/golang-lru v0.6.0/go.mod h1:oAEZxtp7d7sRpIQHyzfpj67F1xEq/7Jp4QGQIFMKqb4=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/util/content.go
+++ b/util/content.go
@@ -94,6 +94,7 @@ type Content struct {
 	SplitFrom uint `json:"splitFrom"`
 
 	PinningStatus string `json:"pinningStatus" gorm:"-"`
+	DealStatus    string `json:"dealStatus" gorm:"-"`
 }
 
 type ContentWithPath struct {


### PR DESCRIPTION
1. Adds two `ExpirableLRU` caches for caching certain http requests with two options of TTL (10 seconds, 60 minutes).
2. Uses the 10 second cache for: `/content/contents`, `/content/staging-zones/*`, part of `/public/stats`
3. Uses the 60 minute cache for: rest of `/public/stats`, `/public/metrics/deals-on-chain`

Note: I only included the 10 second cache for apiV2 because the extended cache endpoints should be moved to metrics API, and I'm not expecting them to be rewritten under apiV2. So, there's no need for the extended cache there.