### PR TITLE
fix: remove the additional userID param

### DIFF
--- a/content/staging.go
+++ b/content/staging.go
@@ -406,7 +406,7 @@ func (cm *ContentManager) getContentsAndDestinationLocationForConsolidation(ctx 
 
 func (cm *ContentManager) GetStagingZonesForUser(ctx context.Context, userID uint, limit int, offset int) ([]*model.StagingZone, error) {
 	var zones []*model.StagingZone
-	if err := cm.db.Limit(limit).Offset(offset).Order("created_at desc").Find(&zones, "user_id = ?", userID, userID).Error; err != nil {
+	if err := cm.db.Limit(limit).Offset(offset).Order("created_at desc").Find(&zones, "user_id = ?", userID).Error; err != nil {
 		return nil, err
 	}
 	return zones, nil


### PR DESCRIPTION
# Changes

The staging zones are not showing right now on any users due to the error on the `content/staging-zones` endpoint.

```
{
    "error": {
        "code": 500,
        "reason": "Internal Server Error",
        "details": "expected 1 arguments, got 2"
    }
}
```

To fix this, we need to remove the additional argument when looking for staging zones.