### PR TITLE
docs: add project status notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
+> [!WARNING]
+>  # Project Discontinued
+> 
+> The instance and its related API endpoints hosted at <https://estuary.tech> are discontinued and no longer maintained.
+> 
+> The codebase is provided as-is for anyone interested in forking or learning.
+> 
+----
+
 # Estuary
 
-> An experimental ipfs node
+> An experimental [IPFS](https://ipfs.tech) node
 
 Questions? Reach out! [![slack](https://img.shields.io/badge/slack-filecoin-blue.svg?logo=slack)](https://filecoinproject.slack.com/)
 


### PR DESCRIPTION
We have people reaching out that https://estuary.tech/ does not work, surprised it is no more:

> [..]  https://docs.estuary.tech/ looks fine but   https://estuary.tech/ is down.
> [..]  the Github Repo isn’t archived either and I couldn’t find any notice regarding the deprecation: https://github.com/application-research/estuary

I'm submitting PRs to add notice to README and reduce confusion in the ecosystem.

cc @frrist