### PR TITLE
Filter SPs by price for estimate

### DIFF
--- a/miner/manager.go
+++ b/miner/manager.go
@@ -75,7 +75,7 @@ func (mm *MinerManager) EstimatePrice(ctx context.Context, repl int, pieceSize a
 	))
 	defer span.End()
 
-	miners, err := mm.PickMiners(ctx, repl, pieceSize, nil, false)
+	miners, err := mm.PickMiners(ctx, repl, pieceSize, nil, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When estimating deal price, don't consider SPs where the price is too high, since they wouldn't be considered during dealmaking anyways.

This should prevent situations where the estimate is astronomically large due to an SP being randomly selected for estimation despite having a very high price:
![Screen Shot 2023-01-25 at 11 00 12 AM](https://user-images.githubusercontent.com/2850013/214612673-c53cbd42-f1a4-433b-894a-fc483ffb4b4c.png)

After this change, the price is consistently 0 FIL for verified deals (which is accurate):
![Screen Shot 2023-01-25 at 11 28 39 AM](https://user-images.githubusercontent.com/2850013/214619997-67a9ce57-5362-4a14-830b-bd837a08b415.png)

Note: the NaN USD in the conversion is due to the external pricing API being down, not a result of this change.
