### PR TITLE
fix: sp info endpoint - chain info always null

### DIFF
--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -1795,10 +1795,9 @@ func (s *apiV1) handleAdminGetMiners(c echo.Context) error {
 		out[i].Version = m.Version
 
 		ci, err := s.minerManager.GetMinerChainInfo(ctx, m.Address.Addr)
-		if err != nil {
+		if err == nil {
 			out[i].ChainInfo = ci
 		}
-
 	}
 
 	s.extendedCacher.Add(key, out)

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -1786,6 +1786,7 @@ func (s *apiV1) handleAdminGetMiners(c echo.Context) error {
 	}
 
 	out := make([]minerResp, len(miners))
+	wg := new(sync.WaitGroup)
 
 	for i, m := range miners {
 		out[i].Addr = m.Address.Addr
@@ -1794,11 +1795,18 @@ func (s *apiV1) handleAdminGetMiners(c echo.Context) error {
 		out[i].Name = m.Name
 		out[i].Version = m.Version
 
-		ci, err := s.minerManager.GetMinerChainInfo(ctx, m.Address.Addr)
-		if err == nil {
-			out[i].ChainInfo = ci
-		}
+		// Spawn a thread to fetch the Chain Info (Lotus RPC call - takes a few ms)
+		wg.Add(1)
+		go func(w *sync.WaitGroup, addr address.Address, i int) {
+			defer w.Done()
+			ci, err := s.minerManager.GetMinerChainInfo(ctx, addr)
+			if err == nil {
+				out[i].ChainInfo = ci
+			}
+		}(wg, m.Address.Addr, i)
 	}
+
+	wg.Wait()
 
 	s.extendedCacher.Add(key, out)
 	return c.JSON(http.StatusOK, out)


### PR DESCRIPTION
closes #905 
- Fixed incorrect error handling:
```
if err != nil { // we should do this if err *IS* nil!
	out[i].ChainInfo = ci
}
```
- Also took the opportunity to speed up the querying of ChainInfo, as the request was taking 30+ seconds to run in prod. In local testing, got it down from 10 seconds to under 2 seconds. 
