### PR TITLE
Fixed issue with retrieving collection contents

### DIFF
--- a/collections/collections.go
+++ b/collections/collections.go
@@ -155,12 +155,13 @@ func GetDirectoryContents(refs []util.ContentWithPath, queryDir, coluuid string)
 
 		if directoryContent != nil { // if there was content
 			if directoryContent.Type == CidTypeDir { // if the content was a directory
-				subDir := directoryContent.Dir
+				subDir := filepath.Join(directoryContent.Dir, directoryContent.Name)
 				if dirs[subDir] { // if the directory had already been added to response, continue
 					continue
 				}
 				dirs[subDir] = true
 			}
+			
 			result = append(result, directoryContent)
 		}
 	}


### PR DESCRIPTION
Ran some tests myself and this change makes it seem to work as intended. Maybe I misunderstood the purpose of the `dirs` map, but I couldn't find any bugs throughout testing.

```bash
curl -L -X GET "http://localhost:3004/collections/a8ced495-14c7-4482-873c-ce64f4e17446?dir=/" -H "Authorization: Bearer ESTec7837fa-c9d3-44e4-a4c2-bc12b7bcfd30ARY" -H 'Content-Type: application/json' -H 'Accept: application/json'
[{"name":"test","type":"directory","size":0,"contId":0,"dir":"/","coluuid":"a8ced495-14c7-4482-873c-ce64f4e17446","updatedAt":"2023-02-28T04:58:20.702276835Z"},{"name":"test2","type":"directory","size":0,"contId":0,"dir":"/","coluuid":"a8ced495-14c7-4482-873c-ce64f4e17446","updatedAt":"2023-02-28T04:58:32.425651744Z"}]
curl -X POST "http://localhost:3004/content/add?coluuid=a8ced495-14c7-4482-873c-ce64f4e17446&overwrite=true&dir=/test/test" -H "Authorization: Bearer AUTH_TOKEN" -H "Accept: application/json" -H "Content-Type: multipart/form-data" -F "data=@subfile.png"
{"cid":"bafkreiexna3d4uxvrywhrclxd2pepfacjnkftpdtnhfvdqd35on2fkkgt4","retrieval_url":"https://dweb.link/ipfs/bafkreiexna3d4uxvrywhrclxd2pepfacjnkftpdtnhfvdqd35on2fkkgt4","estuary_retrieval_url":"https://api.estuary.tech/gw/ipfs/bafkreiexna3d4uxvrywhrclxd2pepfacjnkftpdtnhfvdqd35on2fkkgt4","estuaryId":4,"providers":["/ip4/10.31.247.108/tcp/6744/p2p/12D3KooWGY9SYwzkuggkRKTmUhkjJ48JYUKCEJiyUyWdRtAmLNsB","/ip4/127.0.0.1/tcp/6744/p2p/12D3KooWGY9SYwzkuggkRKTmUhkjJ48JYUKCEJiyUyWdRtAmLNsB"]}
curl -L -X GET "http://localhost:3004/collections/a8ced495-14c7-4482-873c-ce64f4e17446?dir=/" -H "Authorization: Bearer AUTH_TOKEN" -H 'Content-Type: application/json' -H 'Accept: application/json'
[{"name":"test","type":"directory","size":0,"contId":0,"dir":"/","coluuid":"a8ced495-14c7-4482-873c-ce64f4e17446","updatedAt":"2023-02-28T04:58:20.702276835Z"},{"name":"test2","type":"directory","size":0,"contId":0,"dir":"/","coluuid":"a8ced495-14c7-4482-873c-ce64f4e17446","updatedAt":"2023-02-28T04:58:32.425651744Z"}]
curl -L -X GET "http://localhost:3004/collections/a8ced495-14c7-4482-873c-ce64f4e17446?dir=/test" -H "Authorization: Bearer AUTH_TOKEN" -H 'Content-Type: application/json' -H 'Accept: application/json'
[{"name":"subfile.png","type":"file","size":8820,"contId":1,"cid":"bafkreiexna3d4uxvrywhrclxd2pepfacjnkftpdtnhfvdqd35on2fkkgt4","dir":"/test","coluuid":"a8ced495-14c7-4482-873c-ce64f4e17446","updatedAt":"2023-02-28T04:58:20.702276835Z"},{"name":"..","type":"directory","size":0,"contId":0,"dir":"/test","coluuid":"a8ced495-14c7-4482-873c-ce64f4e17446","updatedAt":"2023-02-28T04:58:32.425651744Z"},{"name":"test","type":"directory","size":0,"contId":0,"dir":"/test","coluuid":"a8ced495-14c7-4482-873c-ce64f4e17446","updatedAt":"2023-02-28T05:47:30.698429035Z"}]
```
