### PR TITLE
refactor shuttle connection

### DIFF
--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -4249,7 +4249,7 @@ func (s *apiV1) handleShuttleList(c echo.Context) error {
 
 	var out []util.ShuttleListResponse
 	for _, d := range shuttles {
-		isOnlinne, err := s.shuttleMgr.IsOnline(d.Handle)
+		isOnline, err := s.shuttleMgr.IsOnline(d.Handle)
 		if err != nil {
 			return err
 		}
@@ -4273,7 +4273,7 @@ func (s *apiV1) handleShuttleList(c echo.Context) error {
 			Handle:         d.Handle,
 			Token:          d.Token,
 			LastConnection: d.LastConnection,
-			Online:         isOnlinne,
+			Online:         isOnline,
 			AddrInfo:       addInf,
 			Hostname:       hn,
 			StorageStats:   sts,

--- a/cmd/estuary-shuttle/main.go
+++ b/cmd/estuary-shuttle/main.go
@@ -892,8 +892,7 @@ type Shuttle struct {
 
 	shuttleConfig *config.Shuttle
 
-	apiQueueEngEnabled *bool
-	queueEng           queueng.IShuttleRpcEngine
+	queueEng queueng.IShuttleRpcEngine
 }
 
 func (d *Shuttle) isInflight(c cid.Cid) bool {
@@ -942,12 +941,6 @@ func (d *Shuttle) runRpc(conn *websocket.Conn) (err error) {
 	if err := websocket.JSON.Send(conn, hello); err != nil {
 		return err
 	}
-
-	var hi rpcevent.Hi
-	if err := websocket.JSON.Receive(conn, &hi); err != nil {
-		return err
-	}
-	d.apiQueueEngEnabled = &hi.QueueEngEnabled
 
 	go func() {
 		defer close(readDone)

--- a/cmd/estuary-shuttle/rpc.go
+++ b/cmd/estuary-shuttle/rpc.go
@@ -87,10 +87,6 @@ func (s *Shuttle) SendSanityCheck(cc cid.Cid, errMsg string) {
 	//mark shuttle content?
 }
 
-func (d *Shuttle) apiQueueIsEnabled() bool {
-	return d.apiQueueEngEnabled != nil
-}
-
 func (d *Shuttle) shuttleQueueIsEnabled() bool {
 	return d.queueEng != nil && d.shuttleConfig.RpcEngine.Queue.Enabled
 }
@@ -101,8 +97,8 @@ func (d *Shuttle) sendRpcMessage(ctx context.Context, msg *rpcevent.Message) err
 	msg.TraceCarrier = rpcevent.NewTraceCarrier(trace.SpanFromContext(ctx).SpanContext())
 	msg.Handle = d.shuttleHandle
 
-	// use queue engine for rpc if enabled by shuttle and api
-	if d.shuttleQueueIsEnabled() && d.apiQueueIsEnabled() {
+	// use queue engine for rpc if enabled by shuttle
+	if d.shuttleQueueIsEnabled() {
 		// error if operation is not a registered topic
 		if !rpcevent.MessageTopics[msg.Op] {
 			return fmt.Errorf("%s topic has not been registered properly", msg.Op)

--- a/content/staging.go
+++ b/content/staging.go
@@ -225,7 +225,12 @@ func (cm *ContentManager) consolidateStagedContent(ctx context.Context, zoneCont
 			continue
 		}
 
-		if ntot > curMax && cm.shuttleMgr.CanAddContent(loc) {
+		canAddContent, err := cm.shuttleMgr.CanAddContent(loc)
+		if err != nil {
+			return err
+		}
+
+		if ntot > curMax && canAddContent {
 			curMax = ntot
 			dstLocation = loc
 		}

--- a/main.go
+++ b/main.go
@@ -6,12 +6,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	explru "github.com/paskal/golang-lru/simplelru"
-	"golang.org/x/time/rate"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	explru "github.com/paskal/golang-lru/simplelru"
+	"golang.org/x/time/rate"
 
 	"github.com/application-research/estuary/deal/transfer"
 	"github.com/application-research/estuary/sanitycheck"
@@ -773,7 +774,7 @@ func main() {
 		// resume all resumable legacy data transfer for local contents
 		go func() {
 			time.Sleep(time.Second * 10)
-			if err := transferMgr.RestartAllTransfersForLocation(cctx.Context, constants.ContentLocationLocal); err != nil {
+			if err := transferMgr.RestartAllTransfersForLocation(cctx.Context, constants.ContentLocationLocal, make(chan struct{})); err != nil {
 				log.Errorf("failed to restart transfers: %s", err)
 			}
 		}()
@@ -849,6 +850,7 @@ func migrateSchemas(db *gorm.DB) error {
 		&autoretrieve.PublishedBatch{},
 		&model.StagingZone{},
 		&model.StagingZoneTracker{},
+		&model.ShuttleConnection{},
 	); err != nil {
 		return err
 	}

--- a/model/shuttleconnection.go
+++ b/model/shuttleconnection.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"time"
+
+	"github.com/application-research/estuary/util"
+	"gorm.io/gorm"
+)
+
+type ShuttleConnection struct {
+	gorm.Model
+	UpdatedAt             time.Time
+	Handle                string `gorm:"unique;index"`
+	Hostname              string
+	AddrInfo              util.DbAddrInfo
+	Address               util.DbAddr
+	Private               bool
+	ContentAddingDisabled bool
+	SpaceLow              bool
+	BlockstoreSize        uint64
+	BlockstoreFree        uint64
+	PinCount              int64
+	PinQueueLength        int64
+	QueueEngEnabled       bool
+}

--- a/pinner/pinmgr_test.go
+++ b/pinner/pinmgr_test.go
@@ -352,7 +352,7 @@ func TestNDuplicateNamesNDuplicateUsersNTimes(t *testing.T) {
 
 	for k := 0; k < N; k++ {
 		for j := 0; j < N; j++ {
-			for i := 0; i < N; i++ {
+			for i := 1; i <= N; i++ {
 				pin := newPinData("name"+fmt.Sprint(i), j, i)
 				go mgr.Add(&pin)
 			}

--- a/pinner/pinmgr_test.go
+++ b/pinner/pinmgr_test.go
@@ -81,7 +81,7 @@ func TestEncodeDecode(t *testing.T) {
 		var originsUnmarshalled []*peer.AddrInfo
 		_ = json.Unmarshal([]byte(originsStr), &originsUnmarshalled)
 
-		po := &operation.PinningOperation{Peers: operation.SerializePeers(originsUnmarshalled), Name: "pinning operation name"}
+		po := &operation.PinningOperation{ContId: 1, Peers: operation.SerializePeers(originsUnmarshalled), Name: "pinning operation name"}
 		bytes, err := encodeMsgPack(po)
 		if err != nil {
 			assert.Nil(t, err, "encodeMsgPack should not fail")
@@ -157,7 +157,7 @@ func TestNUniqueNames(t *testing.T) {
 		mgr := newManager(&count)
 
 		go mgr.Run(0)
-		for i := 0; i < N; i++ {
+		for i := 1; i <= N; i++ {
 			pin := newPinData("name"+fmt.Sprint(i), i, i)
 			go mgr.Add(&pin)
 		}
@@ -173,7 +173,7 @@ func TestNUniqueNamesWorker(t *testing.T) {
 		var N = 20
 		mgr := newManager(&count)
 		go mgr.Run(5)
-		for i := 0; i < N; i++ {
+		for i := 1; i <= N; i++ {
 			pin := newPinData("name"+fmt.Sprint(i), i, i)
 			go mgr.Add(&pin)
 		}
@@ -191,7 +191,7 @@ func TestNUniqueNamesSameUserWorker(t *testing.T) {
 		mgr := newManager(&count)
 
 		for j := 0; j < N; j++ {
-			for i := 0; i < N; i++ {
+			for i := 1; i <= N; i++ {
 				pin := newPinData("name"+fmt.Sprint(i), i, i*N+j)
 				go mgr.Add(&pin)
 			}
@@ -215,7 +215,7 @@ func TestNUniqueNamesSameUser(t *testing.T) {
 		go mgr.Run(0)
 		for j := 0; j < N; j++ {
 
-			for i := 0; i < N; i++ {
+			for i := 1; i <= N; i++ {
 				pin := newPinData("name"+fmt.Sprint(i), i, i)
 				go mgr.Add(&pin)
 			}
@@ -237,8 +237,8 @@ func TestNDuplicateNamesWorker(t *testing.T) {
 		go mgr.Add(&pin)
 		time.Sleep(100 * time.Millisecond)
 
-		for i := 0; i < N; i++ {
-			pin := newPinData("name", 0, 0)
+		for i := 1; i <= N; i++ {
+			pin := newPinData("name", 0, 1)
 			go mgr.Add(&pin)
 		}
 
@@ -258,8 +258,8 @@ func TestNDuplicateNames(t *testing.T) {
 		mgr := newManager(&count)
 		go mgr.Run(0)
 
-		for i := 0; i < N; i++ {
-			pin := newPinData("name", 0, 0)
+		for i := 1; i <= N; i++ {
+			pin := newPinData("name", 0, 1)
 			go mgr.Add(&pin)
 		}
 		sleepWhileWork(mgr, 1)
@@ -277,7 +277,7 @@ func TestNDuplicateNamesNDuplicateUsersNTimeWork5Workers(t *testing.T) {
 		go mgr.Run(5)
 		for k := 0; k < N; k++ {
 			for j := 0; j < N; j++ {
-				for i := 0; i < N; i++ {
+				for i := 1; i <= N; i++ {
 					pin := newPinData("name"+fmt.Sprint(i), j, i*N+j)
 					go mgr.Add(&pin)
 				}
@@ -298,7 +298,7 @@ func TestNDuplicateNamesNDuplicateUsersNTime(t *testing.T) {
 		mgr := newManager(&count)
 		go mgr.Run(0)
 
-		for i := 0; i < N; i++ {
+		for i := 1; i <= N; i++ {
 			pin := newPinData("name"+fmt.Sprint(i), i, i)
 			go mgr.Add(&pin)
 		}
@@ -318,7 +318,7 @@ func TestNDuplicateNamesNDuplicateUsersNTimeWork(t *testing.T) {
 		go mgr.Run(1)
 		for k := 0; k < N; k++ {
 			for j := 0; j < N; j++ {
-				for i := 0; i < N; i++ {
+				for i := 1; i <= N; i++ {
 					pin := newPinData("name"+fmt.Sprint(i), j, i*N+j)
 					go mgr.Add(&pin)
 				}
@@ -373,7 +373,7 @@ func TestResumeQueue(t *testing.T) {
 		go mgr.Run(0)
 		for k := 0; k < N; k++ {
 			for j := 0; j < N; j++ {
-				for i := 0; i < N; i++ {
+				for i := 1; i <= N; i++ {
 					pin := newPinData("name"+fmt.Sprint(i), j, j*N+i)
 					go mgr.Add(&pin)
 				}

--- a/shuttle/content.go
+++ b/shuttle/content.go
@@ -15,7 +15,11 @@ func (m *manager) ConsolidateContent(ctx context.Context, loc string, contents [
 	for _, c := range contents {
 		prs := make([]*peer.AddrInfo, 0)
 
-		pr := m.AddrInfo(c.Location)
+		pr, err := m.AddrInfo(c.Location)
+		if err != nil {
+			continue
+		}
+
 		if pr != nil {
 			prs = append(prs, pr)
 		}

--- a/shuttle/location.go
+++ b/shuttle/location.go
@@ -20,7 +20,11 @@ func (m *manager) GetLocationForStorage(ctx context.Context, obj cid.Cid, uid ui
 	lowSpace := make(map[string]bool)
 	var activeShuttles []string
 
-	connectedShuttles := m.rpcMgr.GetShuttleConnections()
+	connectedShuttles, err := m.getConnections()
+	if err != nil {
+		return "", err
+	}
+
 	for _, sh := range connectedShuttles {
 		if !sh.Private && !sh.ContentAddingDisabled {
 			lowSpace[sh.Handle] = sh.SpaceLow
@@ -98,7 +102,11 @@ func (m *manager) GetLocationForRetrieval(ctx context.Context, cont util.Content
 	defer span.End()
 
 	var activeShuttles []string
-	connectedShuttles := m.rpcMgr.GetShuttleConnections()
+	connectedShuttles, err := m.getConnections()
+	if err != nil {
+		return "", err
+	}
+
 	for _, sh := range connectedShuttles {
 		if !sh.Private {
 			activeShuttles = append(activeShuttles, sh.Handle)
@@ -129,9 +137,12 @@ func (m *manager) GetLocationForRetrieval(ctx context.Context, cont util.Content
 
 // TODO: this should be a lotttttt smarter
 func (m *manager) GetPreferredUploadEndpoints(u *util.User) ([]string, error) {
-
 	var shuttles []model.Shuttle
-	connectedShuttles := m.rpcMgr.GetShuttleConnections()
+	connectedShuttles, err := m.getConnections()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, sh := range connectedShuttles {
 		if sh.ContentAddingDisabled {
 			m.log.Debugf("shuttle %+v content adding is disabled", sh)

--- a/shuttle/rpc/engines/websocket/websocket.go
+++ b/shuttle/rpc/engines/websocket/websocket.go
@@ -11,38 +11,26 @@ import (
 	"github.com/application-research/estuary/model"
 	rpcevent "github.com/application-research/estuary/shuttle/rpc/event"
 	"github.com/application-research/estuary/shuttle/rpc/types"
-	"github.com/filecoin-project/go-address"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"golang.org/x/net/websocket"
+	"github.com/application-research/estuary/util"
+	"github.com/labstack/echo/v4"
 	gwebsocket "golang.org/x/net/websocket"
 
 	"github.com/application-research/estuary/config"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var ErrNoShuttleConnection = fmt.Errorf("no connection to requested shuttle")
 
 type Connection struct {
-	Handle                string
-	Ctx                   context.Context
-	Hostname              string
-	AddrInfo              peer.AddrInfo
-	Address               address.Address
-	Private               bool
-	ContentAddingDisabled bool
-	SpaceLow              bool
-	BlockstoreSize        uint64
-	BlockstoreFree        uint64
-	PinCount              int64
-	PinQueueLength        int64
-	QueueEngEnabled       bool
-	cmds                  chan *rpcevent.Command
+	Handle string
+	Ctx    context.Context
+	cmds   chan *rpcevent.Command
 }
 
 type IEstuaryRpcEngine interface {
-	Connect(ws *gwebsocket.Conn, handle string, done chan struct{}) (func() error, func(), error)
-	GetShuttleConnections() []*Connection
+	Connect(c echo.Context, handle string, done chan struct{}) error
 	GetShuttleConnection(handle string) (*Connection, bool)
 }
 
@@ -69,115 +57,127 @@ func NewEstuaryRpcEngine(ctx context.Context, db *gorm.DB, cfg *config.Estuary, 
 	return wbsMgr
 }
 
-func (m *manager) Connect(ws *gwebsocket.Conn, handle string, done chan struct{}) (func() error, func(), error) {
-	var helloBytes []byte
-	if err := gwebsocket.Message.Receive(ws, &helloBytes); err != nil {
-		return nil, nil, err
-	}
+func (m *manager) Connect(c echo.Context, handle string, done chan struct{}) error {
+	gwebsocket.Handler(func(ws *gwebsocket.Conn) {
+		ws.MaxPayloadBytes = 128 << 20
+		defer ws.Close()
+		defer close(done)
 
-	var hello rpcevent.Hello
-	if err := json.Unmarshal(helloBytes, &hello); err != nil {
-		return nil, nil, err
-	}
-
-	b, err := json.Marshal(&rpcevent.Hi{QueueEngEnabled: m.cfg.RpcEngine.Queue.Enabled})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// tell shuttle if api supports queue engine
-	if err := gwebsocket.Message.Send(ws, b); err != nil {
-		return nil, nil, err
-	}
-
-	_, err = url.Parse(hello.Host)
-	if err != nil {
-		m.log.Errorf("shuttle had invalid hostname %q: %s", hello.Host, err)
-		hello.Host = ""
-	}
-
-	if err := m.db.Model(model.Shuttle{}).Where("handle = ?", handle).UpdateColumns(map[string]interface{}{
-		"host":            hello.Host,
-		"peer_id":         hello.AddrInfo.ID.String(),
-		"last_connection": time.Now(),
-		"private":         hello.Private,
-	}).Error; err != nil {
-		return nil, nil, err
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	sc := &Connection{
-		Handle:                handle,
-		Address:               hello.Address,
-		AddrInfo:              hello.AddrInfo,
-		Hostname:              hello.Host,
-		cmds:                  make(chan *rpcevent.Command, m.cfg.RpcEngine.Websocket.OutgoingQueueSize),
-		Ctx:                   ctx,
-		Private:               hello.Private,
-		ContentAddingDisabled: hello.ContentAddingDisabled,
-		QueueEngEnabled:       hello.QueueEngEnabled,
-	}
-
-	m.shuttlesLk.Lock()
-	m.shuttles[handle] = sc
-	m.shuttlesLk.Unlock()
-
-	closeConn := func() {
-		cancel()
-		m.shuttlesLk.Lock()
-		outd, ok := m.shuttles[handle]
-		if ok {
-			if outd == sc {
-				delete(m.shuttles, handle)
-			}
+		var helloBytes []byte
+		if err := gwebsocket.Message.Receive(ws, &helloBytes); err != nil {
+			return
 		}
+
+		var hello rpcevent.Hello
+		if err := json.Unmarshal(helloBytes, &hello); err != nil {
+			return
+		}
+
+		if _, err := url.Parse(hello.Host); err != nil {
+			m.log.Errorf("shuttle had invalid hostname %q: %s", hello.Host, err)
+			hello.Host = ""
+		}
+
+		s := &model.ShuttleConnection{
+			Handle:                handle,
+			Address:               util.DbAddr{Addr: hello.Address},
+			AddrInfo:              util.DbAddrInfo{AddrInfo: hello.AddrInfo},
+			Hostname:              hello.Host,
+			Private:               hello.Private,
+			ContentAddingDisabled: hello.ContentAddingDisabled,
+			QueueEngEnabled:       hello.QueueEngEnabled,
+			UpdatedAt:             time.Now().UTC(),
+		}
+
+		if err := m.db.Clauses(&clause.OnConflict{
+			Columns:   []clause.Column{{Name: "handle"}},
+			DoUpdates: clause.AssignmentColumns([]string{"address", "addr_info", "hostname", "private", "content_adding_disabled", "queue_eng_enabled"}),
+		}).Create(&s).Error; err != nil {
+			return
+		}
+
+		if err := m.db.Model(model.Shuttle{}).Where("handle = ?", handle).UpdateColumns(map[string]interface{}{
+			"host":            hello.Host,
+			"peer_id":         hello.AddrInfo.ID.String(),
+			"last_connection": time.Now(),
+			"private":         hello.Private,
+		}).Error; err != nil {
+			return
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		sc := &Connection{
+			cmds: make(chan *rpcevent.Command, m.cfg.RpcEngine.Websocket.OutgoingQueueSize),
+			Ctx:  ctx,
+		}
+
+		m.shuttlesLk.Lock()
+		m.shuttles[handle] = sc
 		m.shuttlesLk.Unlock()
-	}
 
-	writeWebsocket := func() {
+		// clean up on exit
+		defer func() {
+			cancel()
+			m.shuttlesLk.Lock()
+			outd, ok := m.shuttles[handle]
+			if ok {
+				if outd == sc {
+					delete(m.shuttles, handle)
+				}
+			}
+			m.shuttlesLk.Unlock()
+		}()
+
+		// write to shuttles
+		go func() {
+			for {
+				select {
+				case msg := <-sc.cmds:
+					go func() {
+						msgBytes, err := json.Marshal(msg)
+						if err != nil {
+							m.log.Errorf("failed to serialize message: %s", err)
+							return
+						}
+
+						if err = gwebsocket.Message.Send(ws, msgBytes); err != nil {
+							m.log.Errorf("failed to write command to shuttle: %s", err)
+							return
+						}
+					}()
+				case <-done:
+					return
+				}
+			}
+		}()
+
+		readWebsocket := func() error {
+			var msgBytes []byte
+			if err := gwebsocket.Message.Receive(ws, &msgBytes); err != nil {
+				return err
+			}
+
+			var msg *rpcevent.Message
+			if err := json.Unmarshal(msgBytes, &msg); err != nil {
+				return err
+			}
+
+			msg.Handle = handle
+			go func() {
+				m.rpcWebsocket <- msg
+			}()
+			return nil
+		}
+
 		for {
-			select {
-			case msg := <-sc.cmds:
-				go func() {
-					msgBytes, err := json.Marshal(msg)
-					if err != nil {
-						m.log.Errorf("failed to serialize message: %s", err)
-						return
-					}
-
-					if err = websocket.Message.Send(ws, msgBytes); err != nil {
-						m.log.Errorf("failed to write command to shuttle: %s", err)
-						return
-					}
-				}()
-			case <-done:
+			if err := readWebsocket(); err != nil {
+				m.log.Errorf("failed to read message from shuttle: %s, %s", handle, err)
 				return
 			}
 		}
-	}
-
-	readWebsocket := func() error {
-		var msgBytes []byte
-		if err := websocket.Message.Receive(ws, &msgBytes); err != nil {
-			return err
-		}
-
-		var msg *rpcevent.Message
-		if err := json.Unmarshal(msgBytes, &msg); err != nil {
-			return err
-		}
-
-		msg.Handle = handle
-		go func() {
-			m.rpcWebsocket <- msg
-		}()
-		return nil
-	}
-
-	go writeWebsocket()
-
-	return readWebsocket, closeConn, nil
+	}).ServeHTTP(c.Response(), c.Request())
+	return nil
 }
 
 func (sc *Connection) SendMessage(ctx context.Context, cmd *rpcevent.Command) error {
@@ -196,17 +196,6 @@ func (m *manager) GetShuttleConnection(handle string) (*Connection, bool) {
 	defer m.shuttlesLk.Unlock()
 	conn, isConnected := m.shuttles[handle]
 	return conn, isConnected
-}
-
-func (m *manager) GetShuttleConnections() []*Connection {
-	m.shuttlesLk.Lock()
-	defer m.shuttlesLk.Unlock()
-
-	shts := make([]*Connection, 0)
-	for _, sh := range m.shuttles {
-		shts = append(shts, sh)
-	}
-	return shts
 }
 
 func (m *manager) runWebsocketQueueProcessingWorkers(ctx context.Context, numHandlers int, handlerFn types.MessageHandlerFn) {

--- a/shuttle/rpc/rpc.go
+++ b/shuttle/rpc/rpc.go
@@ -8,6 +8,7 @@ import (
 	dealstatus "github.com/application-research/estuary/deal/status"
 	transferstatus "github.com/application-research/estuary/deal/transfer/status"
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/labstack/echo/v4"
 
 	"github.com/application-research/estuary/config"
 	"github.com/application-research/estuary/constants"
@@ -27,7 +28,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"golang.org/x/net/websocket"
 	"golang.org/x/xerrors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -42,10 +42,8 @@ type transferStatusRecord struct {
 }
 
 type IManager interface {
-	Connect(ws *websocket.Conn, handle string, done chan struct{}) (func() error, func(), error)
+	Connect(c echo.Context, handle string, done chan struct{}) error
 	SendRPCMessage(ctx context.Context, handle string, cmd *rpcevent.Command) error
-	GetShuttleConnections() []*websocketeng.Connection
-	GetShuttleConnection(handle string) (*websocketeng.Connection, bool)
 	GetTransferStatus(dealID uint) (*filclient.ChannelState, error)
 }
 
@@ -93,16 +91,8 @@ func NewEstuaryRpcManager(ctx context.Context, db *gorm.DB, cfg *config.Estuary,
 	return rpcMgr, nil
 }
 
-func (m *manager) Connect(ws *websocket.Conn, handle string, done chan struct{}) (func() error, func(), error) {
-	return m.websocketEng.Connect(ws, handle, done)
-}
-
-func (m *manager) GetShuttleConnection(handle string) (*websocketeng.Connection, bool) {
-	return m.websocketEng.GetShuttleConnection(handle)
-}
-
-func (m *manager) GetShuttleConnections() []*websocketeng.Connection {
-	return m.websocketEng.GetShuttleConnections()
+func (m *manager) Connect(c echo.Context, handle string, done chan struct{}) error {
+	return m.websocketEng.Connect(c, handle, done)
 }
 
 func (m *manager) SendRPCMessage(ctx context.Context, handle string, cmd *rpcevent.Command) error {
@@ -243,16 +233,16 @@ func (m *manager) processMessage(msg *rpcevent.Message, source string) error {
 }
 
 func (m *manager) handleRpcShuttleUpdate(ctx context.Context, handle string, param *rpcevent.ShuttleUpdate) error {
-	d, ok := m.websocketEng.GetShuttleConnection(handle)
-	if !ok {
-		return fmt.Errorf("shuttle connection not found while handling update for %q", handle)
+	if err := m.db.Model(model.ShuttleConnection{}).Where("handle = ?", handle).UpdateColumns(map[string]interface{}{
+		"space_low":        param.BlockstoreFree < (param.BlockstoreSize / 10),
+		"blockstore_free":  param.BlockstoreFree,
+		"blockstore_size":  param.BlockstoreSize,
+		"pin_count":        param.NumPins,
+		"pin_queue_length": int64(param.PinQueueSize),
+		"updated_at":       time.Now().UTC(),
+	}).Error; err != nil {
+		xerrors.Errorf("failed to update content in database: %w", err)
 	}
-
-	d.SpaceLow = param.BlockstoreFree < (param.BlockstoreSize / 10)
-	d.BlockstoreFree = param.BlockstoreFree
-	d.BlockstoreSize = param.BlockstoreSize
-	d.PinCount = param.NumPins
-	d.PinQueueLength = int64(param.PinQueueSize)
 	return nil
 }
 

--- a/shuttle/rpc/rpc.go
+++ b/shuttle/rpc/rpc.go
@@ -241,7 +241,7 @@ func (m *manager) handleRpcShuttleUpdate(ctx context.Context, handle string, par
 		"pin_queue_length": int64(param.PinQueueSize),
 		"updated_at":       time.Now().UTC(),
 	}).Error; err != nil {
-		xerrors.Errorf("failed to update content in database: %w", err)
+		return xerrors.Errorf("failed to update content in database: %w", err)
 	}
 	return nil
 }

--- a/util/database.go
+++ b/util/database.go
@@ -7,7 +7,35 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
+
+type DbAddrInfo struct {
+	AddrInfo peer.AddrInfo
+}
+
+func (dba DbAddrInfo) Scan(v interface{}) error {
+	b, ok := v.([]byte)
+	if !ok {
+		return fmt.Errorf("DbAddrs must be strings")
+	}
+
+	if len(b) == 0 {
+		return nil
+	}
+
+	var addrInfo *peer.AddrInfo
+	if err := json.Unmarshal(b, &addrInfo); err != nil {
+		return err
+	}
+
+	dba.AddrInfo = *addrInfo
+	return nil
+}
+
+func (dba DbAddrInfo) Value() (driver.Value, error) {
+	return dba.AddrInfo.MarshalJSON()
+}
 
 type DbAddr struct {
 	Addr address.Address


### PR DESCRIPTION
This will persist shuttle connection details so that commp can be calculated and deals can flow. Also, it is much better in flaky websocket connections.