### PR TITLE
chore: set the collectionref path as nullable

### DIFF
--- a/collections/collections.go
+++ b/collections/collections.go
@@ -28,9 +28,9 @@ type Collection struct {
 type CollectionRef struct {
 	ID         uint `gorm:"primaryKey"`
 	CreatedAt  time.Time
-	Collection uint    `gorm:"index:,option:CONCURRENTLY; not null"`
+	Collection uint    `gorm:"index:,option:CONCURRENTLY;not null"`
 	Content    uint    `gorm:"index:,option:CONCURRENTLY;not null"`
-	Path       *string `gorm:"not null"`
+	Path       *string `gorm:"null"`
 }
 
 type CidType string


### PR DESCRIPTION
There are existing records in our DB that has `path` that are set to null and when gorm initializes the CollectionRefs, it throws a panic which prevents the API node from starting.

This is a quick fix to set the path column as nullable. 