### PR TITLE
IsSession on auth token and validate admin creds on setup

### DIFF
--- a/.github/workflows/postman-tests.yml
+++ b/.github/workflows/postman-tests.yml
@@ -41,7 +41,7 @@ jobs:
         npm install
 
     - name: Setup
-      run: echo "APIKEY=$(./estuary setup --username admin --password password  |  sed -e's/.*EST/EST/g' | tail -n1)" >> $GITHUB_ENV
+      run: echo "APIKEY=$(./estuary setup --username admin --password password1  |  sed -e's/.*EST/EST/g' | tail -n1)" >> $GITHUB_ENV
 
     - name: Run Estuary
       run: |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ To run locally in a 'dev' environment, first run:
 ./estuary setup --username=<uname> --password=<pword>
 ```
 
-Save the auth token that this outputs, you will need it for interacting with
-and controlling the node. This username and password won't work to log in using the front end (estuary-www), but the auth token will.
+Save the credentials you use here, you will need them to login to the estuary-www frontend.
 
 NOTE: if you want to use a different database than a sqlite instance stored in your local directory, you will need to configure that with the `--database` flag, like so: `./estuary setup --username=<uname> --password=<pword> --database=XXXXX`
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -41,7 +41,25 @@ const TokenExpiryDurationLogin = time.Hour * 24 * 30            // 30 days
 const TokenExpiryDurationDefault = time.Hour * 24 * 30          // 30 days
 const TokenExpiryDurationPermanent = time.Hour * 24 * 365 * 100 // 100 years
 
-var PasswordRegex = regexp.MustCompile(`^[A-Za-z\d]{8,}$`)
+var AdminPasswordLengthAndAlphanumericRegex = regexp.MustCompile(`^[A-Za-z\d]{8,}$`)
+var AdminPasswordContainsAlphaRegex = regexp.MustCompile(`[A-Za-z]`)
+var AdminPasswordContainsNumericRegex = regexp.MustCompile(`\d`)
+
+var AdminPasswordRegexes = []*regexp.Regexp{
+	AdminPasswordLengthAndAlphanumericRegex,
+	AdminPasswordContainsAlphaRegex,
+	AdminPasswordContainsNumericRegex,
+}
+
+func IsAdminPasswordValid(password string) bool {
+	for _, regex := range AdminPasswordRegexes {
+		ok := regex.MatchString(password)
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
 
 var DealMaxPrice abi.TokenAmount
 var VerifiedDealMaxPrice = abi.NewTokenAmount(0)

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -39,6 +40,8 @@ const TokenExpiryDurationRegister = time.Hour * 24 * 7          // 1 week
 const TokenExpiryDurationLogin = time.Hour * 24 * 30            // 30 days
 const TokenExpiryDurationDefault = time.Hour * 24 * 30          // 30 days
 const TokenExpiryDurationPermanent = time.Hour * 24 * 365 * 100 // 100 years
+
+var PasswordRegex = regexp.MustCompile(`^[A-Za-z\d]{8,}$`)
 
 var DealMaxPrice abi.TokenAmount
 var VerifiedDealMaxPrice = abi.NewTokenAmount(0)

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -41,6 +41,12 @@ const TokenExpiryDurationLogin = time.Hour * 24 * 30            // 30 days
 const TokenExpiryDurationDefault = time.Hour * 24 * 30          // 30 days
 const TokenExpiryDurationPermanent = time.Hour * 24 * 365 * 100 // 100 years
 
+var AdminUsernameAlphanumericRegex = regexp.MustCompile(`^[A-Za-z\d]{1,32}$`)
+
+func IsAdminUsernameValid(username string) bool {
+	return AdminUsernameAlphanumericRegex.MatchString(username)
+}
+
 var AdminPasswordLengthAndAlphanumericRegex = regexp.MustCompile(`^[A-Za-z\d]{8,}$`)
 var AdminPasswordContainsAlphaRegex = regexp.MustCompile(`[A-Za-z]`)
 var AdminPasswordContainsNumericRegex = regexp.MustCompile(`\d`)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3403,6 +3403,9 @@ const docTemplate = `{
                 "expiry": {
                     "type": "string"
                 },
+                "isSession": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3396,6 +3396,9 @@
         "expiry": {
           "type": "string"
         },
+        "isSession": {
+          "type": "boolean"
+        },
         "label": {
           "type": "string"
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -52,6 +52,8 @@ definitions:
     properties:
       expiry:
         type: string
+      isSession:
+        type: boolean
       label:
         type: string
       token:

--- a/main.go
+++ b/main.go
@@ -570,21 +570,6 @@ func main() {
 				if err := db.Create(newUser).Error; err != nil {
 					return fmt.Errorf("admin user creation failed: %w", err)
 				}
-
-				token := "EST" + uuid.New().String() + "ARY"
-				authToken := &util.AuthToken{
-					Token:     token,
-					TokenHash: util.GetTokenHash(token),
-					Label:     TOKEN_LABEL_ADMIN,
-					User:      newUser.ID,
-					Expiry:    time.Now().Add(constants.TokenExpiryDurationAdmin),
-					IsSession: false,
-				}
-				if err := db.Create(authToken).Error; err != nil {
-					return fmt.Errorf("admin token creation failed: %w", err)
-				}
-
-				fmt.Printf("Auth Token: %v\n", authToken.Token)
 				return nil
 			},
 		}, {

--- a/main.go
+++ b/main.go
@@ -575,6 +575,20 @@ func main() {
 				if err := db.Create(newUser).Error; err != nil {
 					return fmt.Errorf("admin user creation failed: %w", err)
 				}
+
+				token := "EST" + uuid.New().String() + "ARY"
+				authToken := &util.AuthToken{
+					Token:     token,
+					TokenHash: util.GetTokenHash(token),
+					Label:     TOKEN_LABEL_ADMIN,
+					User:      newUser.ID,
+					Expiry:    time.Now().Add(constants.TokenExpiryDurationAdmin),
+				}
+				if err := db.Create(authToken).Error; err != nil {
+					return fmt.Errorf("admin token creation failed: %w", err)
+				}
+
+				fmt.Printf("Auth Token: %v\n", authToken.Token)
 				return nil
 			},
 		}, {

--- a/main.go
+++ b/main.go
@@ -528,8 +528,8 @@ func main() {
 					return errors.New("setup password cannot be empty")
 				}
 
-				matched := constants.PasswordRegex.MatchString(password)
-				if !matched {
+				ok := constants.IsAdminPasswordValid(password)
+				if !ok {
 					return errors.New("password must be at least eight characters and contain at least one letter and one number")
 				}
 

--- a/main.go
+++ b/main.go
@@ -523,12 +523,17 @@ func main() {
 					return errors.New("setup username cannot be empty")
 				}
 
+				ok := constants.IsAdminUsernameValid(username)
+				if !ok {
+					return errors.New("username must be alphanumeric and 1-32 characters")
+				}
+
 				password := cctx.String("password")
 				if password == "" {
 					return errors.New("setup password cannot be empty")
 				}
 
-				ok := constants.IsAdminPasswordValid(password)
+				ok = constants.IsAdminPasswordValid(password)
 				if !ok {
 					return errors.New("password must be at least eight characters and contain at least one letter and one number")
 				}

--- a/main.go
+++ b/main.go
@@ -528,6 +528,11 @@ func main() {
 					return errors.New("setup password cannot be empty")
 				}
 
+				matched := constants.PasswordRegex.MatchString(password)
+				if !matched {
+					return errors.New("password must be at least eight characters and contain at least one letter and one number")
+				}
+
 				db, err := setupDatabase(cfg.DatabaseConnString)
 				if err != nil {
 					return err
@@ -573,6 +578,7 @@ func main() {
 					Label:     TOKEN_LABEL_ADMIN,
 					User:      newUser.ID,
 					Expiry:    time.Now().Add(constants.TokenExpiryDurationAdmin),
+					IsSession: false,
 				}
 				if err := db.Create(authToken).Error; err != nil {
 					return fmt.Errorf("admin token creation failed: %w", err)

--- a/util/users.go
+++ b/util/users.go
@@ -36,6 +36,7 @@ type AuthToken struct {
 	User       uint
 	UploadOnly bool
 	Expiry     time.Time
+	IsSession  bool
 }
 
 type InviteCode struct {


### PR DESCRIPTION
Along with https://github.com/application-research/estuary-www/pull/164, fixes https://github.com/application-research/estuary-www/issues/99 and https://github.com/application-research/estuary/issues/815

1. Adds `IsSession` field on AuthToken table and populates with `false` for tokens created via api admin page, and `true` for logins/signups. Session tokens will not be rendered in the api admin page so users cannot mix up their service and session tokens. The frontend will also no longer support authenticating via API key to prevent using a service token as a session token. That feature is also unnecessary when admin login is fixed.
2. When running `./estuary setup`, validates admin username and password to be compatible with bcrypt's requirement of 1-32 alphanumeric characters on usernames and 8+ alphanumeric characters on passwords.

![image](https://user-images.githubusercontent.com/2850013/211666063-0743aff9-ec5e-4835-92eb-5be3a821e026.png)
![image](https://user-images.githubusercontent.com/2850013/211673572-03cd25a3-0f77-4b96-b683-1062cd2ca73d.png)


I got a success with a valid creds, but omitted it from the screenshot.