### PR TITLE
Auto-merge dependabot PRs if checks pass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,3 @@ updates:
     target-branch: "dev"
     labels:
       - "gomod dependencies"
-    reviewers:
-      - "neelvirdy"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,22 @@
+# .github/workflows/automerge.yml
+
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          # GitHub provides this variable in the CI env. You don't
+          # need to add anything to the secrets vault.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,3 +20,8 @@ jobs:
           # GitHub provides this variable in the CI env. You don't
           # need to add anything to the secrets vault.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
1. dependabot PRs automatically enable auto-merge
2. dependabot PRs are auto-approved

So, once status checks pass, the PR will automatically merge. This means we will get dependency bumps for free as long as they aren't breaking builds or tests.

See it in action on the filclient repo here (after the rebase): https://github.com/application-research/filclient/pull/121

And here's an example where the status checks failing blocks the merge: https://github.com/application-research/filclient/pull/115