### PR TITLE
exclude cmd directory for swagger entyr points so just the api endpoi…

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -865,19 +865,67 @@ const docTemplate = `{
         },
         "/content/add": {
             "post": {
-                "description": "This endpoint uploads a file.",
+                "description": "This endpoint is used to upload new content.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "content"
                 ],
-                "summary": "Upload a file",
+                "summary": "Add new content",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "File to upload",
+                        "name": "data",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filename to use for upload",
+                        "name": "filename",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Collection UUID",
+                        "name": "coluuid",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Replication value",
+                        "name": "replication",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ignore Dupes true/false",
+                        "name": "ignore-dupes",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Lazy Provide true/false",
+                        "name": "lazy-provide",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Directory",
+                        "name": "dir",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/util.ContentAddResponse"
                         }
                     },
                     "400": {
@@ -897,19 +945,42 @@ const docTemplate = `{
         },
         "/content/add-car": {
             "post": {
-                "description": "This endpoint uploads content via a car file",
+                "description": "This endpoint is used to add a car object to the network. The object can be a file or a directory.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "content"
                 ],
-                "summary": "Upload content via a car file",
+                "summary": "Add Car object",
+                "parameters": [
+                    {
+                        "description": "Car",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ignore Dupes",
+                        "name": "ignore-dupes",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filename",
+                        "name": "filename",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/util.ContentAddResponse"
                         }
                     },
                     "400": {
@@ -1338,49 +1409,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/content/importdeal": {
-            "post": {
-                "description": "This endpoint imports a deal into the shuttle.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "content"
-                ],
-                "summary": "Import a deal",
-                "parameters": [
-                    {
-                        "description": "Import a deal",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.importDealBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
-                    }
-                }
-            }
-        },
         "/content/list": {
             "get": {
                 "description": "This endpoint lists all content",
@@ -1391,47 +1419,6 @@ const docTemplate = `{
                     "content"
                 ],
                 "summary": "List all pinned content",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
-                    }
-                }
-            }
-        },
-        "/content/read/{cont}": {
-            "get": {
-                "description": "This endpoint reads content from the blockstore",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "content"
-                ],
-                "summary": "Read content",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "CID",
-                        "name": "cont",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2414,38 +2401,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/api.emptyResp"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/util.HttpError"
-                        }
-                    }
-                }
-            }
-        },
-        "/net/addrs": {
-            "get": {
-                "description": "This endpoint is used to get net addrs",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "net"
-                ],
-                "summary": "Net Addrs",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "string"
                         }
                     },
                     "400": {
@@ -3480,26 +3435,6 @@ const docTemplate = `{
                     "$ref": "#/definitions/collections.CidType"
                 },
                 "updatedAt": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.importDealBody": {
-            "type": "object",
-            "properties": {
-                "coluuid": {
-                    "type": "string"
-                },
-                "dealIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "dir": {
-                    "type": "string"
-                },
-                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -858,19 +858,67 @@
     },
     "/content/add": {
       "post": {
-        "description": "This endpoint uploads a file.",
+        "description": "This endpoint is used to upload new content.",
+        "consumes": [
+          "multipart/form-data"
+        ],
         "produces": [
           "application/json"
         ],
         "tags": [
           "content"
         ],
-        "summary": "Upload a file",
+        "summary": "Add new content",
+        "parameters": [
+          {
+            "type": "file",
+            "description": "File to upload",
+            "name": "data",
+            "in": "formData",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Filename to use for upload",
+            "name": "filename",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "description": "Collection UUID",
+            "name": "coluuid",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "Replication value",
+            "name": "replication",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Ignore Dupes true/false",
+            "name": "ignore-dupes",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Lazy Provide true/false",
+            "name": "lazy-provide",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Directory",
+            "name": "dir",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/util.ContentAddResponse"
             }
           },
           "400": {
@@ -890,19 +938,42 @@
     },
     "/content/add-car": {
       "post": {
-        "description": "This endpoint uploads content via a car file",
+        "description": "This endpoint is used to add a car object to the network. The object can be a file or a directory.",
         "produces": [
           "application/json"
         ],
         "tags": [
           "content"
         ],
-        "summary": "Upload content via a car file",
+        "summary": "Add Car object",
+        "parameters": [
+          {
+            "description": "Car",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "type": "string",
+            "description": "Ignore Dupes",
+            "name": "ignore-dupes",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filename",
+            "name": "filename",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/util.ContentAddResponse"
             }
           },
           "400": {
@@ -1331,49 +1402,6 @@
         }
       }
     },
-    "/content/importdeal": {
-      "post": {
-        "description": "This endpoint imports a deal into the shuttle.",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "content"
-        ],
-        "summary": "Import a deal",
-        "parameters": [
-          {
-            "description": "Import a deal",
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/main.importDealBody"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
-          }
-        }
-      }
-    },
     "/content/list": {
       "get": {
         "description": "This endpoint lists all content",
@@ -1384,47 +1412,6 @@
           "content"
         ],
         "summary": "List all pinned content",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
-          }
-        }
-      }
-    },
-    "/content/read/{cont}": {
-      "get": {
-        "description": "This endpoint reads content from the blockstore",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "content"
-        ],
-        "summary": "Read content",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "CID",
-            "name": "cont",
-            "in": "path",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2407,38 +2394,6 @@
             "description": "OK",
             "schema": {
               "$ref": "#/definitions/api.emptyResp"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/util.HttpError"
-            }
-          }
-        }
-      }
-    },
-    "/net/addrs": {
-      "get": {
-        "description": "This endpoint is used to get net addrs",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "net"
-        ],
-        "summary": "Net Addrs",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
             }
           },
           "400": {
@@ -3473,26 +3428,6 @@
           "$ref": "#/definitions/collections.CidType"
         },
         "updatedAt": {
-          "type": "string"
-        }
-      }
-    },
-    "main.importDealBody": {
-      "type": "object",
-      "properties": {
-        "coluuid": {
-          "type": "string"
-        },
-        "dealIDs": {
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
-        },
-        "dir": {
-          "type": "string"
-        },
-        "name": {
           "type": "string"
         }
       }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -108,19 +108,6 @@ definitions:
       updatedAt:
         type: string
     type: object
-  main.importDealBody:
-    properties:
-      coluuid:
-        type: string
-      dealIDs:
-        items:
-          type: integer
-        type: array
-      dir:
-        type: string
-      name:
-        type: string
-    type: object
   miner.ClaimMinerBody:
     properties:
       claim:
@@ -885,14 +872,46 @@ paths:
         - content
   /content/add:
     post:
-      description: This endpoint uploads a file.
+      consumes:
+        - multipart/form-data
+      description: This endpoint is used to upload new content.
+      parameters:
+        - description: File to upload
+          in: formData
+          name: data
+          required: true
+          type: file
+        - description: Filename to use for upload
+          in: formData
+          name: filename
+          type: string
+        - description: Collection UUID
+          in: query
+          name: coluuid
+          type: string
+        - description: Replication value
+          in: query
+          name: replication
+          type: integer
+        - description: Ignore Dupes true/false
+          in: query
+          name: ignore-dupes
+          type: string
+        - description: Lazy Provide true/false
+          in: query
+          name: lazy-provide
+          type: string
+        - description: Directory
+          in: query
+          name: dir
+          type: string
       produces:
         - application/json
       responses:
         "200":
           description: OK
           schema:
-            type: string
+            $ref: '#/definitions/util.ContentAddResponse'
         "400":
           description: Bad Request
           schema:
@@ -901,19 +920,34 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/util.HttpError'
-      summary: Upload a file
+      summary: Add new content
       tags:
         - content
   /content/add-car:
     post:
-      description: This endpoint uploads content via a car file
+      description: This endpoint is used to add a car object to the network. The object can be a file or a directory.
+      parameters:
+        - description: Car
+          in: body
+          name: body
+          required: true
+          schema:
+            type: string
+        - description: Ignore Dupes
+          in: query
+          name: ignore-dupes
+          type: string
+        - description: Filename
+          in: query
+          name: filename
+          type: string
       produces:
         - application/json
       responses:
         "200":
           description: OK
           schema:
-            type: string
+            $ref: '#/definitions/util.ContentAddResponse'
         "400":
           description: Bad Request
           schema:
@@ -922,7 +956,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/util.HttpError'
-      summary: Upload content via a car file
+      summary: Add Car object
       tags:
         - content
   /content/add-ipfs:
@@ -1196,34 +1230,6 @@ paths:
       summary: List all failures for a content
       tags:
         - content
-  /content/importdeal:
-    post:
-      description: This endpoint imports a deal into the shuttle.
-      parameters:
-        - description: Import a deal
-          in: body
-          name: body
-          required: true
-          schema:
-            $ref: '#/definitions/main.importDealBody'
-      produces:
-        - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: string
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/util.HttpError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/util.HttpError'
-      summary: Import a deal
-      tags:
-        - content
   /content/list:
     get:
       description: This endpoint lists all content
@@ -1243,33 +1249,6 @@ paths:
           schema:
             $ref: '#/definitions/util.HttpError'
       summary: List all pinned content
-      tags:
-        - content
-  /content/read/{cont}:
-    get:
-      description: This endpoint reads content from the blockstore
-      parameters:
-        - description: CID
-          in: path
-          name: cont
-          required: true
-          type: string
-      produces:
-        - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: string
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/util.HttpError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/util.HttpError'
-      summary: Read content
       tags:
         - content
   /content/staging-zones:
@@ -1889,27 +1868,6 @@ paths:
       summary: Unuspend Miner
       tags:
         - miner
-  /net/addrs:
-    get:
-      description: This endpoint is used to get net addrs
-      produces:
-        - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: string
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/util.HttpError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/util.HttpError'
-      summary: Net Addrs
-      tags:
-        - net
   /pinning/pins:
     get:
       description: This endpoint lists all pin status objects

--- a/scripts/swagger/swag.sh
+++ b/scripts/swagger/swag.sh
@@ -81,7 +81,7 @@ echo "Running Swag"
 chmod +x ./scripts/swagger/echo-swag/swag
 chmod +x ./scripts/swagger/echo-swag/yq
 
-./scripts/swagger/echo-swag/swag init -g api/v1/api.go --parseDependency --parseInternal --parseDepth 1
+./scripts/swagger/echo-swag/swag init -g api/v1/api.go --parseDependency --parseInternal --parseDepth 1  --exclude cmd/
 
 ## workaround to add the security and host - this so we can add the Bearer token to the header
 ## Json 


### PR DESCRIPTION
…nts are used to generate documentation

previously we were using both the shuttle endpoints and the api endpoints to make swagger annotations.

I think generally the only issue is that there were duplicate annotations, however it could be possible that this has some unexpected side effects in the swagger.json generation.